### PR TITLE
fix(ui): Eliminate gap between top bar on mobile

### DIFF
--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -39,6 +39,10 @@
       padding-left: 0;
       padding-right: 0;
     }
+
+    @media (max-width: @xs) {
+      padding-top: 56px;
+    }
   }
 }
 


### PR DESCRIPTION
### Before
![screen shot 2017-09-28 at 11 59 23 am](https://user-images.githubusercontent.com/5818702/30979923-cb52f29a-a444-11e7-8735-bfa8e583cd89.png)

### After
![screen shot 2017-09-28 at 11 59 31 am](https://user-images.githubusercontent.com/5818702/30979930-cf6c13ca-a444-11e7-881c-37e9e6d40f2d.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
