### PR TITLE
fix: Properly bind URLs in priority notifications

### DIFF
--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -127,14 +127,14 @@
         <span class="notification-message">{{ priority.title }}</span>
         <md-button class="md-raised md-accent"
                    ng-if="priority.actionButton"
-                   ng-href="priority.actionButton.url"
+                   ng-href="{{ priority.actionButton.url }}"
                    target="_blank"
                    rel="noopener noreferrer">
           {{ priority.actionButton.label }}
         </md-button>
         <md-button class="md-raised"
                    ng-if="priority.moreInfoButton"
-                   ng-href="priority.moreInfoButton.url"
+                   ng-href="{{ priority.moreInfoButton.url }}"
                    target="_blank"
                    rel="noopener noreferrer">
           {{ priority.moreInfoButton.label }}

--- a/components/staticFeeds/sample-messages.json
+++ b/components/staticFeeds/sample-messages.json
@@ -49,7 +49,10 @@
         "label": "Take action",
         "url": "http://www.google.com"
       },
-      "moreInfoButton": null,
+      "moreInfoButton": {
+        "label": "More info",
+        "url": "http://www.google.com"
+      },
       "confirmButton": null
     },
     {


### PR DESCRIPTION
[MUMMNG-3880](https://jira.doit.wisc.edu/jira/browse/MUMMNG-3880): "As a target of a high priority notification, I want the buttons in the header display to work so that I can take the appropriate action."

**In this PR**:
- Fix a bug where buttons weren't properly binding to scope

No idea how this one managed to slip through :P

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
