### PR TITLE
fix: return nothing on filter fail

### DIFF
--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -172,7 +172,7 @@ define(['angular'], function(angular) {
                   } else if (objectToFind) {
                     return message;
                   }
-                  return message;
+                  return;
                 }).catch(function(error) {
                   $log.warn('Error retrieving data for notification');
                   $log.error(error);


### PR DESCRIPTION
Fixes a fallthrough that returned the message anyway if the filter criteria failed.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
