### PR TITLE
fix(ui): Update notifications page to match functionality of bell

### DIFF
--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -37,33 +37,48 @@
         background-color: rgba(0, 0, 0, 0.12);
       }
 
+      .notifications-list__action {
+        min-width: 60px;
+        text-align: right;
+      }
+
       notifications-list-item {
         width: 100%;
-      }
 
-      .notification-buttons {
-        display: flex;
-        margin: 0 8px;
+        .md-list-item-text {
+          padding: 16px 0;
 
-        .md-button {
-          @media (min-width: @xs) {
-            margin: 0 8px;
+          .notification__priority-message {
+            color: @grayscale8;
+            font-size: 12px;
+            margin-bottom: 6px;
+
+            .material-icons {
+              min-height: 18px;
+              min-width: 18px;
+              height: 18px;
+              width: 18px;
+              font-size: 18px;
+              line-height: 16px;
+              margin-left: -5px;
+            }
           }
-        }
-      }
 
-      a:not(.md-button):not(.btn):not(.launch-app-button) {
-        &:hover {
-          text-decoration: none;
-        }
-      }
+          .notification-buttons {
+            margin: 0 8px;
 
-      .md-list-item-text {
-        width: 90%;
-        padding: 16px 0;
+            @media (max-width: @xs) {
+              margin: 12px 0 0;
 
-        @media (max-width: @xs) {
-          width: 80%;
+              .md-button {
+                margin: 6px 16px 0 0;
+              }
+            }
+          }
+
+          @media (max-width: @xs) {
+            width: 90%;
+          }
         }
       }
 

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -20,7 +20,6 @@
 -->
 <!-- NOTIFICATION CONTENT -->
 <div class="md-list-item-text"
-   ng-href="{{ notification.actionButton.url }}"
    layout="row"
    layout-align="start center"
    layout-xs="column"
@@ -28,7 +27,7 @@
   <!-- Notification text -->
   <div layout="column" layout-align="center start" flex-gt-xs="70">
     <div class="notification__priority-message" ng-if="notification.priority === 'high'">
-      <md-icon class="md-warn" aria-label="high priority:">priority_high</md-icon>
+      <md-icon class="md-warn">priority_high</md-icon>
       <span>High priority</span>
     </div>
     <div>{{ notification.title }}</div>
@@ -37,13 +36,13 @@
   <div ng-if="notification.moreInfoButton || notification.actionButton" class="notification-buttons" flex-gt-xs="30" layout="row" layout-align="end center">
     <md-button class="md-raised md-accent"
                ng-href="{{ notification.actionButton.url }}"
-               ng-if="notification.actionButton"
+               ng-if="notification.actionButton && notification.actionButton.url"
                ng-click="pushGAEvent('notifications page', 'take action', notification.actionButton.url)">
       {{ notification.actionButton.label }}
     </md-button>
     <md-button class="md-raised md-default"
                ng-href="{{ notification.moreInfoButton.url }}"
-               ng-if="notification.moreInfoButton"
+               ng-if="notification.moreInfoButton && notification.moreInfoButton.url"
                ng-click="pushGAEvent('notifications page', 'more info', notification.moreInfoButton.url)"
                target="_blank"
                rel="noopener noreferrer">

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -19,23 +19,35 @@
 
 -->
 <!-- NOTIFICATION CONTENT -->
-<a class="md-list-item-text"
+<div class="md-list-item-text"
    ng-href="{{ notification.actionButton.url }}"
-   target="_blank"
-   rel="noopener noreferrer"
-   aria-label="{{ notification.actionButton.label }}"
    layout="row"
    layout-align="start center"
    layout-xs="column"
    layout-align-xs="center start">
-  <span><md-icon ng-if="notification.priority == 'high'" aria-label="high priority:">priority_high</md-icon> {{ notification.title }}</span>
-  <div ng-if="notification.moreInfoButton" class="notification-buttons" layout-xs="column" layout-align-xs="center start">
+  <!-- Notification text -->
+  <div layout="column" layout-align="center start" flex-gt-xs="70">
+    <div class="notification__priority-message" ng-if="notification.priority === 'high'">
+      <md-icon class="md-warn" aria-label="high priority:">priority_high</md-icon>
+      <span>High priority</span>
+    </div>
+    <div>{{ notification.title }}</div>
+  </div>
+  <!-- Notification buttons -->
+  <div ng-if="notification.moreInfoButton || notification.actionButton" class="notification-buttons" flex-gt-xs="30" layout="row" layout-align="end center">
+    <md-button class="md-raised md-accent"
+               ng-href="{{ notification.actionButton.url }}"
+               ng-if="notification.actionButton"
+               ng-click="pushGAEvent('notifications page', 'take action', notification.actionButton.url)">
+      {{ notification.actionButton.label }}
+    </md-button>
     <md-button class="md-raised md-default"
                ng-href="{{ notification.moreInfoButton.url }}"
-               ng-click="pushGAEvent('notifcations page', 'more info', notification.moreInfoButton.url)"
+               ng-if="notification.moreInfoButton"
+               ng-click="pushGAEvent('notifications page', 'more info', notification.moreInfoButton.url)"
                target="_blank"
                rel="noopener noreferrer">
       {{ notification.moreInfoButton.label }}
     </md-button>
   </div>
-</a>
+</div>

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -44,7 +44,7 @@
                 <div class="notifications-list__action">
                   <md-button class="md-icon-button"
                              ng-hide="notification.dismissible === false"
-                             ng-click="vm.dismissNotification(notification)"
+                             ng-click="vm.dismissNotification(notification);pushGAEvent('notifications page', 'dismiss', notification.id)"
                              aria-label="dismiss this notification">
                     <md-icon>clear</md-icon>
                     <md-tooltip md-delay="500">Dismiss notification</md-tooltip>

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -33,22 +33,23 @@
         <md-tab-body>
           <md-content>
             <md-list class="notifications-list" flex>
-              <md-list-item class="secondary-button-padding notification-item"
+              <md-list-item class="notification-item"
                             ng-repeat="notification in vm.notifications | orderBy:'priority'"
-                            ng-class="{ priority: notification.priority === 'high' }"
                             layout="row"
                             layout-align="start center">
 
                 <notifications-list-item></notifications-list-item>
 
                 <!-- DISMISS BUTTON -->
-                <md-button class="md-icon-button md-secondary"
-                           ng-hide="notification.dismissible === false"
-                           ng-click="vm.dismissNotification(notification)"
-                           aria-label="dismiss this notification">
-                  <md-icon>clear</md-icon>
-                  <md-tooltip md-delay="500">Dismiss notification</md-tooltip>
-                </md-button>
+                <div class="notifications-list__action">
+                  <md-button class="md-icon-button"
+                             ng-hide="notification.dismissible === false"
+                             ng-click="vm.dismissNotification(notification)"
+                             aria-label="dismiss this notification">
+                    <md-icon>clear</md-icon>
+                    <md-tooltip md-delay="500">Dismiss notification</md-tooltip>
+                  </md-button>
+                </div>
               </md-list-item>
             </md-list>
           </md-content>
@@ -62,21 +63,22 @@
         <md-tab-body>
           <md-content>
             <md-list class="notifications-list" flex>
-              <md-list-item class="secondary-button-padding notification-item"
+              <md-list-item class="notification-item"
                             ng-repeat="notification in vm.dismissedNotifications | orderBy:['-priority', '-id']"
-                            ng-class="{ priority: notification.priority === 'high' }"
                             layout="row"
                             layout-align="start center">
 
                 <notifications-list-item></notifications-list-item>
 
                 <!-- RESTORE BUTTON -->
-                <md-button class="md-icon-button md-secondary"
-                           ng-click="vm.restoreNotification(notification)"
-                           aria-label="restore this notification">
-                  <md-icon>undo</md-icon>
-                  <md-tooltip md-delay="500">Restore notification</md-tooltip>
-                </md-button>
+                <div class="notification-list__action">
+                  <md-button class="md-icon-button"
+                             ng-click="vm.restoreNotification(notification)"
+                             aria-label="restore this notification">
+                    <md-icon>undo</md-icon>
+                    <md-tooltip md-delay="500">Restore notification</md-tooltip>
+                  </md-button>
+                </div>
               </md-list-item>
             </md-list>
           </md-content>

--- a/components/portal/misc/partials/app-header.html
+++ b/components/portal/misc/partials/app-header.html
@@ -19,13 +19,13 @@
 
 -->
 <md-subheader role="toolbar" class="app-header">
-  <h1 flex="50" flex-xs="75" class="app-title">
+  <h1 flex="50" flex-xs="65" class="app-title">
     <i ng-if="icon.indexOf('fa-') > -1" class="fa {{::icon}}" aria-hidden="true"></i>
     <md-icon ng-if="icon.indexOf('fa-') <= -1" aria-label="">{{ ::icon }}</md-icon>
     {{::title}}
   </h1>
 
-  <div flex="50" flex-xs="25" class="header-links" ng-controller="AppHeaderOptionsController as vm">
+  <div flex="50" flex-xs="35" class="header-links" ng-controller="AppHeaderOptionsController as vm">
     <div ng-if="vm.optionsTemplate" ng-include="vm.optionsTemplate"></div>
 
      <!--ADD TO HOME BUTTON (HIDDEN XS) -->


### PR DESCRIPTION
**In this PR**:
- Notification no longer clickable, but displays action but (same as bell menu)
- High priority indicator matches bell
- Fixed some layout/spacing wonkiness so it's more consistent on small and large screens
- Add analytics to dismissal from notifications page
- Fixed a typo in analytics message
- Adjust app-header spacing on small screens to leave more room for app-header-options

### Screenshots
<img width="1132" alt="screen shot 2017-10-02 at 1 42 28 pm" src="https://user-images.githubusercontent.com/5818702/31093737-515f5546-a778-11e7-931d-31ee0002898b.png">
<img width="1132" alt="screen shot 2017-10-02 at 1 42 41 pm" src="https://user-images.githubusercontent.com/5818702/31093738-5160a8f6-a778-11e7-8c7a-bbd5429d8d92.png">
<img width="403" alt="screen shot 2017-10-02 at 1 42 55 pm" src="https://user-images.githubusercontent.com/5818702/31093736-515ceb58-a778-11e7-804b-c71e5c562654.png">


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
