### PR TITLE
fix(theme): using uw-system as default theme

### DIFF
--- a/components/js/frame-config.js
+++ b/components/js/frame-config.js
@@ -24,12 +24,12 @@ define(['angular'], function(angular) {
          * THOU SHALT INCREMENT THIS VERSION NUMBER
          * IF THOU CHANGEST ANY OF THE THEMES BELOW
          */
-        'themeVersion': 9,
+        'themeVersion': 10,
         'themes': [
           {
             'name': 'default',
             'portalSkinKey': 'default',
-            'group': 'default',
+            'group': 'uPortal',
             'crest': 'img/apereo-logo.png',
             'title': 'uPortal',
             'subtitle': null,


### PR DESCRIPTION
We had an issue with my.wisconsin.edu defaulting to the uPortal theme rather than uw-system. On top of that, search/marketplace is broken with the uPortal theme ( #559 ). We're not quite operationally ready for uPortal to be the default theme yet, so this changes it back to uw-system.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
