### PR TITLE
fix: Redesign mobile search

### DIFF
--- a/components/css/buckyless/search.less
+++ b/components/css/buckyless/search.less
@@ -93,5 +93,54 @@ search {
         }
       }
     }
+
+    &.myuw-search__mobile {
+      height: 56px;
+      max-width: 100%;
+      width: 100%;
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding: 6px 4px;
+      z-index: 80;
+
+      .md-button {
+        min-height: 44px;
+        min-width: 40px;
+
+        &.search-submit-xs {
+          position: absolute;
+          left: 0;
+        }
+
+        &.search-close-xs {
+          position: absolute;
+          right: 0;
+        }
+
+        .material-icons {
+          color: @black;
+        }
+      }
+
+      md-input-container {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background-color: @white;
+        border-radius: 5px;
+
+        input.md-input {
+          margin: 0 40px;
+          height: 44px;
+        }
+
+        &.md-input-focused {
+          input.md-input {
+            border-color: transparent;
+          }
+        }
+      }
+    }
   }
 }

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -151,20 +151,9 @@ define(['angular', 'require'], function(angular, require) {
       var vm = this;
       vm.navbarCollapsed = true;
       vm.showLogout = true;
-      $scope.showSearch = false;
-      $scope.showSearchFocus = false;
+
       $scope.APP_FLAGS = APP_FLAGS;
       $scope.MISC_URLS = MISC_URLS;
-
-      vm.toggleSearch = function() {
-        $scope.showSearch = !$scope.showSearch;
-        $scope.showSearchFocus = !$scope.showSearchFocus;
-        vm.navbarCollapsed = true;
-      };
-      vm.toggleMenu = function() {
-        $scope.showSearch = false;
-        vm.navbarCollapsed = !vm.navbarCollapsed;
-      };
   }])
 
   /* Footer */

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -73,17 +73,9 @@
 
     <!-- SEARCH BUTTON AND USERNAME MENU XS-ONLY -->
     <div layout="row" layout-align="end center" flex-xs="60" class="top-bar-controls-xs" hide-gt-xs>
-      <md-button class="md-icon-button" aria-label="Toggle {{portal.theme.title}} search" ng-click="toggleSearch()">
-        <md-icon ng-if="!searchExpanded">search</md-icon>
-        <md-icon ng-if="searchExpanded">close</md-icon>
-        <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">
-          <span ng-if="!searchExpanded">Search</span>
-          <span ng-if="searchExpanded">Close search</span>
-        </md-tooltip>
-      </md-button>
+      <search ng-show="APP_FLAGS.showSearch" mode="mobile-search" layout="row" layout-align="end center" hide-gt-xs></search>
       <username layout="row" layout-align="start center"></username>
     </div>
-
 
     <!-- SEARCH BAR SM+ -->
     <div layout="row" flex-gt-xs="40" layout-align="center center" hide-xs>
@@ -99,7 +91,3 @@
     </div>
   </div>
 </md-toolbar>
-<!-- SEARCH BAR XS-ONLY -->
-<div class="search-xs" ng-class="{ 'search-expanded' : searchExpanded }" hide-gt-xs>
-  <search ng-show="APP_FLAGS.showSearch"></search>
-</div>

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -73,7 +73,7 @@
 
     <!-- SEARCH BUTTON AND USERNAME MENU XS-ONLY -->
     <div layout="row" layout-align="end center" flex-xs="60" class="top-bar-controls-xs" hide-gt-xs>
-      <search ng-show="APP_FLAGS.showSearch" mode="mobile-search" layout="row" layout-align="end center" hide-gt-xs></search>
+      <search ng-if="APP_FLAGS.showSearch" mode="mobile-search" layout="row" layout-align="end center" hide-gt-xs></search>
       <username layout="row" layout-align="start center"></username>
     </div>
 

--- a/components/portal/search/directives.js
+++ b/components/portal/search/directives.js
@@ -25,6 +25,9 @@ define(['angular', 'require'], function(angular, require) {
     return {
       restrict: 'E',
       templateUrl: require.toUrl('./partials/search.html'),
+      scope: {
+        directiveMode: '@mode',
+      },
       controller: 'PortalSearchController',
     };
   }]);

--- a/components/portal/search/partials/search.html
+++ b/components/portal/search/partials/search.html
@@ -18,7 +18,34 @@
     under the License.
 
 -->
-<form name="searchForm" ng-submit="submit()" ng-hide="$storage.typeaheadSearch">
+<!-- Mobile search -->
+<form name="searchForm" class="myuw-search__mobile" ng-submid="submit()" ng-if="directiveMode === 'mobile-search' && searchExpanded">
+  <md-input-container class="md-block" md-no-float layout="row" layout-align="start center">
+    <!-- submit xs-only-->
+    <md-button class="md-icon-button search-submit-xs" ng-click="submit()" aria-label="submit search" flex="10">
+      <md-icon>search</md-icon>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Submit</md-tooltip>
+    </md-button>
+    <input type="search"
+           name="initialFilter"
+           placeholder="Search {{portal.theme.title}}"
+           ng-model="initialFilter"
+           flex="80">
+    <!-- close search xs-only-->
+    <md-button class="md-icon-button search-close-xs" ng-click="toggleSearch()" aria-label="close search bar" flex="10">
+      <md-icon>close</md-icon>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Close</md-tooltip>
+    </md-button>
+  </md-input-container>
+</form>
+<md-button ng-if="directiveMode === 'mobile-search'" class="md-icon-button" aria-label="Open {{portal.theme.title}} search" ng-click="toggleSearch()">
+  <md-icon>search</md-icon>
+  <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">
+    <span>Search</span>
+  </md-tooltip>
+</md-button>
+<!-- Desktop search -->
+<form name="searchForm" ng-submit="submit()" ng-if="directiveMode != 'mobile-search'">
   <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center">
     <!-- submit xs+ -->
     <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search" hide-xs>
@@ -36,25 +63,6 @@
            ng-model="initialFilter"
            aria-label="Search bar enter the app you are looking for"
            focus-me="showSearchFocus"
-           autocomplete="off">
-  </md-input-container>
-</form>
-<form name="searchForm" ng-submit="submit()" ng-show="$storage.typeaheadSearch">
-  <md-input-container class="md-block myuw-search" md-no-float layout="row" layout-align="start center">
-    <md-button class="md-icon-button" ng-click="submit()" aria-label="submit search">
-      <md-icon>search</md-icon>
-    </md-button>
-    <input type="search"
-           name="initialFilter"
-           placeholder="Search {{portal.theme.title}}"
-           ng-model="initialFilter"
-           aria-label="Search bar enter the app you are looking for"
-           focus-me="showSearchFocus"
-           typeahead="title as match.title for match in filterMatches | limitTo:10"
-           typeahead-on-select="onSelect($item, $model, $label)"
-           typeahead-loading="portletListLoading"
-           typeahead-min-length="2"
-           typeahead-focus-first='false'
            autocomplete="off">
   </md-input-container>
 </form>


### PR DESCRIPTION
[MUMUP-3099](https://jira.doit.wisc.edu/jira/browse/MUMUP-3099): "As a mobile user of MyUW, I'd like the search button to do something, so that I'm not confused when I click the button and nothing happens."

**In this PR**:
- Refactored behavior of search directive
- Redesigned appearance of mobile search field to take up less space

### Screenshot
<img width="467" alt="screen shot 2017-10-03 at 2 28 44 pm" src="https://user-images.githubusercontent.com/5818702/31144968-ea94f0b6-a847-11e7-90a5-db8485744e44.png">

### Demo
![search-fix](https://user-images.githubusercontent.com/5818702/31144976-f4f4365c-a847-11e7-85b4-e719aed06ff1.gif)

*To do: Animate open/close of mobile search*

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
