### PR TITLE
feat: adding filter to calculate rel on anchors

### DIFF
--- a/components/portal/misc/filters.js
+++ b/components/portal/misc/filters.js
@@ -98,7 +98,8 @@ define(['angular'], function(angular) {
     .filter('targetToRel', function() {
       return function(target) {
         var result = '';
-        if (target === TARGET_BLANK) {
+        if (target &&
+            target.trim().toUpperCase() === TARGET_BLANK.toUpperCase()) {
           result = REL_BLANK_FIX;
         }
         return result;

--- a/components/portal/misc/filters.js
+++ b/components/portal/misc/filters.js
@@ -20,6 +20,9 @@
 
 define(['angular'], function(angular) {
     var DEFAULT_TRUNCATE_LENGTH = 160;
+    var TARGET_SELF = '_self';
+    var TARGET_BLANK = '_blank';
+    var REL_BLANK_FIX = 'noopener noreferrer';
     return angular.module('portal.misc.filters', [])
 
     .filter('truncate', function() {
@@ -85,9 +88,18 @@ define(['angular'], function(angular) {
     })
     .filter('urlToTarget', function() {
       return function(url) {
-        var result = '_self';
+        var result = TARGET_SELF;
         if (url && url.indexOf('//') > -1) {
-          result = '_blank';
+          result = TARGET_BLANK;
+        }
+        return result;
+      };
+    })
+    .filter('targetToRel', function() {
+      return function(target) {
+        var result = '';
+        if (target === TARGET_BLANK) {
+          result = REL_BLANK_FIX;
         }
         return result;
       };


### PR DESCRIPTION
Adding a filter to calculate whether `noopener noreferrer` should be added to an anchor based on the target value.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
