### PR TITLE
fix: portalSkinKey has to match a skin on backend uPortal

### DIFF
--- a/components/js/frame-config.js
+++ b/components/js/frame-config.js
@@ -28,7 +28,7 @@ define(['angular'], function(angular) {
         'themes': [
           {
             'name': 'uPortal',
-            'portalSkinKey': 'uPortal',
+            'portalSkinKey': 'default',
             'group': 'uPortal',
             'crest': 'img/apereo-logo.png',
             'title': 'uPortal',


### PR DESCRIPTION
got a little too zealous renaming the uPortal theme. We still need it to match a skin in uPortal for backend rendered portlets.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
