### PR TITLE
fix: Obscure notifications bell when on full view

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -153,6 +153,8 @@ define(['angular'], function(angular) {
         vm.notificationsUrl = MESSAGES.notificationsPageURL;
         vm.status = 'View notifications';
         vm.isLoading = true;
+        vm.isNotificationsPage =
+          ($location.path() == MESSAGES.notificationsPageURL);
 
         // //////////////////
         // Event listeners //

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -21,7 +21,7 @@
 <div class="notifications">
   <!-- MOBILE BELL -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
-       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0">
+       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0 && !vm.isNotificationsPage">
     <md-icon>notifications</md-icon>
   </div>
 
@@ -33,13 +33,14 @@
                ng-click="vm.pushGAEvent('Mobile Menu', 'Click Link', 'Notifications');"
                layout="row" layout-align="start center">
       <span><md-icon>notifications</md-icon></span>
-      <span>Notifications ({{ vm.notifications.length }})</span>
+      <span>Notifications </span>
+      <span ng-show="!vm.isNotificationsPage">({{ vm.notifications.length }})</span>
     </md-button>
   </md-menu-item>
 
   <!-- DESKTOP NOTIFICATION BELL -->
   <md-menu class="notifications-menu"
-           ng-show="directiveMode === 'bell'"
+           ng-show="directiveMode === 'bell' && !vm.isNotificationsPage"
            md-offset="-200 0"
            md-position-mode="target bottom">
     <md-button ng-click="$mdOpenMenu($event);vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell')"


### PR DESCRIPTION
[MUMMNG-2880](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2880): "As a user dismissing/un-dismissing notifications on the notification page, I would like the bell icon to update to reflect my new unread count, so that consistency is maintained."

**In this PR**:
- Hide notification bell (and mobile menu count) when user is viewing the full notifications page

### Why?
Because the `notifications-bell` (in its many forms) and `view__notifications` templates both use `NotificationsController` to establish and manipulate scope, you would think the scope would be shared among all the things that use that controller. However, this is not the case. The scope of the full view is isolated from the scope(s) of the various instances of the directive. This means that communication between them has to happen on the $rootScope level (barring yet another involved refactor of the notifications/announcements architecture). A truly syncopated experience without a prohibitive amount of work would depend upon `$rootScope.$broadcast` or manipulation of a $rootScope variable every time a notification is dismissed or restored, which means messily updating scope in up to 5 places every time. Additionally, the functionality of the full notifications view and the bell directive are nearly identical (a.k.a. redundant). 

For the above reasons, it's simpler and arguably better practice to just hide the bell when users are already on the notifications page.

### Screenshots
![screen shot 2017-10-11 at 10 34 32 am](https://user-images.githubusercontent.com/5818702/31450798-fec44bd0-ae6f-11e7-9222-b5d678544ad7.png)
![screen shot 2017-10-11 at 10 46 44 am](https://user-images.githubusercontent.com/5818702/31451363-84054f64-ae71-11e7-818c-9c0adf721d0f.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
