### PR TITLE
fix: Obscure notifications bell when on full view

### DIFF
--- a/components/css/buckyless/search.less
+++ b/components/css/buckyless/search.less
@@ -97,12 +97,15 @@ search {
     &.myuw-search__mobile {
       height: 56px;
       max-width: 100%;
-      width: 100%;
+      width: 0;
+      //opacity: 0;
       position: absolute;
       right: 0;
       top: 0;
       padding: 6px 4px;
       z-index: 80;
+      overflow: hidden;
+      transition: @transition-width;
 
       .md-button {
         min-height: 44px;
@@ -126,9 +129,11 @@ search {
       md-input-container {
         margin: 0;
         padding: 0;
+        opacity: 0;
         height: 100%;
         background-color: @white;
         border-radius: 5px;
+        transition: @transition-opacity-fast;
 
         input.md-input {
           margin: 0 40px;
@@ -139,6 +144,15 @@ search {
           input.md-input {
             border-color: transparent;
           }
+        }
+      }
+
+      &.search-expanded {
+        opacity: 1;
+        width: 100%;
+
+        md-input-container {
+          opacity: 1;
         }
       }
     }

--- a/components/css/themes/common-variables.less
+++ b/components/css/themes/common-variables.less
@@ -60,7 +60,9 @@
 */
 @background-transition: background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 @transition-height: height 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+@transition-width: width 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 @transition-opacity: opacity 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+@transition-opacity-fast: opacity 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
 @transition-all: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 @transition-color: color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -153,6 +153,8 @@ define(['angular'], function(angular) {
         vm.notificationsUrl = MESSAGES.notificationsPageURL;
         vm.status = 'View notifications';
         vm.isLoading = true;
+        vm.isNotificationsPage =
+          ($location.path() == MESSAGES.notificationsPageURL);
 
         // //////////////////
         // Event listeners //

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -21,7 +21,7 @@
 <div class="notifications">
   <!-- MOBILE BELL -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
-       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0">
+       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0 && !vm.isNotificationsPage">
     <md-icon>notifications</md-icon>
   </div>
 
@@ -33,13 +33,14 @@
                ng-click="vm.pushGAEvent('Mobile Menu', 'Click Link', 'Notifications');"
                layout="row" layout-align="start center">
       <span><md-icon>notifications</md-icon></span>
-      <span>Notifications ({{ vm.notifications.length }})</span>
+      <span>Notifications </span>
+      <span ng-show="!vm.isNotificationsPage">({{ vm.notifications.length }})</span>
     </md-button>
   </md-menu-item>
 
   <!-- DESKTOP NOTIFICATION BELL -->
   <md-menu class="notifications-menu"
-           ng-show="directiveMode === 'bell'"
+           ng-show="directiveMode === 'bell' && !vm.isNotificationsPage"
            md-offset="-200 0"
            md-position-mode="target bottom">
     <md-button ng-click="$mdOpenMenu($event);vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell')"

--- a/components/portal/search/partials/search.html
+++ b/components/portal/search/partials/search.html
@@ -19,7 +19,7 @@
 
 -->
 <!-- Mobile search -->
-<form name="searchForm" class="myuw-search__mobile" ng-submit="vm.submit()" ng-if="directiveMode === 'mobile-search' && vm.searchExpanded">
+<form name="searchForm" class="myuw-search__mobile" ng-class="{ 'search-expanded' : vm.searchExpanded }" ng-submit="vm.submit()" ng-if="directiveMode === 'mobile-search'">
   <md-input-container class="md-block" md-no-float layout="row" layout-align="start center">
     <!-- submit xs-only-->
     <md-button class="md-icon-button search-submit-xs" ng-click="vm.submit()" aria-label="submit search" flex="10">


### PR DESCRIPTION
[MUMMNG-2880](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2880): "As a user dismissing/un-dismissing notifications on the notification page, I would like the bell icon to update to reflect my new unread count, so that consistency is maintained."

**In this PR**:
- Hide notification bell (and mobile menu count) when user is viewing the full notifications page
- Bonus: Animate mobile search bar open/close

### Screenshots
![screen shot 2017-10-11 at 10 34 32 am](https://user-images.githubusercontent.com/5818702/31450798-fec44bd0-ae6f-11e7-9222-b5d678544ad7.png)
![screen shot 2017-10-11 at 10 46 44 am](https://user-images.githubusercontent.com/5818702/31451363-84054f64-ae71-11e7-818c-9c0adf721d0f.png)
![search-animate](https://user-images.githubusercontent.com/5818702/31452721-675bdac8-ae75-11e7-9ea8-0f3bd31fbf86.gif)


### Why?
Because the `notifications-bell` (in its many forms) and `view__notifications` templates both use `NotificationsController` to establish and manipulate scope, you would think the scope would be shared among all the things that use that controller. However, this is not the case. The scope of the full view is isolated from the scope(s) of the various instances of the directive. This means that communication between them has to happen on the $rootScope level (barring yet another involved refactor of the notifications/announcements architecture). A truly syncopated experience without a prohibitive amount of work would depend upon `$rootScope.$broadcast` or manipulation of a $rootScope variable every time a notification is dismissed or restored, which means messily updating scope in up to 5 places every time. Additionally, the functionality of the full notifications view and the bell directive are nearly identical (a.k.a. redundant). 

For the above reasons, it's simpler and arguably better practice to just hide the bell when users are already on the notifications page.
----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
