### PR TITLE
fix: Fix app hang when promise returns undefined

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -42,11 +42,13 @@ define(['angular'], function(angular) {
         var getMessages = function() {
           messagesService.getAllMessages()
             .then(function(result) {
-              // Ensure messages exist and check for group filtering
-              if (result.messages && result.messages.length > 0) {
-                allMessages = result.messages;
+              if (result) {
+                // Ensure messages exist and check for group filtering
+                if (result.messages && result.messages.length > 0) {
+                  allMessages = result.messages;
+                }
+                filterMessages();
               }
-              filterMessages();
               return allMessages;
             })
             .catch(function(error) {

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -42,13 +42,11 @@ define(['angular'], function(angular) {
         var getMessages = function() {
           messagesService.getAllMessages()
             .then(function(result) {
-              if (result) {
-                // Ensure messages exist and check for group filtering
-                if (result.messages && result.messages.length > 0) {
-                  allMessages = result.messages;
-                }
-                filterMessages();
+              // Ensure messages exist and check for group filtering
+              if (result.messages && result.messages.length > 0) {
+                allMessages = result.messages;
               }
+              filterMessages();
               return allMessages;
             })
             .catch(function(error) {

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -73,10 +73,15 @@ define(['angular'], function(angular) {
         var getAllMessages = function() {
           return $http.get(SERVICE_LOC.messagesURL)
             .then(function(response) {
-              return response.data;
+              if (angular.isArray(response.data)) {
+                return response.data;
+              } else {
+                return [];
+              }
             })
             .catch(function(error) {
               miscService.redirectUser(error.status, 'Get all messages');
+              return [];
             });
         };
 


### PR DESCRIPTION
After pointing star app at new messages feed, the service fails to get messages (a bigger problem than this PR addresses). When it fails, the angular controls hangs because the promise returns `undefined`. This PR just makes sure the block doesn't continue if the promise result is undefined.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
