### PR TITLE
fix: Include /web check in notifications url eval

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -125,10 +125,10 @@ define(['angular'], function(angular) {
       },
     ])
 
-    .controller('NotificationsController', ['$q', '$log', '$scope', '$browser',
+    .controller('NotificationsController', ['$q', '$log', '$scope',
       '$rootScope', '$location', '$localStorage', '$filter', 'MESSAGES',
       'SERVICE_LOC', 'miscService', 'messagesService',
-      function($q, $log, $scope, $browser, $rootScope, $location, $localStorage,
+      function($q, $log, $scope, $rootScope, $location, $localStorage,
                $filter, MESSAGES, SERVICE_LOC, miscService, messagesService) {
         // //////////////////
         // Local variables //

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -43,8 +43,8 @@ define(['angular'], function(angular) {
           messagesService.getAllMessages()
             .then(function(result) {
               // Ensure messages exist and check for group filtering
-              if (result.messages && result.messages.length > 0) {
-                allMessages = result.messages;
+              if (result.length > 0) {
+                allMessages = result;
               }
               filterMessages();
               return allMessages;
@@ -125,11 +125,11 @@ define(['angular'], function(angular) {
       },
     ])
 
-    .controller('NotificationsController', ['$q', '$log', '$scope',
+    .controller('NotificationsController', ['$q', '$log', '$scope', '$browser',
       '$rootScope', '$location', '$localStorage', '$filter', 'MESSAGES',
       'SERVICE_LOC', 'miscService', 'messagesService',
-      function($q, $log, $scope, $rootScope, $location, $localStorage, $filter,
-               MESSAGES, SERVICE_LOC, miscService, messagesService) {
+      function($q, $log, $scope, $browser, $rootScope, $location, $localStorage,
+               $filter, MESSAGES, SERVICE_LOC, miscService, messagesService) {
         // //////////////////
         // Local variables //
         // //////////////////
@@ -153,8 +153,7 @@ define(['angular'], function(angular) {
         vm.notificationsUrl = MESSAGES.notificationsPageURL;
         vm.status = 'View notifications';
         vm.isLoading = true;
-        vm.isNotificationsPage =
-          ($location.path() == MESSAGES.notificationsPageURL);
+        vm.isNotificationsPage = false;
 
         // //////////////////
         // Event listeners //
@@ -167,6 +166,7 @@ define(['angular'], function(angular) {
           // If the parent scope has messages and notifications are enabled,
           // complete initialization
           if (hasMessages) {
+            isNotificationsPage();
             configureNotificationsScope();
           }
         });
@@ -174,6 +174,20 @@ define(['angular'], function(angular) {
         // ////////////////
         // Local methods //
         // ////////////////
+        /**
+         * Check if user is viewing notifications page
+         */
+        var isNotificationsPage = function() {
+          if (MESSAGES.notificationsPageURL.indexOf('/web') != -1) {
+            var portalNotificationsUrl = '/web' + MESSAGES.notificationsPageURL;
+            vm.isNotificationsPage =
+              $location.path() === portalNotificationsUrl;
+          } else {
+            vm.isNotificationsPage =
+              $location.path() === MESSAGES.notificationsPageURL;
+          }
+        };
+
         /**
          * Get notifications from parent scope, then pass them on
          * for filtering by seen/unseen

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -179,9 +179,9 @@ define(['angular'], function(angular) {
          */
         var isNotificationsPage = function() {
           if (MESSAGES.notificationsPageURL.indexOf('/web') != -1) {
-            var portalNotificationsUrl = '/web' + MESSAGES.notificationsPageURL;
+            var portalNotificationsPath = '/web' + $location.path();
             vm.isNotificationsPage =
-              $location.path() === portalNotificationsUrl;
+              portalNotificationsPath === MESSAGES.notificationsPageURL;
           } else {
             vm.isNotificationsPage =
               $location.path() === MESSAGES.notificationsPageURL;

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -125,10 +125,10 @@ define(['angular'], function(angular) {
       },
     ])
 
-    .controller('NotificationsController', ['$q', '$log', '$scope',
+    .controller('NotificationsController', ['$q', '$log', '$scope', '$window',
       '$rootScope', '$location', '$localStorage', '$filter', 'MESSAGES',
       'SERVICE_LOC', 'miscService', 'messagesService',
-      function($q, $log, $scope, $rootScope, $location, $localStorage,
+      function($q, $log, $scope, $window, $rootScope, $location, $localStorage,
                $filter, MESSAGES, SERVICE_LOC, miscService, messagesService) {
         // //////////////////
         // Local variables //
@@ -178,14 +178,8 @@ define(['angular'], function(angular) {
          * Check if user is viewing notifications page
          */
         var isNotificationsPage = function() {
-          if (MESSAGES.notificationsPageURL.indexOf('/web') != -1) {
-            var portalNotificationsPath = '/web' + $location.path();
-            vm.isNotificationsPage =
-              portalNotificationsPath === MESSAGES.notificationsPageURL;
-          } else {
-            vm.isNotificationsPage =
-              $location.path() === MESSAGES.notificationsPageURL;
-          }
+          vm.isNotificationsPage =
+            $window.location.pathname === MESSAGES.notificationsPageURL;
         };
 
         /**

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -58,7 +58,7 @@
     <md-menu-content class="top-bar-menu-content notifications-menu">
       <md-menu-item layout="row" layout-align="space-between center">
         <span>Notifications</span>
-        <a ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');" aria-label="see all notifications" class="link__see-all">
+        <a ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');vm.isNotificationsPage = true;" aria-label="see all notifications" class="link__see-all">
           See all <span ng-if="vm.notifications.length > 0">({{ vm.notifications.length }})</span>
         </a>
       </md-menu-item>

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -73,8 +73,9 @@ define(['angular'], function(angular) {
         var getAllMessages = function() {
           return $http.get(SERVICE_LOC.messagesURL)
             .then(function(response) {
-              if (angular.isArray(response.data)) {
-                return response.data;
+              if (response.data && response.data.messages
+                && angular.isArray(response.data.messages)) {
+                return response.data.messages;
               } else {
                 return [];
               }


### PR DESCRIPTION
**In this PR**:
- First checks if configured notifications url points to portal base path (`/web`), then evaluates `$location.path()`
- Fixed a bug where incorrect type check was causing notifications feed to always be empty

This is a little hacky, but the idea is if a frame app wants to point to the portal-wide notifications feed, it has to point to /web. Since /web is the portal base path (and not included in any $location getters), evaluating the path against the configured notificationsPageURL will always result in `false`. We have to check for /web, and it it's not part of the configured path, we're free to fall back on whatever other path was configured. 

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
