### PR TITLE
Fix spacing when app navigation isn't configured

### DIFF
--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -44,19 +44,6 @@ portal-header {
       max-height: 56px;
       overflow-y: hidden;
 
-      .title-link {
-        h1 {
-          @media (min-width: @xs) {
-            margin-left: 16px;
-          }
-        }
-
-        img {
-          height: 56px;
-          margin-right: 8px;
-        }
-      }
-
       .md-menu {
         > .md-button {
           min-width: 48px;
@@ -64,9 +51,29 @@ portal-header {
         }
       }
 
+      .title-link img {
+        max-height: 40px;
+        line-height: 56px;
+        margin-left: 8px;
+      }
+
       .menu-toggle.md-button {
         min-width: 48px;
         margin: 0;
+
+        + .title-link h1 {
+          @media (min-width: @xs) {
+            margin-left: 0;
+          }
+        }
+
+        &.hide-gt-xs {
+          + .title-link h1 {
+            @media (min-width: @xs) {
+              margin-left: 16px;
+            }
+          }
+        }
       }
 
       .top-bar-controls-xs {

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -51,12 +51,6 @@ portal-header {
         }
       }
 
-      .title-link img {
-        max-height: 40px;
-        line-height: 56px;
-        margin-left: 8px;
-      }
-
       .menu-toggle.md-button {
         min-width: 48px;
         margin: 0;

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -55,14 +55,14 @@ portal-header {
         min-width: 48px;
         margin: 0;
 
-        + .title-link h1 {
+        ~ .title-link h1 {
           @media (min-width: @xs) {
             margin-left: 0;
           }
         }
 
         &.hide-gt-xs {
-          + .title-link h1 {
+          ~ .title-link h1 {
             @media (min-width: @xs) {
               margin-left: 16px;
             }

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -46,7 +46,7 @@ portal-header {
 
       .title-link {
         h1 {
-          @media (min-width: @xs) and (max-width: @sm) {
+          @media (min-width: @xs) {
             margin-left: 16px;
           }
         }

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -118,7 +118,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 78;
+    z-index: 60;
     border-radius: 3px;
     top: 0;
 

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -26,7 +26,7 @@
       <!-- MAIN MENU TOGGLE -->
       <md-button class="menu-toggle" ng-controller="MainMenuController as vm" ng-click="vm.showMainMenu()" ng-class="{ 'hide-gt-xs' : vm.hideMainMenu }">
         <md-icon>menu</md-icon>
-        <md-tooltip md-direction="bottom" md-delay="500" class="top-bar-tooltip">Menu</md-tooltip>
+        <md-tooltip md-direction="bottom" md-delay="500" md-autohide="true" class="top-bar-tooltip">Menu</md-tooltip>
         <notifications-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notifications-bell>
       </md-button>
 

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -26,7 +26,7 @@
       <!-- MAIN MENU TOGGLE -->
       <md-button class="menu-toggle" ng-controller="MainMenuController as vm" ng-click="vm.showMainMenu()" ng-class="{ 'hide-gt-xs' : vm.hideMainMenu }">
         <md-icon>menu</md-icon>
-        <md-tooltip md-direction="bottom" md-delay="500" md-autohide="true" class="top-bar-tooltip">Menu</md-tooltip>
+        <md-tooltip md-direction="bottom" md-delay="500" md-autohide class="top-bar-tooltip">Menu</md-tooltip>
         <notifications-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notifications-bell>
       </md-button>
 


### PR DESCRIPTION
**In this PR**:
- Added some CSS to maintain margins with or without side nav menu button
- Removed a little unused CSS
- Autohide menu tooltip so it doesn't linger on mobile

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
