### PR TITLE
fix: Fix search widget type

### DIFF
--- a/components/portal/widgets/partials/type__search-with-links.html
+++ b/components/portal/widgets/partials/type__search-with-links.html
@@ -19,7 +19,7 @@
 
 -->
 <div class="widget-body">
-  <form action='{{ secureUrl }}' target='{{ config.actionTarget }}'>
+  <form action='{{ secureURL }}' target='{{ config.actionTarget }}'>
     <md-input-container class="md-block" md-no-float>
       <input type="text" name="{{ config.actionParameter }}" placeholder="{{ config.searchPlaceholder }}">
       <md-button type="submit" class="md-primary md-icon-button">


### PR DESCRIPTION
The action url wasn't appearing because the variable name was mistyped.

Compare with [variable name in controller](https://github.com/uPortal-Project/uportal-app-framework/blob/5e78410d1d816e0d030eb366c8bed10f1830df01/components/portal/widgets/controllers.js#L190)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
