### PR TITLE
fix(footer-links): Fix styling in footer links

### DIFF
--- a/components/css/buckyless/footer.less
+++ b/components/css/buckyless/footer.less
@@ -35,18 +35,9 @@ footer {
   }
 
   .links-separated > span {
-    &::before {
-      content: '\f111';
-      font-family: 'FontAwesome';
-      display: inline-block;
-      font-size: 8px;
-      bottom: 1px;
-      position: relative;
-      margin: 0 4px;
-    }
-
-    &:first-child::before {
-      display: none;
+    &:not(:last-child)::after {
+      content: '\23FA';
+      margin-right: 4px;
     }
   }
 


### PR DESCRIPTION
Fix styling in first footer link where first link was stylistically lower than the rest.  It's a pretty tiny cosmetic change.

Resolves MUMUP-2912

Footer area - 

![image](https://user-images.githubusercontent.com/5521429/31908440-816bb65a-b7fc-11e7-9725-5a17c6b77940.png)

Before:

![image](https://user-images.githubusercontent.com/5521429/31908380-432e8bec-b7fc-11e7-80f7-aa4916a779c0.png)

After:
![image](https://user-images.githubusercontent.com/5521429/31908401-5cc79abc-b7fc-11e7-8016-3b6897dcf1ee.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
