### PR TITLE
fix: circle character between footer links

### DIFF
--- a/components/css/buckyless/footer.less
+++ b/components/css/buckyless/footer.less
@@ -36,7 +36,7 @@ footer {
 
   .links-separated > span {
     &:not(:last-child)::after {
-      content: '\23FA';
+      content: '\25CF';
       margin-right: 4px;
     }
   }


### PR DESCRIPTION
Fix the circle character between footer links to one that renders on all os's

I didn't have a font that could have rendered 'black circle for record' (23FA), so I just got a fallback character of 'black circle' on my linux desktop.  So, now it uses 'black circle' (25CF) which was intended all along. 

Before on Android and OSX:
<img width="370" alt="screen shot 2017-10-24 at 11 14 58 am" src="https://user-images.githubusercontent.com/5521429/31954989-a5f9cc72-b8ac-11e7-8667-98130be2917b.png">

After on Android and OSX and Linux:
<img width="379" alt="screen shot 2017-10-24 at 11 15 06 am" src="https://user-images.githubusercontent.com/5521429/31954969-9e28b7a6-b8ac-11e7-8d48-902f7a5fd827.png">


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
