### PR TITLE
feat: Recurring priority notifications

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -218,13 +218,13 @@ define(['angular'], function(angular) {
               result.seenMessageIds
             );
             angular.forEach(separatedNotifications.seen, function(message) {
-              if(message.recurrence){
+              if (message.recurrence) {
                 var index = separatedNotifications.seen
                   .indexOf(message);
                 separatedNotifications.unseen.push(message);
                 separatedNotifications.seen.splice(index, 1);
               }
-            })
+            });
 
             // Set scope notifications and dismissed notifications
             vm.notifications = separatedNotifications.unseen;

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -217,6 +217,15 @@ define(['angular'], function(angular) {
               allNotifications,
               result.seenMessageIds
             );
+            angular.forEach(separatedNotifications.seen, function(message) {
+              if(message.recurrence){
+                var index = separatedNotifications.seen
+                  .indexOf(message);
+                separatedNotifications.unseen.push(message);
+                separatedNotifications.seen.splice(index, 1);
+              }
+            })
+
             // Set scope notifications and dismissed notifications
             vm.notifications = separatedNotifications.unseen;
             vm.dismissedNotifications = separatedNotifications.seen;

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -63,6 +63,7 @@ define(['angular'], function(angular) {
          * @property {string} expireDate
          * @property {string} featureImageUrl
          * @property {string} priority
+         * @property {Boolean} recurrence
          * @property {Boolean} dismissible
          * @property {Object} actionButton
          * @property {Object} moreInfoButton

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -22,7 +22,7 @@ point uportal-app-framework to your desired feed.
             "expireDate": "2017-08-02",
             "featureImageUrl": null,
             "priority": "high",
-            "recurrance": true,
+            "recurrence": true,
             "dismissible": false,
             "audienceFilter": {
                 "groups": ["Users - Service Activation Required"],
@@ -56,7 +56,7 @@ point uportal-app-framework to your desired feed.
 - **expireDate**: *(optional)* Accepts a simple ISO date, including time (as pictured). This is used to stop displaying a message at a certain day/time.
 - **featureImageUrl**: *(optional)* Used by popup announcements and announcements on the Features page.
 - **priority**: Set to "high" if you want the message to be displayed with higher visibility (i.e. As a priority notification or popup announcement, respectively).
-- **recurrence**:(optional) If true, even if a notification is dismissed, it will continue to reoccur in the user's home at the start of every session until the user is no longer a member of the targeted group. For example, if a user is a member of students-with-outstanding-parking-tickets, that user will be confronted with the notification at every login until they pay the fine.
+- **recurrence**:*(experimental, optional)* If true, even if a notification is dismissed, it will continue to reoccur in the user's home at the start of every session until the user is no longer a member of the targeted group. For example, if a user is a member of students-with-outstanding-parking-tickets, that user will be confronted with the notification at every login until they pay the fine.
 - **dismissible**: *(experimental, optional)* Set to false if you want to disallow users from dismissing a notification. This should only be used for truly critical messages. If the attribute is set to true or not set at all, the notification will be dismissible.
 - **audienceFilter**: A group of attributes related to filtering messages based on a user's group or whether the user has pertinent data at a given URL.
   - **groups**: An attribute to optionally show messages only to specific groups (i.e. uPortal groups). If null or empty array, the message will be shown to everyone. Contact your portal development team for more information about group filtering.

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -22,6 +22,7 @@ point uportal-app-framework to your desired feed.
             "expireDate": "2017-08-02",
             "featureImageUrl": null,
             "priority": "high",
+            "recurrance": true,
             "dismissible": false,
             "audienceFilter": {
                 "groups": ["Users - Service Activation Required"],
@@ -55,6 +56,7 @@ point uportal-app-framework to your desired feed.
 - **expireDate**: *(optional)* Accepts a simple ISO date, including time (as pictured). This is used to stop displaying a message at a certain day/time.
 - **featureImageUrl**: *(optional)* Used by popup announcements and announcements on the Features page.
 - **priority**: Set to "high" if you want the message to be displayed with higher visibility (i.e. As a priority notification or popup announcement, respectively).
+- **recurrence**:(optional) If true, even if a notification is dismissed, it will continue to reoccur in the user's home at the start of every session until the user is no longer a member of the targeted group. For example, if a user is a member of students-with-outstanding-parking-tickets, that user will be confronted with the notification at every login until they pay the fine.
 - **dismissible**: *(experimental, optional)* Set to false if you want to disallow users from dismissing a notification. This should only be used for truly critical messages. If the attribute is set to true or not set at all, the notification will be dismissible.
 - **audienceFilter**: A group of attributes related to filtering messages based on a user's group or whether the user has pertinent data at a given URL.
   - **groups**: An attribute to optionally show messages only to specific groups (i.e. uPortal groups). If null or empty array, the message will be shown to everyone. Contact your portal development team for more information about group filtering.


### PR DESCRIPTION
Causes a notification to reoccur every time a user opens a new session, until the user falls out of the targeted group or the notification expires.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
