### PR TITLE
fix: Broadcast changes to variables needed in many places

### DIFF
--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-main-menu {
+main-menu:not(.push-content) {
   .main-menu__mobile-bar {
     background: @grayscale2;
     min-height: 56px;
@@ -66,6 +66,10 @@ main-menu {
     }
   }
 
+  md-backdrop {
+    position: fixed;
+  }
+
   md-sidenav.main-menu__sidenav:not(.md-closed) {
     width: 300px;
     display: flex;
@@ -99,6 +103,15 @@ main-menu {
         width: ~"calc(100% - 56px)";
         min-width: ~"calc(100% - 56px)";
         max-width: ~"calc(100% - 56px)";
+      }
+    }
+
+    @media (min-width: @xs) {
+      position: fixed;
+      top: 60px;
+
+      &.has-priority-notifications {
+        top: 102px;
       }
     }
 

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -105,7 +105,7 @@ portal-header {
   }
 
   @media (min-width: @xs) {
-    &.has-priority-nots + .page-content {
+    &.has-priority-nots ~ .page-content {
       margin-top: 102px;
     }
   }

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -164,6 +164,12 @@ define(['angular', 'require'], function(angular, require) {
       var vm = this;
       vm.navbarCollapsed = true;
       vm.showLogout = true;
+      vm.hasPriorityNotifications = false;
+
+      $scope.$on('priorityNotifications',
+        function(event, hasPriorityNotifications) {
+          vm.hasPriorityNotifications = hasPriorityNotifications;
+      });
 
       $scope.APP_FLAGS = APP_FLAGS;
       $scope.MISC_URLS = MISC_URLS;
@@ -183,13 +189,18 @@ define(['angular', 'require'], function(angular, require) {
       vm.hideMainMenu = false;
       vm.footerLinks = FOOTER_URLS;
       vm.openMenuByDefault = false;
+      vm.hasPriorityNotifications = false;
+      vm.hasUnseenAnnouncements = false;
 
-      // Close side nav on scroll to avoid awkward UI
-      $window.onscroll = function() {
-        if (vm.isMenuOpen() && !$mdMedia('gt-sm')) {
-          vm.closeMainMenu();
-        }
-      };
+      $scope.$on('priorityNotifications',
+        function(event, hasPriorityNotifications) {
+          vm.hasPriorityNotifications = hasPriorityNotifications;
+      });
+
+      $scope.$on('unseenAnnouncements',
+        function(event, hasUnseenAnnouncements) {
+          vm.hasUnseenAnnouncements = hasUnseenAnnouncements;
+      });
 
       /**
        * Check if the side nav menu is open

--- a/components/portal/main/partials/body.html
+++ b/components/portal/main/partials/body.html
@@ -23,7 +23,7 @@
     <a href="#main-content">Skip to main content</a>
   </div>
   <div class="my-uw-body">
-    <portal-header ng-class="{'has-priority-nots': mainCtrl.hasPriorityNotifications}" ng-controller="PortalHeaderController as headerCtrl"></portal-header>
+    <portal-header ng-class="{'has-priority-nots': headerCtrl.hasPriorityNotifications}" ng-controller="PortalHeaderController as headerCtrl"></portal-header>
 
     <div class="page-content" layout="column" tabindex="0" role="main">
       <div role="main" class="region-main" class="no-padding">

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -19,7 +19,7 @@
 
 -->
 <md-toolbar md-scroll-shrink class="md-primary" tabindex="0" ng-controller="MessagesController">
-  <notifications-bell mode="priority" class="priority-gt-xs" header-ctrl="mainCtrl" hide-xs></notifications-bell>
+  <notifications-bell mode="priority" class="priority-gt-xs" hide-xs></notifications-bell>
   <span ng-controller="AnnouncementsController" controllerAs="vm"></span>
   <div class="md-toolbar-tools"  role="banner">
     <div layout="row" flex-gt-xs="30" flex-xs="40" layout-align="start center">
@@ -56,7 +56,7 @@
 
     <!-- TOP BAR BUTTONS (SM+) -->
     <div layout="row" layout-align="end center" flex-gt-xs="30" hide-xs>
-      <mascot-announcement mode="mascot" header-ctrl="mainCtrl"></mascot-announcement>
+      <mascot-announcement mode="mascot"></mascot-announcement>
       <notifications-bell mode="bell" ng-if="!GuestMode"></notifications-bell>
       <username layout="row" layout-align="start center"></username>
     </div>

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -19,21 +19,22 @@
 
 -->
 <md-sidenav class="md-sidenav-left main-menu__sidenav"
+            ng-class="{ 'has-priority-notifications' : vm.hasPriorityNotifications }"
             md-component-id="main-menu"
             md-is-open="vm.openMenuByDefault"
             md-whiteframe="4">
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
-    <md-button href="features" ng-show="mainCtrl.hasUnseenAnnouncements" ng-click="mainCtrl.hasUnseenAnnouncements = false;vm.closeMainMenu();" aria-label="view all announcements">
+    <md-button href="features" ng-show="vm.hasUnseenAnnouncements" ng-click="vm.hasUnseenAnnouncements = false;vm.closeMainMenu();" aria-label="view all announcements">
       <span><md-icon>new_releases</md-icon></span>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">New features</md-tooltip>
     </md-button>
     <!-- Regular notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="view all notifications"  ng-if="!mainCtrl.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="view all notifications"  ng-if="!vm.hasPriorityNotifications">
       <span><md-icon>notifications</md-icon></span>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
     </md-button>
     <!-- High priority notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="you have important notifications"  ng-if="mainCtrl.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="you have important notifications"  ng-if="vm.hasPriorityNotifications">
       <span class="main-menu__high-priority">
         <md-icon class="md-warn">error</md-icon>
       </span>

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -279,12 +279,10 @@ define(['angular'], function(angular) {
             vm.notifications,
             {priority: 'high'}
           );
-          // If priority notifications exist and the view has a
-          // headerController in scope (from directive), set necessary flags
-          if ($scope.headerCtrl) {
-            $scope.headerCtrl.hasPriorityNotifications
-              = vm.priorityNotifications.length > 0;
-          }
+          // If priority notifications exist, update service
+          messagesService.broadcastPriorityNotifications(
+            vm.priorityNotifications.length > 0
+          );
         };
 
         /**
@@ -293,10 +291,11 @@ define(['angular'], function(angular) {
          */
         var clearPriorityNotificationsFlags = function(duringWatchedEvent) {
           vm.priorityNotifications = [];
-          if ($scope.headerCtrl) {
-            $scope.headerCtrl.hasPriorityNotifications
-              = vm.priorityNotifications.length > 0;
-          }
+
+          messagesService.broadcastPriorityNotifications(
+            vm.priorityNotifications.length > 0
+          );
+
           if (!duringWatchedEvent) {
             $rootScope.$broadcast('portalShutdownPriorityNotifications',
               {disable: true});
@@ -475,12 +474,11 @@ define(['angular'], function(angular) {
             vm.announcements = separatedAnnouncements.unseen;
             // Set the mascot image
             setMascot();
-            // Set PortalMainController variable so main menu knows there
-            // are unseen announcements
-            if ($scope.headerCtrl) {
-              $scope.headerCtrl.hasUnseenAnnouncements =
-                vm.announcements.length > 0;
-            }
+
+            // Update service so it knows about unseen announcements
+            messagesService.broadcastUnseenAnnouncements(
+              vm.announcements.length > 0
+            );
           } else {
             // Filter out low priority announcements
             popups = $filter('filter')(
@@ -590,10 +588,9 @@ define(['angular'], function(angular) {
             id
           );
           // Notify up the chain so main menu knows about it
-          if ($scope.headerCtrl) {
-            $scope.headerCtrl.hasUnseenAnnouncements =
-              vm.announcements.length > 0;
-          }
+          messagesService.broadcastUnseenAnnouncements(
+            vm.announcements.length > 0
+          );
           // Add to seenAnnouncementsIds
           seenAnnouncementIds.push(id);
           // Call service to save results

--- a/components/portal/messages/directives.js
+++ b/components/portal/messages/directives.js
@@ -25,7 +25,6 @@ define(['angular', 'require'], function(angular, require) {
         restrict: 'E',
         scope: {
           directiveMode: '@mode',
-          headerCtrl: '=headerCtrl',
         },
         templateUrl: require.toUrl('./partials/notifications-bell.html'),
         controller: 'NotificationsController',
@@ -46,7 +45,6 @@ define(['angular', 'require'], function(angular, require) {
         templateUrl: require.toUrl('./partials/announcement-mascot.html'),
         scope: {
           mode: '@',
-          headerCtrl: '=headerCtrl',
         },
         controller: 'AnnouncementsController',
         controllerAs: 'vm',

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -27,6 +27,7 @@ define(['angular'], function(angular) {
       '$sessionStorage',
       '$q',
       '$filter',
+      '$rootScope',
       'portalGroupService',
       'miscService',
       'keyValueService',
@@ -39,6 +40,7 @@ define(['angular'], function(angular) {
                $sessionStorage,
                $q,
                $filter,
+               $rootScope,
                portalGroupService,
                miscService,
                keyValueService,
@@ -271,12 +273,30 @@ define(['angular'], function(angular) {
             });
         };
 
+        /**
+         * Inform listeners that presence of priority notifications has changed
+         * @param hasPriority
+         */
+        var broadcastPriorityNotifications = function(hasPriority) {
+          $rootScope.$broadcast('priorityNotifications', hasPriority);
+        };
+
+        /**
+         * Inform listeners that presence of unseen announcements has changed
+         * @param hasUnseen
+         */
+        var broadcastUnseenAnnouncements = function(hasUnseen) {
+          $rootScope.$broadcast('unseenAnnouncements', hasUnseen);
+        };
+
         return {
           getAllMessages: getAllMessages,
           getMessagesByGroup: getMessagesByGroup,
           getMessagesByData: getMessagesByData,
           getSeenMessageIds: getSeenMessageIds,
           setMessagesSeen: setMessagesSeen,
+          broadcastPriorityNotifications: broadcastPriorityNotifications,
+          broadcastUnseenAnnouncements: broadcastUnseenAnnouncements,
         };
     }]);
 });


### PR DESCRIPTION
**In this PR**:
- Stop main-menu from scrolljacking user when opened
- Use messages service to broadcast when the existence of priority notifications and unseen announcements has changed
- Add listeners to the controllers that need to know about those events
- Stop passing controllers as attributes of directives

This is all needed mainly to allow the side navigation to work as expected. Without this, the sidenav automatically forces scroll-to-top when opened. It's a buggy behavior that has been ignored by Angular Material devs, despite a number of issues being opened. This is a workaround. 
 
The added benefit is that several directives need to know when/if there are priority notifications or unseen announcements (e.g. the `notifications-bell` and `main-menu` directives). Because of the DOM hierarchy, passing controllers as directive scope variables no longer works in all cases (and is a pretty hack thing to do in the first place). Using a service to broadcast changes to those variables is arguably cleaner and easier to understand.

### Demo

![scroll-demo](https://user-images.githubusercontent.com/5818702/32349961-d5a39f3e-bfe6-11e7-9d32-dd6b8278cdfa.gif)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
