### PR TITLE
fix: Stop auto-scroll and fix notification bugs

### DIFF
--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -66,9 +66,15 @@ main-menu {
     }
   }
 
+  md-backdrop {
+    position: fixed;
+    bottom: 0;
+  }
+
   md-sidenav.main-menu__sidenav:not(.md-closed) {
     width: 300px;
     display: flex;
+    transition: @transition-all;
 
     md-menu-content {
       height: ~"calc(100vh - 100%)";
@@ -101,17 +107,36 @@ main-menu {
         max-width: ~"calc(100% - 56px)";
       }
     }
-
-    @media (max-width: @xs) {
-      z-index: 80;
-      position: fixed;
-    }
   }
 
   &.push-content {
     md-backdrop.md-sidenav-backdrop {
       @media (min-width: @sm) {
         display: none;
+      }
+    }
+  }
+
+  @media (max-width: @xs) {
+    md-sidenav.main-menu__sidenav:not(.push-content) {
+      position: fixed;
+      top: 0;
+      z-index: 80;
+    }
+  }
+
+  @media (min-width: @xs) {
+    &:not(.push-content) {
+      md-sidenav.main-menu__sidenav {
+        position: fixed;
+        top: 60px;
+        z-index: 70;
+      }
+    }
+
+    &.has-priority-notifications:not(.push-content) {
+      md-sidenav.main-menu__sidenav {
+        top: 102px;
       }
     }
   }

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -47,7 +47,6 @@
   .page-content {
     background-color: @grayscale4;
     transition: padding 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-    //margin: 60px 0 0;
     flex: auto;
     display: flex;
     flex-direction: column;
@@ -61,11 +60,6 @@
       flex: auto;
       height: 100%;
     }
-
-    //@media (max-width: @xs) {
-    //  margin-top: 56px;
-    //  height: auto;
-    //}
   }
 }
 

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -42,11 +42,12 @@
 .my-uw-body {
   min-height: 100vh;
   display: flex;
+  flex-direction: column;
 
   .page-content {
     background-color: @grayscale4;
     transition: padding 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-    margin: 60px 0 0;
+    //margin: 60px 0 0;
     flex: auto;
     display: flex;
     flex-direction: column;
@@ -61,10 +62,10 @@
       height: 100%;
     }
 
-    @media (max-width: @xs) {
-      margin-top: 56px;
-      height: auto;
-    }
+    //@media (max-width: @xs) {
+    //  margin-top: 56px;
+    //  height: auto;
+    //}
   }
 }
 

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -19,7 +19,6 @@
 portal-header {
   display: block;
   position: sticky;
-  //width: 100%;
   z-index: 80;
   top: 0;
   overflow-y: hidden;
@@ -103,12 +102,6 @@ portal-header {
       }
     }
   }
-
-  //@media (min-width: @xs) {
-  //  &.has-priority-nots ~ .page-content {
-  //    margin-top: 102px;
-  //  }
-  //}
 
   @media (max-width: @xs) {
     .search-xs {

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -18,8 +18,8 @@
  */
 portal-header {
   display: block;
-  position: fixed;
-  width: 100%;
+  position: sticky;
+  //width: 100%;
   z-index: 80;
   top: 0;
   overflow-y: hidden;
@@ -104,11 +104,11 @@ portal-header {
     }
   }
 
-  @media (min-width: @xs) {
-    &.has-priority-nots + .page-content {
-      margin-top: 102px;
-    }
-  }
+  //@media (min-width: @xs) {
+  //  &.has-priority-nots ~ .page-content {
+  //    margin-top: 102px;
+  //  }
+  //}
 
   @media (max-width: @xs) {
     .search-xs {

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -118,7 +118,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 59;
+    z-index: 58;
     border-radius: 3px;
     top: 0;
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -156,24 +156,23 @@ define(['angular', 'require'], function(angular, require) {
     });
   }])
 
-  /* Header */
-  .controller('PortalHeaderController', ['$rootScope', '$scope', '$location',
-    '$mdSidenav', 'APP_FLAGS', 'MISC_URLS',
-    function($rootScope, $scope, $location, $mdSidenav,
-             APP_FLAGS, MISC_URLS) {
-      var vm = this;
-      vm.navbarCollapsed = true;
-      vm.showLogout = true;
-
-      $scope.APP_FLAGS = APP_FLAGS;
-      $scope.MISC_URLS = MISC_URLS;
+  /* Main menu toggle controller */
+  .controller('MenuToggleController', ['$mdSidenav', function($mdSidenav) {
+    var vm = this;
+    /**
+     * Toggle the side navigation menu
+     */
+    vm.showMainMenu = function() {
+      $mdSidenav('main-menu').toggle();
+    };
   }])
 
   /* Side navigation controller */
   .controller('MainMenuController', ['$rootScope', '$scope', '$mdSidenav',
-    '$mdMedia', '$window', 'APP_OPTIONS', 'FOOTER_URLS', 'MESSAGES', 'NAMES',
-    function($rootScope, $scope, $mdSidenav, $mdMedia, $window, APP_OPTIONS,
-             FOOTER_URLS, MESSAGES, NAMES) {
+    '$mdMedia', '$window', '$localStorage', 'APP_OPTIONS', 'FOOTER_URLS',
+    'MESSAGES', 'NAMES',
+    function($rootScope, $scope, $mdSidenav, $mdMedia, $window, $localStorage,
+             APP_OPTIONS, FOOTER_URLS, MESSAGES, NAMES) {
       var vm = this;
 
       // Scope variables
@@ -183,6 +182,18 @@ define(['angular', 'require'], function(angular, require) {
       vm.hideMainMenu = false;
       vm.footerLinks = FOOTER_URLS;
       vm.openMenuByDefault = false;
+
+      $scope.$on('HAS_PRIORITY_NOTIFICATIONS', function(event, data) {
+        if (angular.isDefined(data.hasNotifications)) {
+          vm.hasPriorityNotifications = data.hasNotifications;
+        }
+      });
+
+      $scope.$on('HAS_UNSEEN_ANNOUNCEMENTS', function(event, data) {
+        if (angular.isDefined(data.hasNotifications)) {
+          vm.hasUnseenAnnouncements = data.hasAnnouncements;
+        }
+      });
 
       // Close side nav on scroll to avoid awkward UI
       $window.onscroll = function() {
@@ -209,13 +220,6 @@ define(['angular', 'require'], function(angular, require) {
       };
 
       /**
-       * Toggle the side navigation menu
-       */
-      vm.showMainMenu = function() {
-        $mdSidenav('main-menu').toggle();
-      };
-
-      /**
        * Check for menu configuration in app config
        */
       var init = function() {
@@ -235,13 +239,18 @@ define(['angular', 'require'], function(angular, require) {
         if (MESSAGES.notificationsPageURL) {
           vm.notificationsPageUrl = MESSAGES.notificationsPageURL;
         }
+        // Add footer links
         if ($rootScope.portal && $rootScope.portal.theme
           && $rootScope.portal.theme.footerLinks) {
           vm.footerLinks =
             vm.footerLinks.concat($rootScope.portal.theme.footerLinks);
         }
+        // Check if push content is set
         vm.openMenuByDefault =
           APP_OPTIONS.enablePushContentMenu && $mdMedia('gt-sm');
+        // Set flags for notifications/announcements
+        vm.hasPriorityNotifications = $localStorage.hasPriorityNotifications;
+        vm.hasUnseenAnnouncements = $localStorage.hasUnseenAnnouncements;
       };
 
       init();

--- a/components/portal/main/partials/body.html
+++ b/components/portal/main/partials/body.html
@@ -23,7 +23,7 @@
     <a href="#main-content">Skip to main content</a>
   </div>
   <div class="my-uw-body">
-    <portal-header ng-class="{'has-priority-nots': mainCtrl.hasPriorityNotifications}" ng-controller="PortalHeaderController as headerCtrl"></portal-header>
+    <portal-header></portal-header>
 
     <div class="page-content" layout="column" tabindex="0" role="main">
       <div role="main" class="region-main" class="no-padding">

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -19,12 +19,12 @@
 
 -->
 <md-toolbar md-scroll-shrink class="md-primary" tabindex="0" ng-controller="MessagesController">
-  <notifications-bell mode="priority" class="priority-gt-xs" header-ctrl="mainCtrl" hide-xs></notifications-bell>
+  <notifications-bell mode="priority" class="priority-gt-xs" hide-xs></notifications-bell>
   <span ng-controller="AnnouncementsController" controllerAs="vm"></span>
   <div class="md-toolbar-tools"  role="banner">
     <div layout="row" flex-gt-xs="30" flex-xs="40" layout-align="start center">
       <!-- MAIN MENU TOGGLE -->
-      <md-button class="menu-toggle" ng-controller="MainMenuController as vm" ng-click="vm.showMainMenu()" ng-class="{ 'hide-gt-xs' : vm.hideMainMenu }">
+      <md-button class="menu-toggle" ng-controller="MenuToggleController as vm" ng-click="vm.showMainMenu()" ng-class="{ 'hide-gt-xs' : vm.hideMainMenu }">
         <md-icon>menu</md-icon>
         <md-tooltip md-direction="bottom" md-delay="500" md-autohide class="top-bar-tooltip">Menu</md-tooltip>
         <notifications-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notifications-bell>
@@ -56,7 +56,7 @@
 
     <!-- TOP BAR BUTTONS (SM+) -->
     <div layout="row" layout-align="end center" flex-gt-xs="30" hide-xs>
-      <mascot-announcement mode="mascot" header-ctrl="mainCtrl"></mascot-announcement>
+      <mascot-announcement mode="mascot"></mascot-announcement>
       <notifications-bell mode="bell" ng-if="!GuestMode"></notifications-bell>
       <username layout="row" layout-align="start center"></username>
     </div>

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -23,17 +23,17 @@
             md-is-open="vm.openMenuByDefault"
             md-whiteframe="4">
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
-    <md-button href="features" ng-show="mainCtrl.hasUnseenAnnouncements" ng-click="mainCtrl.hasUnseenAnnouncements = false;vm.closeMainMenu();" aria-label="view all announcements">
+    <md-button href="features" ng-show="vm.hasUnseenAnnouncements" ng-click="vm.closeMainMenu();" aria-label="view all announcements">
       <span><md-icon>new_releases</md-icon></span>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">New features</md-tooltip>
     </md-button>
     <!-- Regular notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="view all notifications"  ng-if="!mainCtrl.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="view all notifications"  ng-if="!vm.hasPriorityNotifications">
       <span><md-icon>notifications</md-icon></span>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
     </md-button>
     <!-- High priority notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="you have important notifications"  ng-if="mainCtrl.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="you have important notifications"  ng-if="vm.hasPriorityNotifications">
       <span class="main-menu__high-priority">
         <md-icon class="md-warn">error</md-icon>
       </span>

--- a/components/portal/messages/directives.js
+++ b/components/portal/messages/directives.js
@@ -25,7 +25,6 @@ define(['angular', 'require'], function(angular, require) {
         restrict: 'E',
         scope: {
           directiveMode: '@mode',
-          headerCtrl: '=headerCtrl',
         },
         templateUrl: require.toUrl('./partials/notifications-bell.html'),
         controller: 'NotificationsController',
@@ -46,7 +45,6 @@ define(['angular', 'require'], function(angular, require) {
         templateUrl: require.toUrl('./partials/announcement-mascot.html'),
         scope: {
           mode: '@',
-          headerCtrl: '=headerCtrl',
         },
         controller: 'AnnouncementsController',
         controllerAs: 'vm',

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -22,7 +22,7 @@
 
   <!-- MOBILE BELL -->
   <div class="notification-badge notification-badge-mobile" aria-label="{{ status }}"
-       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0 && !vm.isNotificationsPage">
+       ng-show="directiveMode === 'mobile-bell' && vm.notifications.length !== 0 && !vm.isNotificationsPage()">
     <md-icon>notifications</md-icon>
   </div>
 
@@ -35,13 +35,13 @@
                layout="row" layout-align="start center">
       <span><md-icon>notifications</md-icon></span>
       <span>Notifications </span>
-      <span ng-show="!vm.isNotificationsPage">({{ vm.notifications.length }})</span>
+      <span ng-show="!vm.isNotificationsPage()">({{ vm.notifications.length }})</span>
     </md-button>
   </md-menu-item>
 
   <!-- DESKTOP NOTIFICATION BELL -->
   <md-menu class="notifications-menu"
-           ng-show="directiveMode === 'bell' && !vm.isNotificationsPage"
+           ng-show="directiveMode === 'bell' && !vm.isNotificationsPage()"
            md-offset="-200 0"
            md-position-mode="target bottom">
     <md-button ng-click="$mdOpenMenu($event);vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell')"
@@ -59,7 +59,7 @@
     <md-menu-content class="top-bar-menu-content notifications-menu">
       <md-menu-item layout="row" layout-align="space-between center">
         <span>Notifications</span>
-        <a md-autofocus ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');vm.isNotificationsPage = true;" aria-label="see all notifications" class="link__see-all">
+        <a md-autofocus ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');vm.isNotificationsPage();" aria-label="see all notifications" class="link__see-all">
           See all <span ng-if="vm.notifications.length > 0">({{ vm.notifications.length }})</span>
         </a>
       </md-menu-item>
@@ -120,8 +120,8 @@
 
   <!-- PRIORITY NOTIFICATIONS (FIXED-TOP) -->
   <div class="priority-notifications"
-       ng-class="{ 'animate-hide': vm.priorityNotifications.length === 0 }"
-       ng-if="directiveMode === 'priority'">
+       ng-class="{ 'animate-hide': vm.priorityNotifications.length === 0 || vm.isNotificationsPage() }"
+       ng-if="directiveMode === 'priority' && !vm.isNotificationsPage()">
     <div class="priority-bubble"
          ng-if="vm.priorityNotifications.length == 1"
          ng-repeat="priority in vm.priorityNotifications | limitTo: 1"

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -49,7 +49,7 @@
                 <div class="notifications-list__action">
                   <md-button class="md-icon-button"
                              ng-hide="notification.dismissible === false"
-                             ng-click="vm.dismissNotification(notification);pushGAEvent('notifications page', 'dismiss', notification.id)"
+                             ng-click="vm.dismissNotification(notification, notification.priority === 'high');pushGAEvent('notifications page', 'dismiss', notification.id)"
                              aria-label="dismiss this notification">
                     <md-icon>clear</md-icon>
                     <md-tooltip md-delay="500">Dismiss notification</md-tooltip>
@@ -78,7 +78,7 @@
                 <!-- RESTORE BUTTON -->
                 <div class="notification-list__action">
                   <md-button class="md-icon-button"
-                             ng-click="vm.restoreNotification(notification)"
+                             ng-click="vm.restoreNotification(notification, notification.priority === 'high')"
                              aria-label="restore this notification">
                     <md-icon>undo</md-icon>
                     <md-tooltip md-delay="500">Restore notification</md-tooltip>

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -27,6 +27,7 @@ define(['angular'], function(angular) {
       '$sessionStorage',
       '$q',
       '$filter',
+      '$rootScope',
       'portalGroupService',
       'miscService',
       'keyValueService',
@@ -39,6 +40,7 @@ define(['angular'], function(angular) {
                $sessionStorage,
                $q,
                $filter,
+               $rootScope,
                portalGroupService,
                miscService,
                keyValueService,
@@ -271,12 +273,40 @@ define(['angular'], function(angular) {
             });
         };
 
+        /**
+         * Notify listeners that priority notifications flag has changed
+         * @param hasNotifications
+         */
+        var broadcastPriorityFlag = function(hasNotifications) {
+          $rootScope.$broadcast('HAS_PRIORITY_NOTIFICATIONS',
+            {hasNotifications: hasNotifications}
+          );
+
+          // Update storage
+          $localStorage.hasPriorityNotifications = hasNotifications;
+        };
+
+        /**
+         * Notify listeners that unseen announcements flag has changed
+         * @param hasAnnouncements
+         */
+        var broadcastAnnouncementFlag = function(hasAnnouncements) {
+          $rootScope.$broadcast('HAS_UNSEEN_ANNOUNCEMENTS',
+            {hasAnnouncements: hasAnnouncements}
+          );
+
+          // Update storage
+          $localStorage.hasUnseenAnnouncements = hasAnnouncements;
+        };
+
         return {
           getAllMessages: getAllMessages,
           getMessagesByGroup: getMessagesByGroup,
           getMessagesByData: getMessagesByData,
           getSeenMessageIds: getSeenMessageIds,
           setMessagesSeen: setMessagesSeen,
+          broadcastPriorityFlag: broadcastPriorityFlag,
+          broadcastAnnouncementFlag: broadcastAnnouncementFlag,
         };
     }]);
 });

--- a/components/portal/misc/partials/frame-page.html
+++ b/components/portal/misc/partials/frame-page.html
@@ -25,7 +25,7 @@
   app-show-add-to-home="{{appShowAddToHome}}"
   app-fname="{{appFname}}"></app-header>
   <div role="main" class="wrapper__push-content" ng-class="{ 'white-page' : whiteBackground }">
-    <main-menu ng-class="{ 'push-content' : menuPushContent, 'main-menu__open' : vm.isMenuOpen() }"></main-menu>
+    <main-menu ng-class="{ 'push-content' : menuPushContent, 'main-menu__open' : vm.isMenuOpen(), 'has-priority-notifications' : vm.hasPriorityNotifications }"></main-menu>
     <div class="content-wrapper__push-content" ng-if="menuPushContent">
       <ng-transclude></ng-transclude>
     </div>

--- a/components/staticFeeds/sample-messages.json
+++ b/components/staticFeeds/sample-messages.json
@@ -38,7 +38,7 @@
       "expireDate": null,
       "featureImageUrl": null,
       "priority": "high",
-      "dismissible": false,
+      "dismissible": true,
       "audienceFilter": {
         "groups": [""],
         "dataUrl": "",
@@ -92,7 +92,7 @@
       "goLiveDate": "2017-08-01T09:30",
       "expireDate": "2017-08-15",
       "featureImageUrl": "img/the-cow.png",
-      "priority": "high",
+      "priority": null,
       "audienceFilter": {
         "groups": ["Nonexistent-Group"],
         "dataUrl": "",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Your application can overwrite any constant listed below by adding it to the **j
 + **optionsTemplateURL**: A path to the HTML template for app-specific options (appears on the right-hand side of the [app-header](directives.md)). See the [app options doc](app-options.md) to learn how to use this feature.
 + **appMenuTemplateURL**: A path to the HTML template for app-specific menu items (appears in the side navigation menu that is triggered when clicking the top bar hamburger icon button). See the [app navigation doc](configurable-menu.md) to learn how to use this feature.
 + **appMenuItems**: An array of menu item objects used for a simple custom menu (with links that have a text label, icon, and url). See the [app navigation doc](configurable-menu.md) to learn how to use this feature.
-+ **enablePageLevelSidenav**:
++ **enablePushContentMenu**:
   - _CAUTION_
   - False by default
   - Only affects medium and large screens


### PR DESCRIPTION
**In this PR**:
- Fixed a bug that caused the page to scroll automatically when the sidenav was opened (if there was overflowing content)
    - Most CSS changes you'll see were made to accommodate this
- Fixed a bug where the notification bell didn't come back to the top bar after visiting the notifications page and then going elsewhere
- Fixed a bug where priority notifications were still displayed in the top bar while viewing the notifications page
- Fixed a bug where dismissing/restoring a priority notification didn't properly update the things that should be updated
- Gave the sidenav menu button its own controller so not to initialize the sidenav's controller twice
- Stopped passing controllers as scope objects on directives
    - Instead, now using `messagesService` to broadcast when the presence of priority notifications or unseen announcements has changed
- Made top bar "sticky" instead of fixed
    - This means the top bar no longer has to know whether there are priority notifications to adjust the next DOM sibling's spacing
- Removed an unused controller (`PortalHeaderController`)
- Fixed typo in docs

### Demos
![scroll-demo](https://user-images.githubusercontent.com/5818702/32390408-5a21a0a2-c09c-11e7-8d1f-0e7575602d38.gif)

![scroll-demo-xs](https://user-images.githubusercontent.com/5818702/32390407-5a1095b4-c09c-11e7-87cc-1861b0ee75b7.gif)
----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
