### PR TITLE
docs: Recommend title case not sentence case for list-of-links labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+* Recommend title case rather than sentence case for links in list-of-links widgets
+
 ## [6.1.0][] - 2017-10-18
 
 ### Added

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -122,13 +122,13 @@ Follow these steps for each of the predefined widget types described in this doc
       "launchText":"Launch talent development",
       "links": [
         {
-          "title":"All courses and events",
+          "title":"All Courses and Events",
           "href":"https://www.ohrd.wisc.edu/home/",
           "icon":"fa-at",
           "target":"_blank"
         },
         {
-          "title":"My transcript",
+          "title":"My Transcript",
           "href":"https://www.ohrd.wisc.edu/ohrdcatalogportal/LearningTranscript/tabid/57/Default.aspx?ctl=login",
           "icon":"fa-envelope-o",
           "target":"_blank"
@@ -155,7 +155,7 @@ when there's nothing more to launch, that is, when the list-of-links widget simp
 * Avoid using a `list-of-links` widget when you only need to display one link. Instead, use the name and `alternativeMaximizedLink` of [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory) to represent the link.
 This provides a more usable click surface, a simpler and cleaner user experience, and achieves better consistency with other just-a-link widgets in MyUW.
 * The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive.
-* Use sentence case in the titles of the links.
+* Use title case in the titles of the links.
 
 ### Search with links
 


### PR DESCRIPTION
In prototyping recent list-of-links usage with UX consultant @mrdahman , title case rather than sentence case seemed to be preferable for the within-`list-of-links`-type-widget link labels.

![star-widget-prototype](https://user-images.githubusercontent.com/952283/32397249-f0a849b2-c0b6-11e7-8be0-bab209508c3b.png)

This is at odds with the style recommendation currently embedded in the widget documentation (though interestingly the example screenshot in the documentation is already using title case rather than sentence case for this labelling). This changeset would update the guidance to match what we seem to now be preferring.

Personally, I'd have gone with sentence case. But this isn't about me personally. :) So this PR is about reconciling what professionally we ought to be recommending.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
