### PR TITLE
Analytics

### DIFF
--- a/components/config.js
+++ b/components/config.js
@@ -20,7 +20,9 @@
 // eslint-disable-next-line requirejs/no-js-extension
 define(['./my-app/app-config.js'], function(myAppConfig) {
   /**
-   * taken from https://plainjs.com/javascript/utilities/merge-two-javascript-objects-19/
+   * Taken from https://plainjs.com/javascript/utilities/merge-two-javascript-objects-19/
+   * @param {Object} obj
+   * @param {string} src
    */
   function extend(obj, src) {
     Object.keys(src).forEach(function(key) {

--- a/components/portal/about/services.js
+++ b/components/portal/about/services.js
@@ -24,14 +24,17 @@ define(['angular'], function(angular) {
     '$http', 'miscService', 'FRAME_URLS',
     function($http, miscService, FRAME_URLS) {
     /**
-    * Gets frame information from generated about-frame.json
+     * Gets frame information from generated about-frame.json
+     * @return {*}
     **/
     var getFrameDetails = function() {
       return getDetails(FRAME_URLS.aboutFrame);
     };
 
     /**
-    * Get information
+     * Get information
+     * @param {string} URL
+     * @return {*}
     **/
     var getDetails = function(URL) {
       return $http.get(URL, {cache: true})

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -170,9 +170,9 @@ define(['angular', 'require'], function(angular, require) {
   /* Side navigation controller */
   .controller('MainMenuController', ['$rootScope', '$scope', '$mdSidenav',
     '$mdMedia', '$window', '$localStorage', 'APP_OPTIONS', 'FOOTER_URLS',
-    'MESSAGES', 'NAMES',
+    'MESSAGES', 'NAMES', 'miscService',
     function($rootScope, $scope, $mdSidenav, $mdMedia, $window, $localStorage,
-             APP_OPTIONS, FOOTER_URLS, MESSAGES, NAMES) {
+             APP_OPTIONS, FOOTER_URLS, MESSAGES, NAMES, miscService) {
       var vm = this;
 
       // Scope variables
@@ -217,6 +217,16 @@ define(['angular', 'require'], function(angular, require) {
         if (vm.isMenuOpen()) {
           $mdSidenav('main-menu').close();
         }
+      };
+
+      /**
+       * Track clicks on "Notifications" bell in mobile side nav
+       * @param category Context of the event
+       * @param action Action taken
+       * @param label Label/data pertinent to event
+       */
+      vm.pushGAEvent = function(category, action, label) {
+        miscService.pushGAEvent(category, action, label);
       };
 
       /**

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -204,7 +204,7 @@ define(['angular', 'require'], function(angular, require) {
 
       /**
        * Check if the side nav menu is open
-       * @return Boolean
+       * @return {boolean}
        */
       vm.isMenuOpen = function() {
         return $mdSidenav('main-menu').isOpen();
@@ -221,9 +221,9 @@ define(['angular', 'require'], function(angular, require) {
 
       /**
        * Track clicks on "Notifications" bell in mobile side nav
-       * @param category Context of the event
-       * @param action Action taken
-       * @param label Label/data pertinent to event
+       * @param {string} category - Context of the event
+       * @param {string} action - Action taken
+       * @param {string} label - Label/data pertinent to event
        */
       vm.pushGAEvent = function(category, action, label) {
         miscService.pushGAEvent(category, action, label);

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -28,12 +28,18 @@
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">New features</md-tooltip>
     </md-button>
     <!-- Regular notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="view all notifications"  ng-if="!vm.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}"
+               ng-click="vm.pushGAEvent('Sidenav notifications bell (normal state)', 'Click link', 'Normal state');vm.closeMainMenu();"
+               aria-label="view all notifications"
+               ng-if="!vm.hasPriorityNotifications">
       <span><md-icon>notifications</md-icon></span>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
     </md-button>
     <!-- High priority notifications button -->
-    <md-button ng-href="{{ vm.notificationsPageUrl }}" ng-click="vm.closeMainMenu();" aria-label="you have important notifications"  ng-if="vm.hasPriorityNotifications">
+    <md-button ng-href="{{ vm.notificationsPageUrl }}"
+               ng-click="vm.pushGAEvent('Sidenav notifications bell', 'Click link', 'High priority state');vm.closeMainMenu();"
+               aria-label="you have important notifications"
+               ng-if="vm.hasPriorityNotifications">
       <span class="main-menu__high-priority">
         <md-icon class="md-warn">error</md-icon>
       </span>

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -88,7 +88,7 @@ define(['angular'], function(angular) {
 
         /**
          * Separate the message types in scope for child controllers
-         * @param result {*}
+         * @param result Object
          */
         var filterMessagesSuccess = function(result) {
           // Check for filtered notifications

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -88,7 +88,7 @@ define(['angular'], function(angular) {
 
         /**
          * Separate the message types in scope for child controllers
-         * @param result Object
+         * @param {Object} result
          */
         var filterMessagesSuccess = function(result) {
           // Check for filtered notifications
@@ -107,7 +107,7 @@ define(['angular'], function(angular) {
         /**
          * Handle errors that occur while resolving promises to
          * get notifications
-         * @param error {Object}
+         * @param {Object} error
          */
         var filterMessagesFailure = function(error) {
           $log.warn('Problem getting messages from messagesService');
@@ -198,7 +198,7 @@ define(['angular'], function(angular) {
 
         /**
          * Separate seen and unseen notifications, then set scope variables
-         * @param result {Object}
+         * @param {Object} result
          */
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
@@ -250,7 +250,7 @@ define(['angular'], function(angular) {
 
         /**
          * Handle errors getting seen message IDs
-         * @param error {Object}
+         * @param {Object} error
          */
         var getSeenMessageIdsFailure = function(error) {
           $log.warn('Couldn\'t get seen message IDs for notifications ' +
@@ -297,7 +297,7 @@ define(['angular'], function(angular) {
         // ////////////////
         /**
          * Check if user is viewing notifications page
-         * @return boolean
+         * @return {boolean}
          */
         vm.isNotificationsPage = function() {
           return $window.location.pathname === MESSAGES.notificationsPageURL;
@@ -305,8 +305,8 @@ define(['angular'], function(angular) {
 
         /**
          * On-click event to mark a notification as "seen"
-         * @param notification {Object}
-         * @param isHighPriority {boolean}
+         * @param {Object} notification
+         * @param {boolean} isHighPriority
          */
         vm.dismissNotification = function(notification, isHighPriority) {
           vm.notifications = $filter('filterOutMessageWithId')(
@@ -334,8 +334,8 @@ define(['angular'], function(angular) {
 
         /**
          * On-click event to mark a notification as "unseen"
-         * @param notification {Object}
-         * @param isHighPriority {boolean}
+         * @param {Object} notification
+         * @param {boolean} isHighPriority
          */
         vm.restoreNotification = function(notification, isHighPriority) {
           // Remove notification from dismissed array
@@ -392,9 +392,9 @@ define(['angular'], function(angular) {
 
         /**
          * Track clicks on "Notifications" links in mobile menu and top bar
-         * @param category {string} Context of the event
-         * @param action {string} Action taken
-         * @param label {string} Label/data pertinent to event
+         * @param {string} category - Context of the event
+         * @param {string} action - Action taken
+         * @param {string} label - Label/data pertinent to event
          */
         vm.pushGAEvent = function(category, action, label) {
           miscService.pushGAEvent(category, action, label);
@@ -465,7 +465,7 @@ define(['angular'], function(angular) {
         /**
          * Separate seen and unseen, then set mascot image or get popups
          * depending on directive mode.
-         * @param result {Object} Data returned by promises
+         * @param {Object} result - Data returned by promises
          */
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
@@ -519,7 +519,7 @@ define(['angular'], function(angular) {
 
         /**
          * Handle errors encountered while resolving promises
-         * @param error {Object}
+         * @param {Object} error
          */
         var getSeenMessageIdsFailure = function(error) {
           // HANDLE ERRORS
@@ -607,7 +607,7 @@ define(['angular'], function(angular) {
         /**
          * Remove dismissed announcement from scope announcements,
          * then update storage
-         * @param id {string}
+         * @param {string} id
          */
         vm.markSingleAnnouncementSeen = function(id) {
           // Use $filter to filter out by ID
@@ -726,7 +726,7 @@ define(['angular'], function(angular) {
 
         /**
          * Get seen message IDs, then mark all announcements seen
-         * @param result {Object} Data returned by promises
+         * @param {Object} result - Data returned by promises
          */
         var getSeenMessageIdsSuccess = function(result) {
           var originalSeenMessageIds = [];

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -107,7 +107,7 @@ define(['angular'], function(angular) {
         /**
          * Handle errors that occur while resolving promises to
          * get notifications
-         * @param error {*}
+         * @param error {Object}
          */
         var filterMessagesFailure = function(error) {
           $log.warn('Problem getting messages from messagesService');
@@ -198,7 +198,7 @@ define(['angular'], function(angular) {
 
         /**
          * Separate seen and unseen notifications, then set scope variables
-         * @param result {*}
+         * @param result {Object}
          */
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
@@ -250,7 +250,7 @@ define(['angular'], function(angular) {
 
         /**
          * Handle errors getting seen message IDs
-         * @param error {*}
+         * @param error {Object}
          */
         var getSeenMessageIdsFailure = function(error) {
           $log.warn('Couldn\'t get seen message IDs for notifications ' +
@@ -305,8 +305,8 @@ define(['angular'], function(angular) {
 
         /**
          * On-click event to mark a notification as "seen"
-         * @param notification {*}
-         * @param isHighPriority boolean
+         * @param notification {Object}
+         * @param isHighPriority {boolean}
          */
         vm.dismissNotification = function(notification, isHighPriority) {
           vm.notifications = $filter('filterOutMessageWithId')(
@@ -334,8 +334,8 @@ define(['angular'], function(angular) {
 
         /**
          * On-click event to mark a notification as "unseen"
-         * @param notification {*}
-         * @param isHighPriority boolean
+         * @param notification {Object}
+         * @param isHighPriority {boolean}
          */
         vm.restoreNotification = function(notification, isHighPriority) {
           // Remove notification from dismissed array
@@ -392,9 +392,9 @@ define(['angular'], function(angular) {
 
         /**
          * Track clicks on "Notifications" links in mobile menu and top bar
-         * @param category String Context of the event
-         * @param action String Action taken
-         * @param label String Label/data pertinent to event
+         * @param category {string} Context of the event
+         * @param action {string} Action taken
+         * @param label {string} Label/data pertinent to event
          */
         vm.pushGAEvent = function(category, action, label) {
           miscService.pushGAEvent(category, action, label);
@@ -465,7 +465,7 @@ define(['angular'], function(angular) {
         /**
          * Separate seen and unseen, then set mascot image or get popups
          * depending on directive mode.
-         * @param result {*} Data returned by promises
+         * @param result {Object} Data returned by promises
          */
         var getSeenMessageIdsSuccess = function(result) {
           if (result.seenMessageIds && angular.isArray(result.seenMessageIds)
@@ -519,7 +519,7 @@ define(['angular'], function(angular) {
 
         /**
          * Handle errors encountered while resolving promises
-         * @param error {*}
+         * @param error {Object}
          */
         var getSeenMessageIdsFailure = function(error) {
           // HANDLE ERRORS
@@ -607,7 +607,7 @@ define(['angular'], function(angular) {
         /**
          * Remove dismissed announcement from scope announcements,
          * then update storage
-         * @param id String
+         * @param id {string}
          */
         vm.markSingleAnnouncementSeen = function(id) {
           // Use $filter to filter out by ID
@@ -726,7 +726,7 @@ define(['angular'], function(angular) {
 
         /**
          * Get seen message IDs, then mark all announcements seen
-         * @param result {*} Data returned by promises
+         * @param result {Object} Data returned by promises
          */
         var getSeenMessageIdsSuccess = function(result) {
           var originalSeenMessageIds = [];

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -26,25 +26,12 @@
     <md-icon>notifications</md-icon>
   </div>
 
-  <!-- MOBILE MENU ROW -->
-  <md-menu-item ng-show="directiveMode === 'mobile-menu'">
-    <md-button title="click to view notifications"
-               class="md-default"
-               ng-href="{{ vm.notificationsUrl }}"
-               ng-click="vm.pushGAEvent('Mobile Menu', 'Click Link', 'Notifications');"
-               layout="row" layout-align="start center">
-      <span><md-icon>notifications</md-icon></span>
-      <span>Notifications </span>
-      <span ng-show="!vm.isNotificationsPage()">({{ vm.notifications.length }})</span>
-    </md-button>
-  </md-menu-item>
-
   <!-- DESKTOP NOTIFICATION BELL -->
   <md-menu class="notifications-menu"
            ng-show="directiveMode === 'bell' && !vm.isNotificationsPage()"
            md-offset="-200 0"
            md-position-mode="target bottom">
-    <md-button ng-click="$mdOpenMenu($event);vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell')"
+    <md-button ng-click="$mdOpenMenu($event);vm.trackRenderedNotifications()"
                class="notification-desktop"
                md-no-ink
                md-menu-origin>
@@ -59,7 +46,7 @@
     <md-menu-content class="top-bar-menu-content notifications-menu">
       <md-menu-item layout="row" layout-align="space-between center">
         <span>Notifications</span>
-        <a md-autofocus ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Top Bar', 'Click Link', 'Notification Bell');vm.isNotificationsPage();" aria-label="see all notifications" class="link__see-all">
+        <a md-autofocus ng-href="{{ vm.notificationsUrl }}" ng-click="vm.pushGAEvent('Notification bell menu', 'Click link', 'See all');vm.isNotificationsPage();" aria-label="see all notifications" class="link__see-all">
           See all <span ng-if="vm.notifications.length > 0">({{ vm.notifications.length }})</span>
         </a>
       </md-menu-item>
@@ -72,7 +59,7 @@
       </md-menu-item>
       <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->
       <div ng-show="vm.notifications.length > 0">
-        <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:3"
+        <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:vm.renderLimit"
                       class="top-bar-menu-item">
           <!-- NOTIFICATION CONTENT -->
           <div class="menu-item-content" layout="row" layout-align="space-between center">
@@ -89,7 +76,7 @@
                 <md-button class="md-raised md-accent"
                            ng-show="notification.actionButton"
                            ng-href="{{ notification.actionButton.url }}"
-                           ng-click="vm.pushGAEvent('Notification', 'Action button bell', notification.id);""
+                           ng-click="vm.pushGAEvent('Notification menu item', 'Click action button', notification.id);"
                            target="_blank"
                            rel="noopener noreferrer">
                   {{ notification.actionButton.label }}
@@ -97,6 +84,7 @@
                 <md-button class="md-default"
                            ng-show="notification.moreInfoButton"
                            ng-href="{{ notification.moreInfoButton.url }}"
+                           ng-click="vm.pushGAEvent('Notification menu item', 'Click more info', notification.id);"
                            target="_blank"
                            rel="noopener noreferrer">
                   {{ notification.moreInfoButton.label }}
@@ -106,7 +94,7 @@
             <!-- DISMISS BUTTON -->
             <md-button class="md-icon-button button__mark-seen"
                        ng-hide="notification.dismissible === false"
-                       ng-click="vm.dismissNotification(notification)"
+                       ng-click="vm.dismissNotification(notification);vm.pushGAEvent('Notification menu item', 'Dismiss', notification.id)"
                        aria-label="dismiss this notification"
                        md-prevent-menu-close="md-prevent-menu-close"
                        flex="20">
@@ -146,7 +134,7 @@
       <div class="dismiss-priority">
         <md-button class="md-icon-button"
                    ng-hide="priority.dismissible === false"
-                   ng-click="vm.dismissNotification(priority, true)"
+                   ng-click="vm.dismissNotification(priority, true);vm.pushGAEvent('Priority notification', 'Dismiss', priority.id)"
                    aria-label="Dismiss this notification">
           <md-icon>close</md-icon>
         </md-button>

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -49,7 +49,7 @@
                 <div class="notifications-list__action">
                   <md-button class="md-icon-button"
                              ng-hide="notification.dismissible === false"
-                             ng-click="vm.dismissNotification(notification, notification.priority === 'high');pushGAEvent('notifications page', 'dismiss', notification.id)"
+                             ng-click="vm.dismissNotification(notification, notification.priority === 'high');pushGAEvent('Notifications page', 'Dismiss notification', notification.id)"
                              aria-label="dismiss this notification">
                     <md-icon>clear</md-icon>
                     <md-tooltip md-delay="500">Dismiss notification</md-tooltip>
@@ -78,7 +78,7 @@
                 <!-- RESTORE BUTTON -->
                 <div class="notification-list__action">
                   <md-button class="md-icon-button"
-                             ng-click="vm.restoreNotification(notification, notification.priority === 'high')"
+                             ng-click="vm.restoreNotification(notification, notification.priority === 'high');pushGAEvent('Notifications page', 'Restore notification', notification.id)"
                              aria-label="restore this notification">
                     <md-icon>undo</md-icon>
                     <md-tooltip md-delay="500">Restore notification</md-tooltip>

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -74,7 +74,7 @@ define(['angular'], function(angular) {
 
         /**
          * Get everything at the messages service endpoint
-         * @returns {Array} An array of message objects
+         * @return {Array} An array of message objects
          */
         var getAllMessages = function() {
           return $http.get(SERVICE_LOC.messagesURL)
@@ -95,8 +95,8 @@ define(['angular'], function(angular) {
         /**
          * Filter the array of messages based on each message's groups
          * attribute
-         * @param messages An array of message objects
-         * @returns {Array} A filtered array of messages
+         * @param {Array} messages - An array of message objects
+         * @return {Array} A filtered array of messages
          */
         var getMessagesByGroup = function(messages) {
           return portalGroupService.getGroups()
@@ -144,8 +144,8 @@ define(['angular'], function(angular) {
         /**
          * Filter the array of messages based on if
          * data was requested before showing
-         * @param messages An array of message objects
-         * @returns {filteredMessages[]} an array of messages that
+         * @param {Array} messages An array of message objects
+         * @return {filteredMessages[]} an array of messages that
          *   includes only non-data messages and messages that requested
          *   data and had data
          */
@@ -209,7 +209,7 @@ define(['angular'], function(angular) {
 
         /**
          * Get list of seen message IDs from K/V store or session storage
-         * @returns {*}
+         * @return {*}
          */
         var getSeenMessageIds = function() {
           // If K/V store isn't turned on, don't proceed
@@ -231,10 +231,12 @@ define(['angular'], function(angular) {
 
         /**
          * Set list of seen IDs in K/V store and session storage
-         * @param originalSeenIds The ids when the controller initialized
-         * @param alteredSeenIds The ids following action in the controller
-         * @param action The action to take (restore or dismiss)
-         * @returns {*}
+         * @param {Array} originalSeenIds - The ids when the
+         *    controller initialized
+         * @param {Array} alteredSeenIds - The ids following action in
+         *    the controller
+         * @param {string} action - The action to take (restore or dismiss)
+         * @return {*}
          */
         var setMessagesSeen = function(originalSeenIds,
                                        alteredSeenIds,
@@ -275,7 +277,7 @@ define(['angular'], function(angular) {
 
         /**
          * Notify listeners that priority notifications flag has changed
-         * @param hasNotifications
+         * @param {boolean} hasNotifications
          */
         var broadcastPriorityFlag = function(hasNotifications) {
           $rootScope.$broadcast('HAS_PRIORITY_NOTIFICATIONS',
@@ -288,7 +290,7 @@ define(['angular'], function(angular) {
 
         /**
          * Notify listeners that unseen announcements flag has changed
-         * @param hasAnnouncements
+         * @param {boolean} hasAnnouncements
          */
         var broadcastAnnouncementFlag = function(hasAnnouncements) {
           $rootScope.$broadcast('HAS_UNSEEN_ANNOUNCEMENTS',

--- a/components/portal/misc/partials/example-menu.html
+++ b/components/portal/misc/partials/example-menu.html
@@ -35,7 +35,6 @@
     <span>MyUW Home</span>
   </md-button>
 </md-menu-item>
-<notifications-bell mode="mobile-menu"></notifications-bell>
 <md-menu-item>
   <md-button href="https://github.com/uPortal-Project/uportal-app-framework" ng-click="vm.closeMainMenu();">
     <i class="fa fa-github"></i>

--- a/components/portal/misc/partials/example-menu.html
+++ b/components/portal/misc/partials/example-menu.html
@@ -35,6 +35,7 @@
     <span>MyUW Home</span>
   </md-button>
 </md-menu-item>
+<notifications-bell mode="mobile-menu"></notifications-bell>
 <md-menu-item>
   <md-button href="https://github.com/uPortal-Project/uportal-app-framework" ng-click="vm.closeMainMenu();">
     <i class="fa fa-github"></i>

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -35,15 +35,14 @@ define(['angular', 'jquery'], function(angular, $) {
     };
 
     /**
-    * Filter the array given the groups, with an optional groupFieldName
-    * @param array: an array of objects to be filteredLayout
-    * @param groups: The array of groups
-    * @param arrayGroupFieldName:
-    *        The field in the array to filter upon.
-    *        @default 'group'.
-    * @param groupsNameFieldName:
-    *        The field on the group object that is the group's name.
-    *        @default 'name'
+     * Filter the array given the groups, with an optional groupFieldName
+     * @param {Array} array - an array of objects to be filteredLayout
+     * @param {Array} groups - The array of groups
+     * @param {string} [arrayGroupFieldName=group] - The field in the array
+     *    to filter upon.
+     * @param {string} [groupsNameFieldName=name] - The field on the group
+     *     object that is the group's name.
+     * @return {*}
     */
     var filterArrayByGroups = function(
       array, groups, arrayGroupFieldName, groupsNameFieldName
@@ -155,10 +154,11 @@ define(['angular', 'jquery'], function(angular, $) {
   .factory('miscService',
   function($analytics, $http, $window, $location, $log, MISC_URLS) {
     /**
-     Used to redirect users to login screen
-     iff result code is 0 (yay shib) or 302
-
-     Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
+     * Used to redirect users to login screen
+     *    if result code is 0 (yay shib) or 302
+     *    Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
+     * @param {number} status
+     * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
       if (status === 0 || status === 302) {
@@ -176,13 +176,13 @@ define(['angular', 'jquery'], function(angular, $) {
     };
 
     /**
-     Google Analytics event push
-     - category : e.g.: beta header
-     - action   : e.g.: beta buttons
-     - label    : e.g.: back to classic
-
-     See https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide for more info
-    **/
+     * Google Analytics event push
+     * See https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide for more info
+     * @param {string} category - Context of the event
+     * @param {string} action - Action taken
+     * @param {string} label - Label/data pertinent to event
+     * @param {string} value
+     */
     var pushGAEvent = function(category, action, label, value) {
       $analytics.eventTrack(action, {
         'category': category,

--- a/components/portal/settings/services.js
+++ b/components/portal/settings/services.js
@@ -25,6 +25,8 @@ define(['angular', 'jquery'], function(angular, $) {
         function($q, $http, miscService, SERVICE_LOC) {
           /**
            * Sets the skin on the backend layout manager
+           * @param {string} skinKey
+           * @return {*}
            */
           function setPortalSkin(skinKey) {
             if (SERVICE_LOC.portalLayoutRestEndpoint) {

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -33,8 +33,8 @@ define(['angular'], function(angular) {
      * Check for widget types that require extra configuration
      * (including null/undefined case), default to provided
      * widget type.
-     * @param widget The widget object provided by widgetService
-     * @returns {*} A string for the widget type
+     * @param {Object} widget - The widget object provided by widgetService
+     * @return {*} - A string for the widget type
      */
     var widgetType = function widgetType(widget) {
       // Check for types that need handling
@@ -74,6 +74,7 @@ define(['angular'], function(angular) {
     /**
      * Initial widget setup -- gets data for a single widget
      * from the provided fname attribute
+     * @param {string} fname
      */
     $scope.initializeWidget = function(fname) {
       // Initialize scope variables
@@ -103,7 +104,7 @@ define(['angular'], function(angular) {
     /**
      * Set the launch button url for static content,
      * exclusive mode, and basic widgets
-     * @returns {*}
+     * @return {*}
      */
     $scope.renderUrl = function renderUrl() {
       var widget = $scope.widget;
@@ -196,8 +197,8 @@ define(['angular'], function(angular) {
     /**
      * Turn the provided date string into an actual
      * Date so it can be filtered into something prettier.
-     * @param dateString A hideously ugly date string
-     * @returns {*} A Date object or null
+     * @param {string} dateString - A hideously ugly date string
+     * @return {*} A Date object or null
      */
     $scope.getPrettyDate = function(dateString) {
       // Create a new date if a date string was provided, otherwise return null
@@ -206,8 +207,8 @@ define(['angular'], function(angular) {
 
     /**
      * Remove leading/trailing spaces from RSS titles
-     * @param title The RSS title
-     * @returns String The trimmed title
+     * @param {string} title - The RSS title
+     * @return {string} The trimmed title
      */
     $scope.trim = function(title) {
       return title.trim();
@@ -304,7 +305,7 @@ define(['angular'], function(angular) {
     // Scope functions
     /**
      * Navigate to the url provided by the action item
-     * @param url A path provided by the action item
+     * @param {string} url - A path provided by the action item
      */
     $scope.goToAction = function(url) {
       // Go there if the url exists
@@ -317,7 +318,7 @@ define(['angular'], function(angular) {
     /**
      * Gets the quantity for the provided item from its feedUrl, then
      * builds a new actionItem object to add to scope.
-     * @param item Object for a single action item
+     * @param {Object} item - Object for a single action item
      */
     var assembleActionItemsList = function(item) {
       // Get number from provided url
@@ -508,7 +509,7 @@ define(['angular'], function(angular) {
 
     /**
      * Display time-sensitive content with provided configuration
-     * @param config The provided configuration for a call to action
+     * @param {*} config - The provided configuration for a call to action
      */
     var displayTimeSensitiveContent = function(config) {
       var dates = config.activeDateRange;
@@ -577,7 +578,7 @@ define(['angular'], function(angular) {
      * @param {Object} object The array entry to search through
      * @param {Array<String>} strings
      *        The string values to test against each entry
-     * @returns {Array<Object>} An array containing only the desired
+     * @return {Array<Object>} An array containing only the desired
      */
     $scope.filteredArray = function(array, object, strings) {
       if (array && object && strings) {
@@ -595,7 +596,7 @@ define(['angular'], function(angular) {
 
     /**
      * Initialize scope variables before getting widget content
-     * @param template The provided custom HTML template
+     * @param {string} template - The provided custom HTML template
      */
     var initializeCustomWidget = function(template) {
       $scope.content = [];

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -26,8 +26,8 @@ define(['angular'], function(angular) {
     function($http, $log, SERVICE_LOC) {
     /**
      * Get the a single app's full entity file as JSON
-     * @param fname The app's fname value (<fname> in entity files)
-     * @returns {*}
+     * @param {string} fname - The app's fname value (<fname> in entity files)
+     * @return {*}
      */
     var getSingleWidgetData = function getSingleWidgetData(fname) {
       // configuration backwards compatibility
@@ -51,7 +51,7 @@ define(['angular'], function(angular) {
     /**
      * Display error message if a user doesn't have
      * permission to see/use the requested widget
-     * @param fname
+     * @param {string} fname
      * @return {Object} Special error-case widget configuration
      */
     var getErrorPage = function(fname) {
@@ -77,7 +77,7 @@ define(['angular'], function(angular) {
      * Get additional values/configuration not provided
      * by the widget's basic configuration.
      * Used by Option Link and Custom widgets
-     * @param widget
+     * @param {Object} widget
      * @return {*}
      */
     var getWidgetJson = function(widget) {
@@ -105,8 +105,8 @@ define(['angular'], function(angular) {
 
     /**
      * Get an RSS feed from the provided url as json
-     * @param url
-     * @returns {*}
+     * @param {string} url
+     * @return {*}
      */
     var getRssAsJson = function(url) {
       return $http.get(url, {cache: true})
@@ -122,8 +122,8 @@ define(['angular'], function(angular) {
     /**
      * Get the quantity of items needing attention
      * for an action-item widget
-     * @param url The url provided in widgetConfig
-     * @returns Number The number of items needing attention
+     * @param {string} url - The url provided in widgetConfig
+     * @return {number} The number of items needing attention
      */
     var getActionItemQuantity = function(url) {
       return $http.get(url)

--- a/components/test/main.js
+++ b/components/test/main.js
@@ -33,6 +33,7 @@ require(['/base/config.js'], function(config) {
 
     /**
      * Find all test files by filename convention
+     * @return {Object} allTestFiles
      */
     function getAllTestFiles() {
         var allTestFiles = [];

--- a/tools/static/build.js
+++ b/tools/static/build.js
@@ -100,9 +100,9 @@ copy(
 /**
  * Process the .less styles into css, auto-prefix the css,
  * then write to a .css file
- * @param srcPath String for the input .less file path
- * @param theme String for the name of the theme
- * @param styles String read from the input less file
+ * @param {string} srcPath - for the input .less file path
+ * @param {string} theme - for the name of the theme
+ * @param {string} styles - read from the input less file
  */
 function writeCss(srcPath, theme, styles) {
   // Output file path for the theme


### PR DESCRIPTION
[MUMUP-3023](https://jira.doit.wisc.edu/jira/browse/MUMUP-3023): "As a MyUW stakeholder, I would like to know how many times a given notification was dismissed/undismissed, so that I can better understand how effective the notification is and how users engage with it."

[MUMUP-3024](https://jira.doit.wisc.edu/jira/browse/MUMUP-3024): "As a stakeholder, I would like to know how many times a given notification has been rendered, so that I better understand how effective MyUW notifications are."

**In this PR:** 
- Track notifications rendered by clicking the notification bell
- Track dismissal from bell menu
- Track priority notification renders
- Track dismiss from priority notification
- Track dismiss/restore from notifications page 
- Track clicks on mobile side nav notification bell (with and without priority indicator)
- Remove unused directive mode (`notifications-bell mode="mobile-menu">`)
- Fix a bunch of JSDoc warnings that I'm tired of seeing from eslint every time I commit something. **I realize that this should have been a separate PR, but I got carried away...so I'll note the files that have changes pertinent to analytics:**
    - [components/portal/main/controllers.js](https://github.com/uPortal-Project/uportal-app-framework/compare/master...thevoiceofzeke:analytics?expand=1#diff-b99667b6dbc79e157ed2e2e56c528ad1)
    - [components/portal/main/partials/main-menu.html](https://github.com/uPortal-Project/uportal-app-framework/compare/master...thevoiceofzeke:analytics?expand=1#diff-49a9b6a5e699e76c304a2d88a83425ec)
    - [components/portal/messages/controllers.js](https://github.com/uPortal-Project/uportal-app-framework/compare/master...thevoiceofzeke:analytics?expand=1#diff-5dc1012888a1a7946853bbacd81416b6)
    - [components/portal/messages/partials/notifications-bell.html](https://github.com/uPortal-Project/uportal-app-framework/compare/master...thevoiceofzeke:analytics?expand=1#diff-36897e733a0d6a744c47fbd224622b0d)
    - [components/portal/messages/partials/view_notifications.html](https://github.com/uPortal-Project/uportal-app-framework/compare/master...thevoiceofzeke:analytics?expand=1#diff-b7ff6e582aad00eae02a5794130dab67)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
