### PR TITLE
fix: Track notifications by index to cope with duplicate values

### DIFF
--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -59,7 +59,7 @@
       </md-menu-item>
       <!-- SHOW UP TO 3 NEW NOTIFICATIONS -->
       <div ng-show="vm.notifications.length > 0">
-        <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:vm.renderLimit"
+        <md-menu-item ng-repeat="notification in vm.notifications | orderBy:'priority' | limitTo:vm.renderLimit track by $index"
                       class="top-bar-menu-item">
           <!-- NOTIFICATION CONTENT -->
           <div class="menu-item-content" layout="row" layout-align="space-between center">


### PR DESCRIPTION
#601 appears to have introduced a bug that causes display of notifications to fail (which I am unable to produce locally). This PR adds tracking by index, which we should probably have anyway, and which might fix the bug.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
