### PR TITLE
fix: Add index tracking to notifications page

### DIFF
--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -39,7 +39,7 @@
           <md-content>
             <md-list class="notifications-list" flex>
               <md-list-item class="notification-item"
-                            ng-repeat="notification in vm.notifications | orderBy:'priority'"
+                            ng-repeat="notification in vm.notifications | orderBy:'priority' track by $index"
                             layout="row"
                             layout-align="start center">
 
@@ -69,7 +69,7 @@
           <md-content>
             <md-list class="notifications-list" flex>
               <md-list-item class="notification-item"
-                            ng-repeat="notification in vm.dismissedNotifications | orderBy:['-priority', '-id']"
+                            ng-repeat="notification in vm.dismissedNotifications | orderBy:['-priority', '-id']  track by $index"
                             layout="row"
                             layout-align="start center">
 


### PR DESCRIPTION
#602 fixed the bug, but we need the same fix on the notifications page.

*Note: This bug seems to have been caused by two notifications that have identical IDs -- in reality we should never encounter this issue as we are the gatekeepers of production notifications.*

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
