### PR TITLE
revert: docs: Recommend title case not sentence case for list-of-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,6 @@ indicator
 + Clarify safety of `/settings` tooling to reset in-browser state. (#600)
 + Fix notification rendering robustness against duplicate ids (#602, #603)
 
-### Docs
-
-+ Recommend Title Case not Sentence case for link labels in `list-of-links`
-widgets (#588)
-
-This is controversial and may be reversed in a future release as the
-relationship with Material Design is clarified.
-
 ### Refactor
 
 + Use `moment.js` in `time-sensitive-content` widget type (#593)

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -122,13 +122,13 @@ Follow these steps for each of the predefined widget types described in this doc
       "launchText":"Launch talent development",
       "links": [
         {
-          "title":"All Courses and Events",
+          "title":"All courses and events",
           "href":"https://www.ohrd.wisc.edu/home/",
           "icon":"fa-at",
           "target":"_blank"
         },
         {
-          "title":"My Transcript",
+          "title":"My transcript",
           "href":"https://www.ohrd.wisc.edu/ohrdcatalogportal/LearningTranscript/tabid/57/Default.aspx?ctl=login",
           "icon":"fa-envelope-o",
           "target":"_blank"
@@ -155,7 +155,7 @@ when there's nothing more to launch, that is, when the list-of-links widget simp
 * Avoid using a `list-of-links` widget when you only need to display one link. Instead, use the name and `alternativeMaximizedLink` of [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory) to represent the link.
 This provides a more usable click surface, a simpler and cleaner user experience, and achieves better consistency with other just-a-link widgets in MyUW.
 * The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive.
-* Use title case in the titles of the links.
+* Use sentence case in the titles of the links.
 
 ### Search with links
 


### PR DESCRIPTION
This commit reverts 793d59354a3522bb1c7bf4c0918f65a0e0658bfc ( #597 ).

There's some controversy about whether within-`list-of-links`-widget link labels are more usable as Title Case or as Sentence case and so what our style guidance ought to recommend, and how this relates to how literally we're adopting Material Design.

In the spirit of *stare decisis*, let's not change the recommendation at this juncture. This changeset reverts this guidance to the way it was in the most recent `uportal-app-framework` release so that the guidance does not change in this next release. Continue to think about it. It'll likely come up again. Maybe some future release will change this guidance if it ends up being important.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
