### PR TITLE
fix: Sensible aria labels for widgets, display bugs

### DIFF
--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -147,6 +147,7 @@ frame-page .wrapper__frame-page {
     @media (min-width: @sm) {
       .wrapper__push-content {
         position: relative;
+        overflow-x: hidden;
 
         .content-wrapper__push-content {
           flex: inherit;

--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -129,7 +129,7 @@ main-menu {
     &:not(.push-content) {
       md-sidenav.main-menu__sidenav {
         position: fixed;
-        top: 60px;
+        top: 56px;
         z-index: 70;
       }
     }

--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -147,7 +147,6 @@ frame-page .wrapper__frame-page {
     @media (min-width: @sm) {
       .wrapper__push-content {
         position: relative;
-        overflow-x: hidden;
 
         .content-wrapper__push-content {
           flex: inherit;

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -63,6 +63,7 @@
       ng-view#main-content {
         display: flex;
         flex: inherit;
+        max-width: 100%;
       }
     }
   }
@@ -72,9 +73,10 @@
 frame-page {
   display: flex;
   flex: inherit;
+  max-width: 100%;
 
   .wrapper__frame-page {
-    height: 100%;
+    max-width: 100%;
     display: flex;
     flex: inherit;
     flex-direction: column;

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -57,17 +57,26 @@
 
     .region-main {
       position: relative;
+      display: flex;
       flex: auto;
-      height: 100%;
+
+      ng-view#main-content {
+        display: flex;
+        flex: inherit;
+      }
     }
   }
 }
 
 /* Frame page styles for on-page side navigation */
 frame-page {
+  display: flex;
+  flex: inherit;
+
   .wrapper__frame-page {
     height: 100%;
     display: flex;
+    flex: inherit;
     flex-direction: column;
 
     .wrapper__push-content {

--- a/components/css/buckyless/general.less
+++ b/components/css/buckyless/general.less
@@ -19,6 +19,11 @@
 
 /* General MyUW Styles */
 
+body {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 a {
   transition: @transition-color;
 

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -59,7 +59,7 @@ define(['angular'], function(angular) {
             'searchURL': '/web/apps/search/',
         })
         .value('MESSAGES', {
-            'notificationsPageURL': '/notifications',
+            'notificationsPageURL': '/web/notifications',
         })
         .value('MISC_URLS', {
             'feedbackURL': 'https://my.wisc.edu/portal/p/feedback',

--- a/components/js/override.js
+++ b/components/js/override.js
@@ -27,5 +27,8 @@ define(['angular'], function(angular) {
       'SERVICE_LOC': {
         // 'messagesURL': 'staticFeeds/sample-messages.json',
       },
+      'MESSAGES': {
+        // 'notificationsPageURL': '/notifications',
+      },
     });
 });

--- a/components/js/override.js
+++ b/components/js/override.js
@@ -25,7 +25,7 @@ define(['angular'], function(angular) {
         'enablePushContentMenu': true,
       },
       'SERVICE_LOC': {
-        'messagesURL': 'staticFeeds/sample-messages.json',
+        // 'messagesURL': 'staticFeeds/sample-messages.json',
       },
       'MESSAGES': {
         // 'notificationsPageURL': '/notifications',

--- a/components/js/override.js
+++ b/components/js/override.js
@@ -25,7 +25,7 @@ define(['angular'], function(angular) {
         'enablePushContentMenu': true,
       },
       'SERVICE_LOC': {
-        // 'messagesURL': 'staticFeeds/sample-messages.json',
+        'messagesURL': 'staticFeeds/sample-messages.json',
       },
       'MESSAGES': {
         // 'notificationsPageURL': '/notifications',

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -86,16 +86,15 @@ define(['angular'], function(angular) {
                 messagesService.getMessagesByTitle(allMessages),
             };
           }
-            // Call filtered notifications promises, then pass on to
-            // the completion function
-            $q.all(promiseFilteredMessages)
-              .then(filterMessagesSuccess)
-              .catch(filterMessagesFailure);
-         
-            // Separate all messages by their types
-            $scope.messages = $filter('separateMessageTypes')(allMessages);
-            // Change hasMessages so child controllers can pick up on it
-            $scope.hasMessages = true;
+          // Call filtered notifications promises, then pass on to
+          // the completion function
+          $q.all(promiseFilteredMessages)
+            .then(filterMessagesSuccess)
+            .catch(filterMessagesFailure);
+          // Separate all messages by their types
+          $scope.messages = $filter('separateMessageTypes')(allMessages);
+          // Change hasMessages so child controllers can pick up on it
+          $scope.hasMessages = true;
         };
 
         /**

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -208,6 +208,61 @@ define(['angular'], function(angular) {
         };
 
         /**
+         * Filter the array of messages based on if
+         * a url to get the title was requested
+         * @param {Array} messages An array of message objects
+         * @return {filteredMessages[]} an array of messages that
+         *   includes messages that requested a title from a url
+         */
+        var getMessagesByTitle = function(messages) {
+          var promises = [];
+          var filteredMessages = [];
+          var toBeDiscarded = [];
+          angular.forEach(messages, function(message) {
+            if (message.titleUrl) {
+              promises.push($http.get(message.titleUrl)
+                .then(function(result) {
+                  if (result.data) {
+                    var titleObject = result.data;
+                    if (titleObject.result && titleObject.result.length > 0) {
+                      var fromApi = titleObject.result[0];
+                      if (fromApi.full) {
+                        message.title = fromApi.full;
+                      } else {
+                        message.title = fromApi;
+                      }
+                      filteredMessages.push(message);
+                    } else {
+                      // There is no data to display to the user,
+                      // either due to an error - or the owner of this
+                      // notification has nothing to display to this user.
+                      // Either way, we discard this notification.
+
+                      toBeDiscarded.push(message);
+                      return null;
+                    }
+                  }
+                  return message;
+                }).catch(function(error) {
+                  $log.warn(error);
+                  toBeDiscarded.push(message);
+                })
+              );
+            }
+          });
+          // Once all the promises are prepared, run 'em
+          return $q.all(promises)
+            .then(function(result) {
+              angular.forEach(result, function(message) {
+                if (message) {
+                  filteredMessages.push(message);
+                }
+              });
+              return filteredMessages;
+            });
+        };
+
+        /**
          * Get list of seen message IDs from K/V store or session storage
          * @return {*}
          */
@@ -299,53 +354,6 @@ define(['angular'], function(angular) {
 
           // Update storage
           $localStorage.hasUnseenAnnouncements = hasAnnouncements;
-        };
-        var getMessagesByTitle = function(messages) {
-          var promises = [];
-          var filteredMessages = [];
-          var toBeDiscarded = [];
-          angular.forEach(messages, function(message) {
-            if (message.titleUrl) {
-              promises.push($http.get(message.titleUrl)
-                .then(function(result) {
-                  if (result.data) {
-                     var titleObject = result.data;
-                     if (titleObject.result && titleObject.result.length > 0) {
-                       var fromApi = titleObject.result[0];
-                       if (fromApi.full) {
-                         message.title = fromApi.full;
-                       } else {
-                         message.title = fromApi;
-                       }
-                       filteredMessages.push(message);
-                     } else {
-                       // There is no data to display to the user, 
-                       // either due to an error - or the owner of this
-                       // notification has nothing to display to this user.
-                       // Either way, we discard this notification. 
-
-                       toBeDiscarded.push(message);
-                       return null;
-                     }
-                  }
-                  return message;
-                }).catch(function(error) {
-                  $log.warn(error);
-                  toBeDiscarded.push(message);
-                })
-              );
-            }
-        });
-         // Once all the promises are prepared, run 'em
-          return $q.all(promises)
-            .then(function(result) {
-              angular.forEach(result, function(message) {
-                if (message) {
-                  filteredMessages.push(message);
-                }
-              });
-              return filteredMessages;
-             });
         };
 
         return {

--- a/components/portal/widgets/partials/demo-widgets.html
+++ b/components/portal/widgets/partials/demo-widgets.html
@@ -26,7 +26,7 @@
       - Must set SERVICE_LOC->widgetApi.entry in app-config.js to: "staticFeeds/"
     -->
   <p>To make these widgets appear without error state, open js/app-config.js, find the <code>SERVICE_LOC</code> value, and change <code>widgetApi.entry</code> to point to "staticFeeds/"</p>
-  <div layout="row" layout-align="center center">
+  <div layout="row" layout-align="center center" style="flex-wrap:wrap;">
     <div flex-xs="100" style="max-width:310px">
       <widget fname="sample-widget__benefits"></widget>
     </div>

--- a/components/portal/widgets/partials/demo-widgets.html
+++ b/components/portal/widgets/partials/demo-widgets.html
@@ -20,36 +20,33 @@
 -->
 <frame-page app-title="Demo Widgets"
             app-icon="settings"
-            white-background="true"
             class="demo-widgets-page">
-
-  <md-content layout-padding>
-    <!--
+  <!--
       LOCAL DEMO
       - Must set SERVICE_LOC->widgetApi.entry in app-config.js to: "staticFeeds/"
     -->
-    <p>To make these widgets appear without error state, open js/app-config.js, find the <code>SERVICE_LOC</code> value, and change <code>widgetApi.entry</code> to point to "staticFeeds/"</p>
-    <div layout="row" layout-align="center center">
-      <div flex-xs="100" style="max-width:310px">
-        <widget fname="sample-widget__benefits"></widget>
-      </div>
-      <!--<div flex-xs="100" style="max-width:310px">-->
-        <!--<widget fname="sample-widget__custom"></widget>-->
-      <!--</div>-->
-      <!--<div flex-xs="100" style="max-width:310px">-->
-        <!--<widget fname="sample-widget__rss"></widget>-->
-      <!--</div>-->
+  <p>To make these widgets appear without error state, open js/app-config.js, find the <code>SERVICE_LOC</code> value, and change <code>widgetApi.entry</code> to point to "staticFeeds/"</p>
+  <div layout="row" layout-align="center center">
+    <div flex-xs="100" style="max-width:310px">
+      <widget fname="sample-widget__benefits"></widget>
     </div>
+    <div flex-xs="100" style="max-width:310px">
+      <widget fname="sample-widget__custom"></widget>
+    </div>
+    <div flex-xs="100" style="max-width:310px">
+      <widget fname="sample-widget__rss"></widget>
+    </div>
+  </div>
     <!--<div layout="row" layout-align="center center">-->
-      <!--<div flex-xs="100" style="max-width:310px">-->
-        <!--<widget fname="sample-widget__list-of-links"></widget>-->
-      <!--</div>-->
-      <!--<div flex-xs="100" style="max-width:310px">-->
-        <!--<widget fname="sample-widget__action-items"></widget>-->
-      <!--</div>-->
-      <!--<div flex-xs="100" style="max-width:310px">-->
-        <!--<widget fname="sample-widget__basic"></widget>-->
-      <!--</div>-->
+    <!--<div flex-xs="100" style="max-width:310px">-->
+    <!--<widget fname="sample-widget__list-of-links"></widget>-->
     <!--</div>-->
-  </md-content>
+    <!--<div flex-xs="100" style="max-width:310px">-->
+    <!--<widget fname="sample-widget__action-items"></widget>-->
+    <!--</div>-->
+    <!--<div flex-xs="100" style="max-width:310px">-->
+    <!--<widget fname="sample-widget__basic"></widget>-->
+    <!--</div>-->
+    <!--</div>-->
+
 </frame-page>

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -54,4 +54,4 @@
 <launch-button data-href="{{ widget.url }}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'See all' }}"
-               data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>
+               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -61,4 +61,4 @@
 <launch-button data-href="{{widget.url}}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
-               data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>
+               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__option-link.html
+++ b/components/portal/widgets/partials/type__option-link.html
@@ -66,4 +66,4 @@
 <launch-button data-href="{{ widget.selectedUrl }}"
                data-target="{{ widget.selectedUrl | urlToTarget }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
-               data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>
+               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__rss.html
+++ b/components/portal/widgets/partials/type__rss.html
@@ -44,5 +44,5 @@
 <launch-button data-href="{{ widget.url }}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'See all' }}"
-               data-aria-label="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch ' + widget.title }}">
+               data-aria-label="{{ 'Launch ' + widget.title }}">
 </launch-button>

--- a/components/portal/widgets/partials/type__search-with-links.html
+++ b/components/portal/widgets/partials/type__search-with-links.html
@@ -54,4 +54,4 @@
 <launch-button data-href="{{widget.url}}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
-               data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>
+               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__time-sensitive.html
+++ b/components/portal/widgets/partials/type__time-sensitive.html
@@ -63,4 +63,4 @@
 <launch-button data-href="{{widget.url}}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
-               data-aria-label="{{ config.launchText ? config.launchText : 'Launch ' + widget.title }}"></launch-button>
+               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -32,18 +32,19 @@
 
   <!-- HEADER -->
   <md-card-header class="widget-header">
-    <!-- Widget Chrome -->
+    <!-- Widget description tooltip -->
     <md-button class="widget-action widget-info md-icon-button" aria-label="{{ widget.title }}: {{ widget.description }}" role="tooltip" ng-hide="widget.lifecycleState === 'MAINTENANCE'">
       <md-tooltip md-direction="top" class="widget-action-tooltip">
         {{ widget.description }}
       </md-tooltip>
       <md-icon>info</md-icon>
     </md-button>
+    <!-- Remove widget button -->
     <div ng-transclude id="widget-removal">
     </div>
 
-    <md-card-header-text>
-      <span class="md-title" style="text-align: center;" aria-label="{{ widget.title }}" tabindex="0">
+    <md-card-header-text aria-hidden="true">
+      <span class="md-title" style="text-align: center;" tabindex="-1">
 	      {{ widget.title }}
       </span>
     </md-card-header-text>
@@ -101,7 +102,7 @@
                        data-target="{{ widget.target ? widget.target : '_self' }}"
                        data-rel="noopener noreferrer"
                        data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}"
-                       data-aria-label="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch ' + widget.title }}">
+                       data-aria-label="{{ 'Launch ' + widget.title }}">
         </launch-button>
       </div>
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -83,6 +83,7 @@ The above attributes are all you need to configure a basic widget!
 Widget types provide a predefined standard template that can do a lot more than a basic widget while saving you the trouble of creating a custom design.
 
 + It is less development effort to compose configuration and data for an existing widget type than to develop a novel widget.
++ All defined types come with built-in accessibility features to ensure that screen reader users get the best experience possible.
 + Widget types are maintained as part of the uportal-home product, so usages of these types will less often need developer attention to keep them looking up-to-date and working well.
 + Widget types separate configuration (widgetConfig) and data (backing JSON web service) from the implementation of the markup for the widget (widget type).
 + Widget types are more amenable to automated unit testing than are ad-hoc custom widgets.
@@ -415,6 +416,33 @@ Provided dates **MUST** match one of the following formats:
 + Similarly, if you want the widget to tell users that a period to take action recently ended, you must provide dates for both `takeActionEndDate` (the date when taking the action stopped being possible) and `templateRetireDate` (the date the widget should go back to showing basic content). The former date must be *BEFORE* the latter one. During the days between the two dates, the widget will display "Ended `takeActionEndDate`".
 + If you only want the widget to show time-sensitive content when that content is actionable, you only have to provide dates for `templateLiveDate` and `templateRetireDate`. During the days between the two dates, the widget will display a countdown of days remaining to take action.
 
+## Other Configuration
+
+### Launch button text
+If you provide a `widgetConfig` with any defined widget type (i.e. not a custom widget) with a value for `launchText`, it will replace the text of the
+launch button with the provided value, even for non-widgets. Use sentence case in launch button text.
+
+Read more about the [launch button best practices](widget-launch-button.md).
+
+### Maintenance mode
+If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
+add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
+a message communicating that the app is unavailable and the widget will be disabled (unclickable). To turn maintenance mode off,
+simply set the attributes value to "false" or remove it from your `widgetConfig` altogether.
+
+Example:
+
+```xml
+<portlet-preference>
+  <name>widgetConfig</name>
+  <value>
+    <![CDATA[{
+      'launchText' : 'See all the Weather',
+      'maintenanceMode' : true
+    }]]>
+  </value>
+</portlet-preference>
+```
 
 ## Custom widgets
 Using a JSON service is a great way to have user-focused content in your widgets. Here are the steps you have to take to create your custom JSON-backed widget:
@@ -475,11 +503,23 @@ This is where the template goes. We suggest using a CDATA tag here.
           </ul>
         </div>
       </div>
-      <a class='btn btn-default launch-app-button' href='/portal/p/earnings-statement'>See all payroll information</a>
+      <launch-button data-href='/portal/p/earnings-statement'
+                     data-target='_self'
+                     data-button-text='Launch full app'
+                     data-aria-label='Launch payroll information'></launch-button>
     ]]>
   </value>
 </portlet-preference>
 ```
+
+#### Accessibility guidance
+
+Creating a custom widget means you'll miss out on built-in accessibility features, like aria-labels for screen reader users. We recommend using the `<launch-button>` directive for
+you widget launch button, and providing a simple but meaningful value for the `data-aria-label` attribute.
+
+Read more about the [launch button best practices](widget-launch-button.md).
+
+*Note: If you do not use the launch-button directive, please give your launch button a class of "launch-app-button" to ensure it matches other widgets.*
 
 ### 4. widgetConfig
 
@@ -497,34 +537,6 @@ Currently we only use the evalString to evaluate emptiness. We may add more in t
 By doing just this we were able to generate:
 
 ![custom widget](./img/custom-widget.png)
-
-## Other Configuration
-
-### Launch button text
-If you provide a `widgetConfig` with any widget type with a value for `launchText`, it will replace the text of the
-launch button with the provided value, even for non-widgets. Use sentence case in launch button text.
-
-### Maintenance mode
-If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
-add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
-a message communicating that the app is unavailable and the widget will be disabled (unclickable). To turn maintenance mode off,
-simply set the attributes value to "false" or remove it from your `widgetConfig` altogether.
-
-Example:
-
-```xml
-<portlet-preference>
-  <name>widgetConfig</name>
-  <value>
-    <![CDATA[{
-      'launchText' : 'See all the Weather',
-      'maintenanceMode' : true
-    }]]>
-  </value>
-</portlet-preference>
-```
-
-Read more about the [launch button text guidance](widget-launch-button.md).
 
 
 [rssToJson]: https://github.com/UW-Madison-DoIT/rssToJson

--- a/docs/widget-launch-button.md
+++ b/docs/widget-launch-button.md
@@ -8,6 +8,8 @@ For example, clicking on the main button of a widget could:
 * Launch an application outside of the portal, or
 * Launch a website outside of the portal
 
+See the [launch-button directive documentation](directives.md#launch-button).
+
 ## Suggested button text
 
 To maintain consistent labeling, which is important to user experience, **we strongly suggest widgets use one of the following labels** for
@@ -18,6 +20,8 @@ the launch button's `data-button-text` attribute:
 * **Launch full app**: (Default) Best for task-based applications -- can also be used for any applications that open within the portal and do not meet the criteria of other labels
 
 ## Launch buttons and accessibility
+
+_Note: This only applies if you are creating a custom widget. Predefined widget types already include accessibility features._
 
 To ensure launch buttons are accessible to vision-impaired users and other screen reader users, use the `data-aria-label`
 to provide additional context that is not communicated by the button's text alone. Aria-labels should be short and should include


### PR DESCRIPTION
[MUMUP-3146](https://jira.doit.wisc.edu/jira/browse/MUMUP-3146): "As a screen reader user, I would like widget launch buttons to have labels meaningful considered in isolation, so that I can exercise widgets effectively by stepping through the hyperlinks on the page."

**In this PR**:
- Resolves #608 
- Predefined widget types have launch button aria text of "Launch [widget title]"
- Updated docs to make guidance more visible for custom widgets
- Set redundant widget title to aria-hidden (title is included in the widget's first element, prior to description) to improve screen reader flow
- Continue flex-based model for push-content side navigation
- Move horizontal overflow limit to highest element (document body) to cope with potentially poorly-designed app content areas while using push-content navigation

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
