### PR TITLE
fix: Clearer app menu subheading

### DIFF
--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -52,7 +52,7 @@
     <username></username>
   </div>
   <md-menu-content>
-    <md-subheader class="md-primary subheader__app-name" ng-if="vm.appName != ''">{{ vm.appName }}</md-subheader>
+    <md-subheader class="subheader__app-name" ng-if="vm.appName != ''">{{ vm.appName }} menu</md-subheader>
     <!-- App-specific content -->
     <div ng-if="vm.appMenuTemplate" ng-include="vm.appMenuTemplate"></div>
     <md-menu-item ng-if="!vm.appMenuTemplate" ng-repeat="item in vm.menuItems">


### PR DESCRIPTION
UX guidance suggested that the side navigation menu's subheading may be confused for a link by some users. This change aims to reduce that confusion.

### Screenshot
![screen shot 2017-11-20 at 9 58 08 am](https://user-images.githubusercontent.com/5818702/33027703-7cc0747c-cdd9-11e7-9361-658b0ef73671.png)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
