### PR TITLE
Fix side nav bugs and update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ app framework relies upon might still use Java, of course.)
 + Fix bug where notification bell still showed on notification page (#576)
 + Add error message when notifications fail (#577)
 + Fix spacing error if no configurable side navigation is used (#583)
++ Allow unbroken experience when opting-out of portal-wide notifications (#611)
++ Fix accessibility bug where screen reader/keyboard navigation couldn't access notifications/announcements (#613)
++ Clarify that side navigation subheader is not a link (#617)
 
 ## [6.0.3][] - 2017-09-29
 + fix(messages): return nothing on filter fail (#554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][] (7.0.0?)
 
-### BREAKING CHANGE
+### BREAKING CHANGES
 
-The new side navigation feature in this release will likely break apps
-upgrading to this version of the framework from previous versions, in ways that
-are hard to predict. (#588).
+Updates to the side navigation feature in this release introduce a hard dependency on the `<frame-page>` directive for unbroken menu experience (#588). **If you're upgrading from 6.1.0**
+and you have already configured side navigation (by setting values for either `appMenuTemplateURL` or `appMenuItems` in your override.js file), you will need to ensure that every main
+view in your app uses the `<frame-page>` directive as its outermost container element. If you don't want to use the side navigation and you have not previously configured side navigation,
+you should not be affected by this change.
+
+There are also CSS changes to the layout container elements that precede the `<ng-view>` element (where your app's on-page content is pulled in) to prefer a flex-based layout (#588).
+This may affect you if:
+
++ You have a lot of elements that have a defined `min-width` property
++ You're already using flex positioning but are not using `flex-wrap` on containers with a lot of content
++ You have many elements with `position: absolute` (may experience a minor shift in placement)
 
 Examples of the kinds of downstream changes required:
 
-+ uPortal-home [change to use `<frame-page>` in some views][uPortal-home #739] and [in a couple other views][uPortal-home #742]
++ uPortal-home [change to use `<frame-page>` in some views][uPortal-home #739] and [in the rest of the views][uPortal-home #742]
 
 ### Features
 
 + Add on-page side navigation feature (#588)
+  + To use: Set `APP_OPTIONS.enablePushContentMenu` to true in your override.js file
 + Add more Google Analytics around notifications (#598). Events for
     + rendering priority (banner across the top) notification
     + dismissing priority notification
@@ -61,6 +70,7 @@ app framework relies upon might still use Java, of course.)
 ### Added
 + Add filter to determine rel attribute on anchors (#569)
 + Add configurable side navigation (#561)
+  - See [uportal-app-framework documentation][Sidenav-documentation] of this new feature
 
 ### Changed
 + Refactor theme names (#568)
@@ -87,7 +97,7 @@ app framework relies upon might still use Java, of course.)
 + correct references uportal app framework (#548)
 
 ## [6.0.1][] - 2017-09-25
-+ Cleaning up project name relicts (#538, #539, #540, #541, #542)
++ Cleaning up project name relics (#538, #539, #540, #541, #542)
 + Fix typo in time-sensitive widget (#537)
 
 ## [6.0.0][] - 2017-09-22
@@ -410,3 +420,4 @@ break compatibility with some older components.  If you used any angular-ui-boot
 
 [uPortal-home #739]: https://github.com/uPortal-Project/uportal-home/pull/739
 [uPortal-home #742]: https://github.com/uPortal-Project/uportal-home/pull/742
+[Sidenav-documentation]: http://uportal-project.github.io/uportal-app-framework/configurable-menu.html

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -50,39 +50,17 @@ portal-header {
         }
       }
 
-      .title-link h1.has-app-name {
-        display: flex;
-        justify-content: center;
-        align-items: start;
-        flex-direction: column;
-
-        .portal-title {
-          display: flex;
-          font-size: 14px;
-        }
-
-        .app-name {
-          font-weight: bold;
-          font-size: 18px;
-          display: flex;
-        }
+      .title-link h1 {
+        margin-left: 16px;
       }
 
-      .menu-toggle.md-button {
+      .menu-toggle.md-button.menu-margin {
         min-width: 48px;
         margin: 0;
 
         ~ .title-link h1 {
           @media (min-width: @xs) {
             margin-left: 0;
-          }
-        }
-
-        &.hide-gt-xs {
-          ~ .title-link h1 {
-            @media (min-width: @xs) {
-              margin-left: 16px;
-            }
           }
         }
       }

--- a/components/js/override.js
+++ b/components/js/override.js
@@ -21,8 +21,8 @@ define(['angular'], function(angular) {
   return angular.module('override', [])
     .constant('OVERRIDE', {
       'APP_OPTIONS': {
-        'appMenuTemplateURL': 'portal/misc/partials/example-menu.html',
-        'enablePushContentMenu': true,
+        // 'appMenuTemplateURL': 'portal/misc/partials/example-menu.html',
+        // 'enablePushContentMenu': true,
       },
       'SERVICE_LOC': {
         // 'messagesURL': 'staticFeeds/sample-messages.json',

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -157,14 +157,32 @@ define(['angular', 'require'], function(angular, require) {
   }])
 
   /* Main menu toggle controller */
-  .controller('MenuToggleController', ['$mdSidenav', function($mdSidenav) {
-    var vm = this;
-    /**
-     * Toggle the side navigation menu
-     */
-    vm.showMainMenu = function() {
-      $mdSidenav('main-menu').toggle();
-    };
+  .controller('MenuToggleController', ['$mdSidenav', 'APP_OPTIONS',
+    function($mdSidenav, APP_OPTIONS) {
+      var vm = this;
+
+      vm.isMenuConfigured = true;
+
+      /**
+       * Toggle the side navigation menu
+       */
+      vm.showMainMenu = function() {
+        $mdSidenav('main-menu').toggle();
+      };
+
+      /**
+       * Hide main menu toggle if minimum configuration requirements
+       * are unmet
+       */
+      var init = function() {
+        if (APP_OPTIONS.appMenuItems.length == 0
+          && (angular.isUndefined(APP_OPTIONS.appMenuTemplateURL)
+          || APP_OPTIONS.appMenuTemplateURL == null)) {
+          vm.isMenuConfigured = false;
+        }
+      };
+
+      init();
   }])
 
   /* Side navigation controller */
@@ -260,7 +278,8 @@ define(['angular', 'require'], function(angular, require) {
         }
         // Check if push content is set
         vm.openMenuByDefault =
-          APP_OPTIONS.enablePushContentMenu && $mdMedia('gt-sm');
+          APP_OPTIONS.enablePushContentMenu
+          && $mdMedia('gt-sm') && !vm.hideMainMenu;
       };
 
       /**

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -24,7 +24,12 @@
   <div class="md-toolbar-tools"  role="banner">
     <div layout="row" flex-gt-xs="30" flex-xs="40" layout-align="start center">
       <!-- MAIN MENU TOGGLE -->
-      <md-button class="menu-toggle" ng-controller="MenuToggleController as vm" ng-click="vm.showMainMenu()" ng-class="{ 'hide-gt-xs' : vm.hideMainMenu }">
+      <md-button class="menu-toggle"
+                 ng-controller="MenuToggleController as vm"
+                 ng-click="vm.showMainMenu()"
+                 ng-class="{ 'menu-margin' : vm.isMenuConfigured }"
+                 ng-show="vm.isMenuConfigured"
+                 ng-cloak>
         <md-icon>menu</md-icon>
         <md-tooltip md-direction="bottom" md-delay="500" md-autohide class="top-bar-tooltip">Menu</md-tooltip>
         <notifications-bell mode="mobile-bell" ng-if="!GuestMode" hide-gt-xs></notifications-bell>

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -21,7 +21,8 @@
 <md-sidenav class="md-sidenav-left main-menu__sidenav"
             md-component-id="main-menu"
             md-is-open="vm.openMenuByDefault"
-            md-whiteframe="4">
+            md-whiteframe="4"
+            ng-hide="vm.hideMainMenu">
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
     <md-button href="features"
                ng-if="vm.hasUnseenAnnouncements && vm.showMessagesFeatures"


### PR DESCRIPTION
[MUMUP-3195](https://jira.doit.wisc.edu/jira/browse/MUMUP-3195): "As a MyUW app developer I would like uaf to stabilize, document, release notes confidently so it can release v7 so I have a concrete release to upgrade to with the side push menu feature."

**In this PR:**
- Fix a bug where the app menu button would appear even if app menu configuration flags were unset or wrongly configured
- Fixes a bug where setting `enablePushContentMenu` to true would show on-page menu content (footer links) and push the page over even if `appMenuItems` and `appMenuTemplateURL` are unset or wrongly configured
- Sets default configuration to not use side navigation menu (so simpler apps won't be forced to come up with side nav content)
- Remove some unused CSS

### Screenshot (unset side nav config)
![screen shot 2017-11-20 at 11 22 43 am](https://user-images.githubusercontent.com/5818702/33031887-26bfbd10-cde5-11e7-8de4-53195bba651d.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
