### PR TITLE
MUMMNG-3983 - Synch header bar with priority notification bell

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -193,11 +193,17 @@ define(['angular'], function(angular) {
             // Else hide messages features
             if (angular.equals($scope.$parent.showMessagesFeatures, true)) {
               configureNotificationsScope();
+              checkForChangesInOtherInstances();
             } else {
               vm.showMessagesFeatures = false;
               vm.isLoading = false;
             }
           }
+        });
+
+        var checkForChangesInOtherInstances = $rootScope.$watch(
+          'priorityNotificationCount', function() {
+            configurePriorityNotificationsScope();
         });
 
         // ////////////////
@@ -284,11 +290,18 @@ define(['angular'], function(angular) {
          * Alert the UI to show priority notifications if they exist
          */
         var configurePriorityNotificationsScope = function() {
+          var howManyPriorities = $rootScope.priorityNotificationCount;
           // Use angular's built-in filter to grab priority notifications
           vm.priorityNotifications = $filter('filter')(
             vm.notifications,
             {priority: 'high'}
           );
+
+          if (vm.priorityNotifications.length != howManyPriorities) {
+              $rootScope.priorityNotificationCount
+                  = vm.priorityNotifications.length;
+            }
+
           // If priority notifications exist, notify listeners
           messagesService.broadcastPriorityFlag(
             vm.priorityNotifications.length > 0
@@ -351,6 +364,7 @@ define(['angular'], function(angular) {
           if (isHighPriority) {
             clearPriorityNotificationsFlags();
           }
+          configurePriorityNotificationsScope();
         };
 
         /**


### PR DESCRIPTION
Dismissing a priority notification in the bell did not cause the header bar to update. There are two instances of the controller running at the same time. Call to $rootScope to cause a refresh of the priority notification count. 

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
