### PR TITLE
docs: normalize to prefer term "app directory" over "marketplace"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Examples of the kinds of downstream changes required:
 
 + uPortal-home [change to use `<frame-page>` in some views][uPortal-home #739] and [in the rest of the views][uPortal-home #742]
 + uPortal-home had to further adjust [to accommodate flex-based layout][uPortal-home #747]
-+ uPortal-home [updated the marketplace details page with plain CSS][uPortal-home #750] to cope with this change
++ uPortal-home [updated the app directory entry details page with plain CSS][uPortal-home #750] to cope with this change
 
 ### Features
 

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -48,7 +48,7 @@ define(['angular'], function(angular) {
           return undefined;
         })
         .catch(function(error) {
-          $log.warn('Error getting marketplace entry for ' + fname);
+          $log.warn('Error getting app directory entry for ' + fname);
           $log.error(error);
           return getErrorPage(fname);
         });

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -61,7 +61,7 @@ to create one from scratch. Widgets are app directory entries, so see also [docu
 * **desc**: Description of the app (visible when hovering the widget's "info" icon
 * **mdIcon** parameter: The widget's icon
 * **alternativeMaximizedLink** parameter: An optional parameter to use if your widget links to an external URL
-* **keywords** portlet-preference: A list of keywords to expose your widget when users search the portal marketplace
+* **keywords** portlet-preference: A list of keywords to expose your widget when users search the app directory
 * **content** portlet-preference: A required snippet of static content. If your widget has an alternativeMaximizedLink, this content will never be visible, but it's still required.
 
 The above attributes are all you need to configure a basic widget!

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,6 +1,6 @@
 # Widgets in uportal-app-framework
 
-It's possible for uportal-app-framework apps to pull in the markup and configuration for widgets in the MyUW "marketplace" of apps.
+It's possible for uportal-app-framework apps to pull in the markup and configuration for widgets in the MyUW directory of apps.
 
 You can experiment with widgets in the [Widget Creator][] (currently available in test tier only).
 


### PR DESCRIPTION
Once upon a time we were trying to call the "store" of things in the portal a "marketplace" riffing on Apple and Google's "App Store" concept. We've since evolved to think of it as an "app directory". There's still remnants of calling it a "marketplace" in the JSON data model and in API paths, but at least this changeset normalizes "market" out of the documentation.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
