### PR TITLE
docs(contributing): Note Conventional Commits and tips for complying

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to `uportal-app-framework`
 
-+ Be kind. (Uphold the Code of conduct).
 + Be an ICLA signatory. (Comply with Apereo licensing policy).
++ Be kind. (Uphold the [code of conduct][]).
 + Try to compose commit messages implementing [Conventional Commits][].
 
 ## Code of conduct
@@ -55,3 +55,4 @@ configuration on this point, e.g. via [Husky][].
 [Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy
 [Conventional Commits]: https://conventionalcommits.org/
 [Husky]: https://github.com/typicode/husky
+[code of conduct]: ../CODE_OF_CONDUCT.md

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to `uportal-app-framework`
 
-+ Be an ICLA signatory. (Comply with Apereo licensing policy).
 + Be kind. (Uphold the [code of conduct][]).
++ Be an ICLA signatory. (Comply with [Apereo licensing policy][Apereo website on licensing]).
 + Try to compose commit messages implementing [Conventional Commits][].
 
 ## Code of conduct

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,23 @@ The long version:
 
 *Please* provide feedback about how these practices impact your ability to contribute. You might voice that feedback on the [Apereo licensing discussion Google Group][] or in any other way in which you are comfortable.
 
+## Conventional Commits
+
+This project uses [Conventional Commits][].
+
+Conventional Commits compliance is not a hard requirement to contribute. Do
+what you can. If necessary commit message style can be further worked up at the
+Pull Request / code review layer. Non-compliant commit messages will be flagged
+by continuous integration (e.g. Travis-CI) on pull requests.
+
+You can locally lint (check for style compliance) your most recent commit message by `npm run lint-commit`.
+
+You can locally lint your commit messages via a pre-commit hook by
+
+1. Setting `"commitmsg": "commitlint -e",` in your local `package.json`
+2. Having a `.git/commit-msg` script that honors the `package.json`
+configuration on this point, e.g. via [Husky][].
+
 [uportal-home website on incubating]: http://uportal-project.github.io/uportal-home/apereo-incubation.html
 [Apereo inbound intellectual property licensing practices]: https://www.apereo.org/licensing/practices
 [Apereo Individual Contributor License Agreement]: https://www.apereo.org/sites/default/files/Licensing%20Agreements/apereo-icla.pdf
@@ -32,3 +49,5 @@ The long version:
 [Apereo CLA roster]: http://licensing.apereo.org/completed-clas
 [CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
 [Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy
+[Conventional Commits]: https://conventionalcommits.org/
+[Husky]: https://github.com/typicode/husky

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 ## Code of conduct
 
-The [Apereo Welcoming Policy][] applies. Cf. [CODE_OF_CONDUCT.md][]
+The [Apereo Welcoming Policy][] applies. Cf. [code of conduct][].
 
 ## Contributor License Agreements
 
@@ -51,7 +51,6 @@ configuration on this point, e.g. via [Husky][].
 [Apereo website on Contributor License Agreement]: https://www.apereo.org/licensing/agreements
 [Apereo licensing discussion Google Group]: https://groups.google.com/a/apereo.org/forum/#!forum/licensing-discuss
 [Apereo CLA roster]: http://licensing.apereo.org/completed-clas
-[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
 [Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy
 [Conventional Commits]: https://conventionalcommits.org/
 [Husky]: https://github.com/typicode/husky

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to `uportal-app-framework`
 
++ Be kind. (Uphold the Code of conduct).
++ Be an ICLA signatory. (Comply with Apereo licensing policy).
++ Try to compose commit messages implementing [Conventional Commits][].
+
 ## Code of conduct
 
 The [Apereo Welcoming Policy][] applies. Cf. [CODE_OF_CONDUCT.md][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+### Documentation
+
++ Notes adopting Conventional Commits message style in `CONTRIBUTING.md`, with
+tips for easing compliance. (#634)
+
 ## [7.0.0][] - 2017-11-30
 
 ### BREAKING CHANGES


### PR DESCRIPTION
Fixes #633 .

Acknowledges in `CONTRIBUTING.md` that we're trying to do Conventional Commits.

Adds hints on how to locally lint commit messages and even on how to automate this.

I think the hints work in that I locally followed my own instructions to re-add this pre-commit hook. (To be fair I was only able to do this by cribbing from the PR that removed the hook ( #581 ), so, hurray for clear, discoverable change history.).

Funny anecdote: The hook caught problems with my initial commit message attempt for ~~both~~ all three of these commits. Writing in Sentence case with a full stop. it's an ingrained habit.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
