### PR TITLE
build(lint-staged): suppress eslint on `docs/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 + Notes adopting Conventional Commits message style in `CONTRIBUTING.md`, with
 tips for easing compliance. (#634)
 
+### Build
+
++ Suppresses `eslint` on `docs/` when linting staged changes. (#636)
+
 ## [7.0.0][] - 2017-11-30
 
 ### BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,json,md}": "eslint --ext js --ext json --ext md",
+    "*.{js,json,md}": "eslint --ext js --ext json --ext md --ignore-pattern docs/",
     "*.md": "remark --frail",
     "*.less": "stylelint --syntax less"
   }


### PR DESCRIPTION
Since `lint-js` ignores docs, also ignore docs when JS-linting staged changes.

(I ran into this when touching `app-options.md`: while I didn't touch the example JavaScript, the example JavaScript failed `eslint`.)

Arguably we should be linting the JavaScript embedded in Markdown files -- but if we should, we should do so consistently.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
