### PR TITLE
MUMMNG-3983 Priority header synch with bell

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -177,6 +177,17 @@ define(['angular'], function(angular) {
         // //////////////////
         // Event listeners //
         // //////////////////
+
+        /**
+         * For a change to the notifications, such as
+         * a dismissal, ensure that all instances of the 
+         * controller are notified. 
+         */
+        $rootScope.$on('notificationChange', function() {
+          configureNotificationsScope();
+          configurePriorityNotificationsScope();
+        })
+
         /**
          * When the parent controller has messages, initialize
          * things dependent on messages

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -183,7 +183,7 @@ define(['angular'], function(angular) {
          * i.e. a dismissal, and ensure that all instances of the
          * controller are updated.
          */
-        var notificationChange = $rootScope.$on('notificationChange', 
+        var notificationChange = $rootScope.$on('notificationChange',
           function() {
             configureNotificationsScope();
             configurePriorityNotificationsScope();
@@ -391,11 +391,7 @@ define(['angular'], function(angular) {
             messagesService.setMessagesSeen(allSeenMessageIds,
               dismissedNotificationIds, 'restore');
           }
-
-          // Reconfigure priority scope if a priority notification was restored
-          if (isHighPriority) {
-            configurePriorityNotificationsScope();
-          }
+          notificationChange();
         };
 
         /**

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -179,9 +179,9 @@ define(['angular'], function(angular) {
         // //////////////////
 
         /**
-         * For a change to the notifications, such as
-         * a dismissal, ensure that all instances of the 
-         * controller are notified. 
+         * Process event where notifications have changed, 
+         * i.e. a dismissal, and ensure that all instances of the 
+         * controller are updated. 
          */
         $rootScope.$on('notificationChange', function() {
           configureNotificationsScope();

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -179,14 +179,15 @@ define(['angular'], function(angular) {
         // //////////////////
 
         /**
-         * Process event where notifications have changed, 
-         * i.e. a dismissal, and ensure that all instances of the 
-         * controller are updated. 
+         * Process event where notifications have changed,
+         * i.e. a dismissal, and ensure that all instances of the
+         * controller are updated.
          */
-        $rootScope.$on('notificationChange', function() {
-          configureNotificationsScope();
-          configurePriorityNotificationsScope();
-        })
+        var notificationChange = $rootScope.$on('notificationChange', 
+          function() {
+            configureNotificationsScope();
+            configurePriorityNotificationsScope();
+          });
 
         /**
          * When the parent controller has messages, initialize

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -267,6 +267,7 @@ define(['angular'], function(angular) {
           return keyValueService.setValue(KV_KEYS.VIEWED_MESSAGE_IDS,
             originalSeenIds)
             .then(function() {
+              $rootScope.$emit('notificationChange');
               return originalSeenIds;
             })
             .catch(function(error) {


### PR DESCRIPTION
Emitting an event to the rootScope when a notification is dismissed causes all instances of the controller to reset properly, keeping the header bar in synch with the notification bell. 

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
