### PR TITLE
Improve priority notifications appearance

### DIFF
--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -235,11 +235,15 @@
   .notification-message {
     color: @black;
     padding: 4px 26px;
-    font-size: 14px;
+    font-size: 0;
     line-height: 1;
     text-align: center;
     display: block;
     margin-bottom: 0;
+
+    > span {
+      font-size: 14px;
+    }
   }
 
   p {

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -173,6 +173,7 @@ define(['angular'], function(angular) {
         vm.isLoading = true;
         vm.renderLimit = 3;
         vm.showMessagesFeatures = true;
+        vm.titleLengthLimit = 140;
 
         // //////////////////
         // Event listeners //

--- a/components/portal/messages/filters.js
+++ b/components/portal/messages/filters.js
@@ -106,6 +106,6 @@ define(['angular'], function(angular) {
     .filter('trim', function() {
       return function(input) {
         return input.trim();
-      }
+      };
     });
 });

--- a/components/portal/messages/filters.js
+++ b/components/portal/messages/filters.js
@@ -102,5 +102,10 @@ define(['angular'], function(angular) {
           return array2.indexOf(element) != -1;
         });
       };
+    })
+    .filter('trim', function() {
+      return function(input) {
+        return input.trim();
+      }
     });
 });

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -114,8 +114,8 @@
          ng-if="vm.priorityNotifications.length == 1"
          ng-repeat="priority in vm.priorityNotifications | limitTo: 1"
          layout="row" layout-align="center center" layout-fill>
-      <div flex layout="row" layout-align="center center" class="compact-buttons">
-        <span class="notification-message">{{ priority.title }}</span>
+      <span class="notification-message">{{ priority.title }}</span>
+      <div layout="row" class="compact-buttons">
         <md-button class="md-raised md-accent"
                    ng-if="priority.actionButton"
                    ng-href="{{ priority.actionButton.url }}"

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -114,7 +114,10 @@
          ng-if="vm.priorityNotifications.length == 1"
          ng-repeat="priority in vm.priorityNotifications | limitTo: 1"
          layout="row" layout-align="center center" layout-fill>
-      <span class="notification-message">{{ priority.title }}</span>
+      <div class="notification-message">
+        <span>{{ priority.title | limitTo: vm.titleLengthLimit | trim }}</span>
+        <span ng-if="priority.title.length > vm.titleLengthLimit">...</span>
+      </div>
       <div layout="row" class="compact-buttons">
         <md-button class="md-raised md-accent"
                    ng-if="priority.actionButton"
@@ -141,7 +144,9 @@
       </div>
     </div>
     <div class="priority-bubble" ng-if="vm.priorityNotifications.length > 1" layout="row" layout-align="center center" layout-fill>
-      <span class="notification-message">You have {{ vm.priorityNotifications.length }} important notifications.</span>
+      <div class="notification-message">
+        <span>You have {{ vm.priorityNotifications.length }} important notifications.</span>
+      </div>
       <div class="compact-buttons">
         <md-button class="md-raised md-accent" ng-href="{{ vm.notificationsUrl }}">Go to notifications</md-button>
       </div>

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -47,7 +47,7 @@ Widget messaging is based on JSON input configured in a [widget's configuration]
 
 - **id**: A unique string to identify the message. This is used for tracking seen/unseen messages, dimissed notifications, and the sort order on the notifications page.
 - **title**: The text to be displayed as the message's main content -- used in all message types. **Best practices:**
-  - Be concise! Try to limit your message's title to ~140 characters. Shorter titles improve click-through and are less likely to cause display issues on smaller screens.
+  - Be concise! Try to limit your message's title to ~140 characters. Shorter titles improve click-through and are less likely to cause display issues on smaller screens. *Note: Titles longer than 140 characters will be truncated (with ellipsis) to ensure consistent appearance.*
   - Use general language and avoid pronouns for broadly visible messages that may not pertain to specific users' needs (ex. "City of Madison - Declared Snow Emergency").
   - Use the word "You" when the group- or data-filtering for a message is somewhat specific (i.e. Users with unactivated accounts).
 - **titleShort**: A shorter version of the message title used by the mascot announcer menu. *Required if the `messageType` is "announcement".*

--- a/docs/text-guidelines.md
+++ b/docs/text-guidelines.md
@@ -26,7 +26,9 @@ Defer to the typography specs provided by [Google Material](https://material.goo
   * Use the word "You" when the notification pertains to a specific group of users
 * `label` attribute  of action buttons should be 2-3 words at most
 
-See the [notifications documentation](notifications.md) for detailed information.
+See the [notifications documentation](messaging-implementation.md) for detailed information.
+
+*Note: Notifications with titles longer than 140 characters will be truncated (with ellipsis) to ensure consistent appearance.*
 
 ## MyUW-specific language
 


### PR DESCRIPTION
#610: "As a user with a priority notification with a (required!) action button, I would like that action button to afford room for a typical label, so I can read the label of the action button."

[MUMUP-3218](https://jira.doit.wisc.edu/jira/browse/MUMUP-3218): "As a MyUW user, I would like the priority notification text banner to artfully limit the characters so that I know if there is more text to see."

**In this PR:**
- Ensure notification buttons aren't clipped by limited space
- Enforce title length limit on priority notifications to guarantee consistent appearance

### Screenshot
<img width="821" alt="screen shot 2017-12-13 at 11 27 11 am" src="https://user-images.githubusercontent.com/5818702/33953112-88789f42-dff9-11e7-947c-2c36e61b2c8d.png">

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
