### PR TITLE
feat: filter messages by dates (if provided)

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -96,16 +96,14 @@ define(['angular'], function(angular) {
          */
         var filterMessagesSuccess = function(result) {
           // Check for filtered notifications
-          var filteredMessages = [];
           if (result.filteredByGroup && result.filteredByData) {
             // Combine the two filtered arrays into one (no dupes)
-            filteredMessages = $filter('filterForCommonElements')(
+            var combinedMessages = $filter('filterForCommonElements')(
               result.filteredByGroup,
               result.filteredByData
             );
-            $scope.messages =
-              $filter('separateMessageTypes')(filteredMessages);
-            $scope.hasMessages = true;
+            // Filter out messages that don't fall within intended date ranges
+            filterMessagesByDate(combinedMessages);
           }
         };
 
@@ -116,6 +114,26 @@ define(['angular'], function(angular) {
          */
         var filterMessagesFailure = function(error) {
           $log.warn('Problem getting messages from messagesService');
+        };
+
+        /**
+         * Filter out messages that don't fall within intended date
+         * ranges (if ranges were provided).
+         * @param {Array} messages
+         */
+        var filterMessagesByDate = function(messages) {
+          var filteredMessages = $filter('filterByDates')(messages);
+          notifyChildControllers(filteredMessages);
+        };
+
+        /**
+         * Update $scope messages to notify downstream watchers
+         * @param {Array} messages
+         */
+        var notifyChildControllers = function(messages) {
+          $scope.messages =
+            $filter('separateMessageTypes')(messages);
+          $scope.hasMessages = true;
         };
 
         /**

--- a/components/portal/messages/filters.js
+++ b/components/portal/messages/filters.js
@@ -18,7 +18,7 @@
  */
 'use strict';
 
-define(['angular'], function(angular) {
+define(['angular', 'moment'], function(angular, moment) {
   return angular.module('portal.messages.filters', [])
     .filter('separateMessageTypes', ['$filter', function($filter) {
       return function(messages) {
@@ -100,6 +100,36 @@ define(['angular'], function(angular) {
       return function(array1, array2) {
         return array1.filter(function(element) {
           return array2.indexOf(element) != -1;
+        });
+      };
+    })
+    .filter('filterByDates', function() {
+      return function(messages) {
+        // Get current date/time
+        var now = moment();
+        // Filter messages based on date/time
+        return messages.filter(function(message) {
+          if (message.goLiveDate || message.expireDate) {
+            // If both dates are defined, check between
+            if (message.goLiveDate && message.expireDate) {
+              if (now.isBetween(message.goLiveDate, message.expireDate)) {
+                return message;
+              }
+            // If goLive defined, check after
+            } else if (message.goLiveDate) {
+              if (now.isAfter(message.goLiveDate)) {
+                return message;
+              }
+            // If expire defined, check before
+            } else if (message.expireDate) {
+              if (now.isBefore(message.expireDate)) {
+                return message;
+              }
+            }
+          } else {
+            // Has neither date defined, so don't filter it
+            return message;
+          }
         });
       };
     });

--- a/components/portal/messages/filters.js
+++ b/components/portal/messages/filters.js
@@ -115,12 +115,12 @@ define(['angular', 'moment'], function(angular, moment) {
               if (now.isBetween(message.goLiveDate, message.expireDate)) {
                 return message;
               }
-            // If goLive defined, check after
+              // If goLive defined, check after
             } else if (message.goLiveDate) {
               if (now.isAfter(message.goLiveDate)) {
                 return message;
               }
-            // If expire defined, check before
+              // If expire defined, check before
             } else if (message.expireDate) {
               if (now.isBefore(message.expireDate)) {
                 return message;
@@ -130,7 +130,9 @@ define(['angular', 'moment'], function(angular, moment) {
             // Has neither date defined, so don't filter it
             return message;
           }
-        })
+        });
+      };
+    })
     .filter('trim', function() {
       return function(input) {
         return input.trim();

--- a/components/staticFeeds/sample-messages.json
+++ b/components/staticFeeds/sample-messages.json
@@ -7,8 +7,35 @@
       "description": null,
       "descriptionShort": null,
       "messageType": "notification",
-      "goLiveDate": null,
-      "expireDate": null,
+      "goLiveDate": "2017-12-13",
+      "expireDate": "2018-01-13",
+      "featureImageUrl": null,
+      "priority": null,
+      "audienceFilter": {
+        "groups": [],
+        "dataUrl": "",
+        "dataObject": "",
+        "dataArrayFilter": {}
+      },
+      "actionButton": {
+        "label": "Take action",
+        "url": "http://www.google.com"
+      },
+      "moreInfoButton": {
+        "label": "More info",
+        "url": "http://www.google.com"
+      },
+      "confirmButton": null
+    },
+    {
+      "id": "sample-uportal-app-framework-expired-notification",
+      "title": "This notification expired in the past, so should not be displayed.",
+      "titleShort": null,
+      "description": null,
+      "descriptionShort": null,
+      "messageType": "notification",
+      "goLiveDate": "2017-07-01",
+      "expireDate": "2017-08-01",
       "featureImageUrl": null,
       "priority": null,
       "audienceFilter": {
@@ -34,7 +61,7 @@
       "description": null,
       "descriptionShort": null,
       "messageType": "notification",
-      "goLiveDate": "2017-08-03",
+      "goLiveDate": null,
       "expireDate": null,
       "featureImageUrl": null,
       "priority": "high",
@@ -63,7 +90,7 @@
       "descriptionShort": "This is a short description",
       "messageType": "announcement",
       "goLiveDate": "2017-08-01T09:30",
-      "expireDate": "2017-08-15",
+      "expireDate": null,
       "featureImageUrl": "img/features/bucky-announcement.png",
       "priority": null,
       "audienceFilter": {
@@ -83,16 +110,16 @@
       "confirmButton": null
     },
     {
-      "id": "sample-uportal-app-framework-filtered-popup-announcement",
-      "title": "This is a filtered popup",
-      "titleShort": "Filtered popup",
-      "description": "This popup message should not appear to anyone unless group filtering is disabled (via beta settings).",
+      "id": "sample-uportal-app-framework-filtered-announcement",
+      "title": "This is a filtered announcement",
+      "titleShort": "Filtered announcement",
+      "description": "This message should not appear to anyone unless group filtering is disabled (via beta settings).",
       "descriptionShort": "You must have disabled group filtering!",
       "messageType": "announcement",
-      "goLiveDate": "2017-08-01T09:30",
-      "expireDate": "2017-08-15",
+      "goLiveDate": null,
+      "expireDate": "2018-02-15",
       "featureImageUrl": "img/the-cow.png",
-      "priority": null,
+      "priority": "high",
       "audienceFilter": {
         "groups": ["Nonexistent-Group"],
         "dataUrl": "",


### PR DESCRIPTION
Resolves #609 

Duplicates/replaces #639 

**In this PR:**
- Filter messages by `goLiveDate` and `expireDate` if dates are provided
- If no dates provided, show the messages
- Break up some logic for the sake of separation of concerns

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
