### PR TITLE
docs(changelog): spelling and typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ source (#649)
 
 + leverage commitlint travis helper (#621)
 + update to latest version (6.0.0) of lint-staged (#631)
-+ update documentation to read more and state intent more cleary (#632)
++ update documentation to read more and state intent more clearly (#632)
 + move some git commit hooks to be optionally installed (#635)
 + suppress `eslint` on `docs/` when linting staged changes (#636)
 + require npm 5.6.0 or higher (#644)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ file. (#649)
 + add documentation stating intent to use Conventional commits and tips on how
 to comply (#634)
 + track clicks on sidenav footer links (#642)
-+ add documentation clarifing major upgrades (#647)
++ add documentation clarifying major upgrades (#647)
 + add the ability to set message title via an external data source (#649)
 + add the ability to set a message more info button url via an external data
 source (#649)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ file. (#649)
 
 ### Added
 
-+ add documention stating intent to use Conventional commits and tips on how to
-comply (#634)
++ add documentation stating intent to use Conventional commits and tips on how
+to comply (#634)
 + track clicks on sidenav footer links (#642)
 + add documentation clarifing major upgrades (#647)
 + add the ability to set message title via an external data source (#649)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking Changes
 
-Moves the data object in messages out of the audience object and into a seperate
+Moves the data object in messages out of the audience object and into a separate
 object.  This will affect installations that have configured a messages.json
 file. (#649)
 


### PR DESCRIPTION
Trivial spelling and typo fixes in `CHANGELOG.md`.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
