### PR TITLE
fix: "OK" rather than "Continue" on widget cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
++ Label widget cover dismiss button as "OK" rather than "Continue" (#675)
+
 ### Removed
 
 ## [8.0.0][] - 2018-01-08

--- a/components/portal/widgets/partials/external-message.html
+++ b/components/portal/widgets/partials/external-message.html
@@ -33,7 +33,7 @@
         <md-button class="md-accent" id="overlay-continue-button"
           aria-label= "Continue to {{widget.title}}"
             ng-click="message_acknowledged = true">
-            Continue
+            OK
         </md-button>
     </div>
   </div>


### PR DESCRIPTION
Trivially, changes the label from "Continue" to "OK" on the button for dismissing the dynamic interrupt-access-to-the-widget message.

This is intended to clarify, emphasize that this UI control is for just dismissing the cover, not addressing the issue the cover is communicating.

Motivating example: in MyUW we're using this feature to interrupt O365 users whose accounts are slated for de-provisioning to get their attention as they're trying to access those moribund accounts. The message is that their account will be terminated. We don't want them to be confused and think that "Continue" will somehow continue those accounts -- it won't, the UI control just lets them continue through to access the content *right now* regardless of the unchanged moribund nature of their O365 account.

[OK rather than Ok seemed to be the convention to follow for button labeling.](https://www.nngroup.com/articles/ok-cancel-or-cancel-ok/) . 🆗 

Within MyUW Scrum this is story [MUMUP-3259](https://jira.doit.wisc.edu/jira/browse/MUMUP-3259) .

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
