### PR TITLE
refactor: mv setTitle() to mainService from PortalMainController

### DIFF
--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -33,23 +33,6 @@ define(['angular', 'require'], function(angular, require) {
       layoutMode: 'list', // other option is 'widgets
     };
 
-    /**
-     * set the frame title using theme
-     */
-    function setTitle() {
-      var frameTitle = '';
-      if ($rootScope.portal && $rootScope.portal.theme) {
-        frameTitle = $rootScope.portal.theme.title;
-        if (frameTitle !== NAMES.title && !APP_FLAGS.isWeb) {
-          frameTitle = ' | ' + frameTitle;
-        } else {
-          // since frame title equals the title in NAMES lets not duplicate it
-          frameTitle = '';
-        }
-      }
-      $document[0].title=NAMES.title + frameTitle;
-    }
-
     // =====functions ======
     var init = function() {
       $scope.$storage = $localStorage.$default(defaults);
@@ -61,13 +44,13 @@ define(['angular', 'require'], function(angular, require) {
       $scope.APP_OPTIONS = APP_OPTIONS;
 
       if (NAMES.title) {
-        setTitle();
+        mainService.setTitle();
       }
       // https://github.com/Gillespie59/eslint-plugin-angular/issues/231
       // eslint-disable-next-line angular/on-watch
       $rootScope.$watch('portal.theme', function(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
-          setTitle();
+          mainService.setTitle();
         }
       });
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -25,8 +25,10 @@ define(['angular', 'require'], function(angular, require) {
     '$localStorage', '$sessionStorage', '$scope', '$rootScope', '$document',
     '$location', 'NAMES', 'MISC_URLS', 'APP_FLAGS',
     'APP_OPTIONS', 'THEMES', 'miscService',
-    function($localStorage, $sessionStorage, $scope, $rootScope, $document,
-    $location, NAMES, MISC_URLS, APP_FLAGS, APP_OPTIONS, THEMES, miscService) {
+    function(
+      $localStorage, $sessionStorage, $scope, $rootScope, $document,
+      $location, NAMES, MISC_URLS, APP_FLAGS,
+      APP_OPTIONS, THEMES, miscService) {
     var defaults = {
       layoutMode: 'list', // other option is 'widgets
     };

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -24,11 +24,11 @@ define(['angular', 'require'], function(angular, require) {
   .controller('PortalMainController', [
     '$localStorage', '$sessionStorage', '$scope', '$rootScope', '$document',
     '$location', 'NAMES', 'MISC_URLS', 'APP_FLAGS',
-    'APP_OPTIONS', 'THEMES', 'miscService',
+    'APP_OPTIONS', 'THEMES', 'miscService', 'mainService',
     function(
       $localStorage, $sessionStorage, $scope, $rootScope, $document,
       $location, NAMES, MISC_URLS, APP_FLAGS,
-      APP_OPTIONS, THEMES, miscService) {
+      APP_OPTIONS, THEMES, miscService, mainService) {
     var defaults = {
       layoutMode: 'list', // other option is 'widgets
     };

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -23,9 +23,9 @@ define(['angular'], function(angular) {
 
   .factory('mainService', [
     '$http', '$log', '$sessionStorage',
-    'miscService', 'SERVICE_LOC', 'APP_FLAGS',
+    'miscService', 'SERVICE_LOC', 'APP_FLAGS', '$rootScope',
     function($http, $log, $sessionStorage,
-             miscService, SERVICE_LOC, APP_FLAGS) {
+             miscService, SERVICE_LOC, APP_FLAGS, $rootScope) {
       var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
       var userPromise;
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -63,8 +63,26 @@ define(['angular'], function(angular) {
         return userPromise;
     };
 
+      /**
+       * set the frame title using theme
+       */
+      function setTitle() {
+        var frameTitle = '';
+        if ($rootScope.portal && $rootScope.portal.theme) {
+          frameTitle = $rootScope.portal.theme.title;
+          if (frameTitle !== NAMES.title && !APP_FLAGS.isWeb) {
+            frameTitle = ' | ' + frameTitle;
+          } else {
+            // since frame title equals the title in NAMES lets not duplicate it
+            frameTitle = '';
+          }
+        }
+        $document[0].title=NAMES.title + frameTitle;
+      }
+
     return {
       getUser: getUser,
+      setTitle: setTitle,
     };
   }]);
 });

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -23,9 +23,9 @@ define(['angular'], function(angular) {
 
   .factory('mainService', [
     '$http', '$log', '$sessionStorage',
-    'miscService', 'SERVICE_LOC', 'APP_FLAGS', '$rootScope',
+    'miscService', 'SERVICE_LOC', 'APP_FLAGS', '$rootScope', 'NAMES',
     function($http, $log, $sessionStorage,
-             miscService, SERVICE_LOC, APP_FLAGS, $rootScope) {
+             miscService, SERVICE_LOC, APP_FLAGS, $rootScope, NAMES) {
       var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
       var userPromise;
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -24,8 +24,10 @@ define(['angular'], function(angular) {
   .factory('mainService', [
     '$http', '$log', '$sessionStorage',
     'miscService', 'SERVICE_LOC', 'APP_FLAGS', '$rootScope', 'NAMES',
+    '$document',
     function($http, $log, $sessionStorage,
-             miscService, SERVICE_LOC, APP_FLAGS, $rootScope, NAMES) {
+             miscService, SERVICE_LOC, APP_FLAGS, $rootScope, NAMES,
+             $document) {
       var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
       var userPromise;
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -77,7 +77,7 @@ define(['angular'], function(angular) {
             frameTitle = '';
           }
         }
-        $document[0].title=NAMES.title + frameTitle;
+        $document[0].title = NAMES.title + frameTitle;
       }
 
     return {


### PR DESCRIPTION
No functional change.

Refactor to move the existing `setTitle()` function from the `PortalMainController` to the `mainService`.

This is a step towards making title setting available from more places and more dynamic, so that navigating within the app yields meaningful page titles describing where you are in the app, addressing WCAG2: 2.4.2:

> 2.4.2 Page Titled: Web pages have titles that describe topic or purpose. (Level A) 

Locally tested: status quo was that switching theme switches the page title to reflect the name of the portal per the selected theme. This still works with this changeset.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
