### PR TITLE
docs: clarify client-side message filtering disable toggle

### DIFF
--- a/components/js/frame-config.js
+++ b/components/js/frame-config.js
@@ -1077,9 +1077,11 @@ define(['angular'], function(angular) {
           },
           {
             'id': 'disableGroupFilteringForMessages',
-            'title': 'Disable Group Filter',
-            'description': 'This flag disables group filtering or in-app ' +
-              'messages if you have it enabled. (page refresh required)',
+            'title': 'Disable Client-side Message Filtering By Group',
+            'description': 'Disable client-side filtering of portal-wide ' +
+              'messages (e.g. notifications, mascot announcements) by group. ' +
+              'Useful for demoing or testing messages you would not normally ' +
+              'see. (page refresh required)',
           },
         ]);
 });


### PR DESCRIPTION
Noticed typo.

Took a fresh stab at titling and describing this Beta Settings toggle.

After:

![improve-disable-client-side-message-filtering-toggle](https://user-images.githubusercontent.com/952283/35354980-80f5826a-0111-11e8-946a-e505cedb0e9a.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
