### PR TITLE
Reflect page title in document title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 + `mainService` now offers `computeWindowTitle(...)` (#679)
-+ `AppHeaderOptionsController` now offers `updateTitle(...)` (#679)
++ `AppHeaderOptionsController` now offers `updateWindowTitle(...)` (#679)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
++ `mainService` now offers `computeWindowTitle(...)` (#679)
++ `AppHeaderOptionsController` now offers `updateTitle(...)` (#679)
+
 ### Changed
+
++ `app-header` (and so, `frame-page`) now set Document title (#679)
 
 ### Fixed
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -39,7 +39,7 @@ define(['angular', 'require'], function(angular, require) {
      * sets the document title to that value.
      * @param {string} pageTitle - Optional, name of specific page viewed.
      */
-    function updateTitle(pageTitle) {
+    function updateWindowTitle(pageTitle) {
       var appTitle = NAMES.title;
 
       var portalTitle = '';
@@ -67,13 +67,13 @@ define(['angular', 'require'], function(angular, require) {
       $scope.APP_OPTIONS = APP_OPTIONS;
 
       if (NAMES.title) {
-        updateTitle();
+        updateWindowTitle();
       }
       // https://github.com/Gillespie59/eslint-plugin-angular/issues/231
       // eslint-disable-next-line angular/on-watch
       $rootScope.$watch('portal.theme', function(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
-          updateTitle();
+          updateWindowTitle();
         }
       });
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -35,6 +35,9 @@ define(['angular', 'require'], function(angular, require) {
 
     /**
      * Set Document title.
+     * Asks mainService what the document title ought to be and
+     * sets the document title to that value.
+     * @param {string} pageTitle - Optional, name of specific page viewed.
      */
     function updateTitle(pageTitle) {
       var appTitle = NAMES.title;

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -33,6 +33,26 @@ define(['angular', 'require'], function(angular, require) {
       layoutMode: 'list', // other option is 'widgets
     };
 
+    /**
+     * Set Document title.
+     */
+    function updateTitle(pageTitle) {
+      var appTitle = NAMES.title;
+
+      var portalTitle = '';
+      if ($rootScope.portal && $rootScope.portal.theme &&
+            $rootScope.portal.theme.title) {
+        // there's an active theme with a title.
+        // consider that title the name of the portal
+        portalTitle = $rootScope.portal.theme.title;
+      }
+
+      var windowTitle =
+        mainService.computeWindowTitle(pageTitle, appTitle, portalTitle);
+
+      $document[0].title = windowTitle;
+    }
+
     // =====functions ======
     var init = function() {
       $scope.$storage = $localStorage.$default(defaults);
@@ -44,13 +64,13 @@ define(['angular', 'require'], function(angular, require) {
       $scope.APP_OPTIONS = APP_OPTIONS;
 
       if (NAMES.title) {
-        mainService.setTitle();
+        updateTitle();
       }
       // https://github.com/Gillespie59/eslint-plugin-angular/issues/231
       // eslint-disable-next-line angular/on-watch
       $rootScope.$watch('portal.theme', function(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
-          mainService.setTitle();
+          updateTitle();
         }
       });
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -37,7 +37,7 @@ define(['angular', 'require'], function(angular, require) {
      * Set Document title.
      * Asks mainService what the document title ought to be and
      * sets the document title to that value.
-     * @param {string} pageTitle - Optional, name of specific page viewed.
+     * @param {string} [pageTitle] - Name of specific page viewed.
      */
     function updateWindowTitle(pageTitle) {
       var appTitle = NAMES.title;

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -54,36 +54,6 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.whenGET(SERVICE_LOC.sessionInfo).respond();
         }));
 
-        it('should set title to MyUW'
-        + 'when MyUW is both portal name and app name '
-        + 'and there is no page name', function() {
-          // setup
-          NAMES.title = 'MyUW';
-          $scope.portal.theme.title = 'MyUW';
-
-          // test
-          service.setTitle();
-
-          expect($document[0].title).toEqual('MyUW');
-
-          httpBackend.flush();
-        });
-
-        it('should set title to STAR | MyUW '
-        + 'when STAR is app name and MyUW is portal name '
-        + 'and there is no page name', function() {
-          // setup
-          NAMES.title = 'STAR';
-          $scope.portal.theme.title = 'MyUW';
-
-          // test
-          service.setTitle();
-
-          expect($document[0].title).toEqual('STAR | MyUW');
-
-          httpBackend.flush();
-        });
-
         it('should set title to Timesheets | STAR | MyUW '
         + 'when STAR is app name and MyUW is portal name '
         + 'and Timesheets is page name', function() {
@@ -140,6 +110,36 @@ define(['angular-mocks', 'portal'], function() {
           service.setTitle('Notifications');
 
           expect($document[0].title).toEqual('Notifications | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to STAR | MyUW '
+        + 'when STAR is app name and MyUW is portal name '
+        + 'and there is no page name', function() {
+          // setup
+          NAMES.title = 'STAR';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle();
+
+          expect($document[0].title).toEqual('STAR | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to MyUW'
+        + 'when MyUW is both portal name and app name '
+        + 'and there is no page name', function() {
+          // setup
+          NAMES.title = 'MyUW';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle();
+
+          expect($document[0].title).toEqual('MyUW');
 
           httpBackend.flush();
         });

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -113,5 +113,35 @@ define(['angular-mocks', 'portal'], function() {
 
           httpBackend.flush();
         });
+
+        it('should set title to Notifications | MyUW '
+        + 'when app name is null and MyUW is portal name '
+        + 'and Notifications is page name', function() {
+          // setup
+          NAMES.title = null;
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('Notifications');
+
+          expect($document[0].title).toEqual('Notifications | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to Notifications | MyUW '
+        + 'when app name is empty and MyUW is portal name '
+        + 'and Notifications is page name', function() {
+          // setup
+          NAMES.title = '';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('Notifications');
+
+          expect($document[0].title).toEqual('Notifications | MyUW');
+
+          httpBackend.flush();
+        });
     });
 });

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -54,9 +54,8 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.whenGET(SERVICE_LOC.sessionInfo).respond();
         }));
 
-        it('should set title to Timesheets | STAR | MyUW '
-        + 'when STAR is app name and MyUW is portal name '
-        + 'and Timesheets is page name', function() {
+        it('should set title to include page, app, and portal name when '
+           + 'all of these are present and non-redundant.', function() {
           // setup
           NAMES.title = 'STAR';
           $scope.portal.theme.title = 'MyUW';
@@ -69,9 +68,8 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
-        it('should set title to Notifications | MyUW '
-        + 'when MyUW is app name and MyUW is portal name '
-        + 'and Notifications is page name', function() {
+        it('should set title to omit app name when redundant with portal name',
+          function() {
           // setup
           NAMES.title = 'MyUW';
           $scope.portal.theme.title = 'MyUW';
@@ -84,9 +82,7 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
-        it('should set title to Notifications | MyUW '
-        + 'when app name is null and MyUW is portal name '
-        + 'and Notifications is page name', function() {
+        it('should set title to omit app name when null', function() {
           // setup
           NAMES.title = null;
           $scope.portal.theme.title = 'MyUW';
@@ -99,9 +95,7 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
-        it('should set title to Notifications | MyUW '
-        + 'when app name is empty and MyUW is portal name '
-        + 'and Notifications is page name', function() {
+        it('should set title to omit app name when it is empty', function() {
           // setup
           NAMES.title = '';
           $scope.portal.theme.title = 'MyUW';
@@ -114,9 +108,8 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
-        it('should set title to STAR | MyUW '
-        + 'when STAR is app name and MyUW is portal name '
-        + 'and there is no page name', function() {
+        it('should set title to omit page name when it is not provided',
+          function() {
           // setup
           NAMES.title = 'STAR';
           $scope.portal.theme.title = 'MyUW';
@@ -129,9 +122,8 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
-        it('should set title to MyUW'
-        + 'when MyUW is both portal name and app name '
-        + 'and there is no page name', function() {
+        it('should set title to only the portal name when the app name is '
+          + 'redundant and the page name is not provided.', function() {
           // setup
           NAMES.title = 'MyUW';
           $scope.portal.theme.title = 'MyUW';

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+/* eslint-env node */
+/* global inject */
+define(['angular-mocks', 'portal'], function() {
+    describe('mainService', function() {
+        var service;
+
+        var loginSilentUrl;
+        var httpBackend;
+
+        var $document;
+        var $scope;
+        var NAMES;
+
+        beforeEach(function() {
+          module('portal');
+        });
+
+        beforeEach(inject(function(
+          _mainService_, _$httpBackend_,
+          _$document_, _$rootScope_,
+          SERVICE_LOC, MESSAGES, APP_FLAGS, _NAMES_
+        ) {
+          $scope = _$rootScope_.$new();
+          service = _mainService_;
+          $document = _$document_;
+          httpBackend = _$httpBackend_;
+          NAMES = _NAMES_;
+          loginSilentUrl = APP_FLAGS.loginOnLoad;
+
+          if (loginSilentUrl) {
+            httpBackend.whenGET(loginSilentUrl)
+            .respond({'status': 'success', 'username': 'admin'});
+          }
+
+          httpBackend.whenGET(SERVICE_LOC.sessionInfo).respond();
+        }));
+
+        it('should set title to MyUW'
+        + 'when MyUW is both portal name and app name '
+        + 'and there is no page name', function() {
+          // setup
+          NAMES.title = 'MyUW';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle();
+
+          expect($document[0].title).toEqual('MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to STAR | MyUW '
+        + 'when STAR is app name and MyUW is portal name '
+        + 'and there is no page name', function() {
+          // setup
+          NAMES.title = 'STAR';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle();
+
+          expect($document[0].title).toEqual('STAR | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to Timesheets | STAR | MyUW '
+        + 'when STAR is app name and MyUW is portal name '
+        + 'and Timesheets is page name', function() {
+          // setup
+          NAMES.title = 'STAR';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('Timesheets');
+
+          expect($document[0].title).toEqual('Timesheets | STAR | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to Notifications | MyUW '
+        + 'when MyUW is app name and MyUW is portal name '
+        + 'and Notifications is page name', function() {
+          // setup
+          NAMES.title = 'MyUW';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('Notifications');
+
+          expect($document[0].title).toEqual('Notifications | MyUW');
+
+          httpBackend.flush();
+        });
+    });
+});

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -57,13 +57,14 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to include page, app, and portal name when '
            + 'all of these are present and non-redundant.', function() {
           // setup
-          NAMES.title = 'STAR';
+          NAMES.title = 'STAR Time Entry';
           $scope.portal.theme.title = 'MyUW';
 
           // test
           service.setTitle('Timesheets');
 
-          expect($document[0].title).toEqual('Timesheets | STAR | MyUW');
+          expect($document[0].title)
+            .toEqual('Timesheets | STAR Time Entry | MyUW');
 
           httpBackend.flush();
         });
@@ -111,13 +112,13 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to omit page name when it is not provided',
           function() {
           // setup
-          NAMES.title = 'STAR';
+          NAMES.title = 'STAR Time Entry';
           $scope.portal.theme.title = 'MyUW';
 
           // test
           service.setTitle();
 
-          expect($document[0].title).toEqual('STAR | MyUW');
+          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
 
           httpBackend.flush();
         });

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -123,6 +123,34 @@ define(['angular-mocks', 'portal'], function() {
           httpBackend.flush();
         });
 
+        it('should set title to omit page name when it is null',
+          function() {
+          // setup
+          NAMES.title = 'STAR Time Entry';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle(null);
+
+          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to omit page name when it is empty string',
+          function() {
+          // setup
+          NAMES.title = 'STAR Time Entry';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('');
+
+          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
+
+          httpBackend.flush();
+        });
+
         it('should set title to only the portal name when the app name is '
           + 'redundant and the page name is not provided.', function() {
           // setup
@@ -133,6 +161,63 @@ define(['angular-mocks', 'portal'], function() {
           service.setTitle();
 
           expect($document[0].title).toEqual('MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to only the portal name when redundant with both '
+          + 'the app name and the page name.', function() {
+          // setup
+          NAMES.title = 'MyUW';
+          $scope.portal.theme.title = 'MyUW';
+
+          // test
+          service.setTitle('MyUW');
+
+          expect($document[0].title).toEqual('MyUW');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to only the app name when portal name and page '
+          + 'name are null', function() {
+          // setup
+          NAMES.title = 'STAR Time and Leave';
+          $scope.portal.theme.title = null;
+
+          // test
+          service.setTitle(null);
+
+          expect($document[0].title).toEqual('STAR Time and Leave');
+
+          httpBackend.flush();
+        });
+
+        it('should set title to only the page name when portal name and app '
+          + 'name are null', function() {
+          // setup
+          var priorNamesTitle = NAMES.title;
+          NAMES.title = null;
+          $scope.portal.theme.title = null;
+
+          // test
+          service.setTitle('SomePage');
+
+          expect($document[0].title).toEqual('SomePage');
+
+          httpBackend.flush();
+          NAMES.title = priorNamesTitle; // undo change made by this test
+        });
+
+        it('should gracefully handle missing theme.', function() {
+          // setup
+          NAMES.title = 'SomeApp';
+          $scope.portal.theme = null;
+
+          // test
+          service.setTitle('SomePage');
+
+          expect($document[0].title).toEqual('SomePage | SomeApp');
 
           httpBackend.flush();
         });

--- a/components/portal/main/main_service_spec.js
+++ b/components/portal/main/main_service_spec.js
@@ -26,24 +26,16 @@ define(['angular-mocks', 'portal'], function() {
         var loginSilentUrl;
         var httpBackend;
 
-        var $document;
-        var $scope;
-        var NAMES;
-
         beforeEach(function() {
           module('portal');
         });
 
         beforeEach(inject(function(
           _mainService_, _$httpBackend_,
-          _$document_, _$rootScope_,
-          SERVICE_LOC, MESSAGES, APP_FLAGS, _NAMES_
+          SERVICE_LOC, MESSAGES, APP_FLAGS
         ) {
-          $scope = _$rootScope_.$new();
           service = _mainService_;
-          $document = _$document_;
           httpBackend = _$httpBackend_;
-          NAMES = _NAMES_;
           loginSilentUrl = APP_FLAGS.loginOnLoad;
 
           if (loginSilentUrl) {
@@ -57,13 +49,15 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to include page, app, and portal name when '
            + 'all of these are present and non-redundant.', function() {
           // setup
-          NAMES.title = 'STAR Time Entry';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = 'Timesheets';
+          var appTitle = 'STAR Time Entry';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('Timesheets');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title)
+          expect(windowTitle)
             .toEqual('Timesheets | STAR Time Entry | MyUW');
 
           httpBackend.flush();
@@ -72,53 +66,45 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to omit app name when redundant with portal name',
           function() {
           // setup
-          NAMES.title = 'MyUW';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = 'Notifications';
+          var appTitle = 'MyUW';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('Notifications');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('Notifications | MyUW');
+          expect(windowTitle).toEqual('Notifications | MyUW');
 
           httpBackend.flush();
         });
 
         it('should set title to omit app name when null', function() {
           // setup
-          NAMES.title = null;
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = 'Notifications';
+          var appTitle = null;
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('Notifications');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('Notifications | MyUW');
+          expect(windowTitle).toEqual('Notifications | MyUW');
 
           httpBackend.flush();
         });
 
         it('should set title to omit app name when it is empty', function() {
           // setup
-          NAMES.title = '';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = 'Notifications';
+          var appTitle = '';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('Notifications');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('Notifications | MyUW');
-
-          httpBackend.flush();
-        });
-
-        it('should set title to omit page name when it is not provided',
-          function() {
-          // setup
-          NAMES.title = 'STAR Time Entry';
-          $scope.portal.theme.title = 'MyUW';
-
-          // test
-          service.setTitle();
-
-          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
+          expect(windowTitle).toEqual('Notifications | MyUW');
 
           httpBackend.flush();
         });
@@ -126,13 +112,14 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to omit page name when it is null',
           function() {
           // setup
-          NAMES.title = 'STAR Time Entry';
-          $scope.portal.theme.title = 'MyUW';
+          var appTitle = 'STAR Time Entry';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle(null);
+          var windowTitle =
+            service.computeWindowTitle(null, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
+          expect(windowTitle).toEqual('STAR Time Entry | MyUW');
 
           httpBackend.flush();
         });
@@ -140,13 +127,15 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to omit page name when it is empty string',
           function() {
           // setup
-          NAMES.title = 'STAR Time Entry';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = '';
+          var appTitle = 'STAR Time Entry';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('STAR Time Entry | MyUW');
+          expect(windowTitle).toEqual('STAR Time Entry | MyUW');
 
           httpBackend.flush();
         });
@@ -154,13 +143,15 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to only the portal name when the app name is '
           + 'redundant and the page name is not provided.', function() {
           // setup
-          NAMES.title = 'MyUW';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = '';
+          var appTitle = 'MyUW';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle();
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('MyUW');
+          expect(windowTitle).toEqual('MyUW');
 
           httpBackend.flush();
         });
@@ -168,13 +159,15 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to only the portal name when redundant with both '
           + 'the app name and the page name.', function() {
           // setup
-          NAMES.title = 'MyUW';
-          $scope.portal.theme.title = 'MyUW';
+          var pageTitle = 'MyUW';
+          var appTitle = 'MyUW';
+          var portalTitle = 'MyUW';
 
           // test
-          service.setTitle('MyUW');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('MyUW');
+          expect(windowTitle).toEqual('MyUW');
 
           httpBackend.flush();
         });
@@ -182,13 +175,15 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to only the app name when portal name and page '
           + 'name are null', function() {
           // setup
-          NAMES.title = 'STAR Time and Leave';
-          $scope.portal.theme.title = null;
+          var pageTitle = null;
+          var appTitle = 'STAR Time and Leave';
+          var portalTitle = null;
 
           // test
-          service.setTitle(null);
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('STAR Time and Leave');
+          expect(windowTitle).toEqual('STAR Time and Leave');
 
           httpBackend.flush();
         });
@@ -196,28 +191,30 @@ define(['angular-mocks', 'portal'], function() {
         it('should set title to only the page name when portal name and app '
           + 'name are null', function() {
           // setup
-          var priorNamesTitle = NAMES.title;
-          NAMES.title = null;
-          $scope.portal.theme.title = null;
+          var pageTitle = 'SomePage';
+          var appTitle = null;
+          var portalTitle = null;
 
           // test
-          service.setTitle('SomePage');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('SomePage');
+          expect(windowTitle).toEqual('SomePage');
 
           httpBackend.flush();
-          NAMES.title = priorNamesTitle; // undo change made by this test
         });
 
         it('should gracefully handle missing theme.', function() {
           // setup
-          NAMES.title = 'SomeApp';
-          $scope.portal.theme = null;
+          var pageTitle = 'SomePage';
+          var appTitle = 'SomeApp';
+          var portalTitle = null;
 
           // test
-          service.setTitle('SomePage');
+          var windowTitle =
+            service.computeWindowTitle(pageTitle, appTitle, portalTitle);
 
-          expect($document[0].title).toEqual('SomePage | SomeApp');
+          expect(windowTitle).toEqual('SomePage | SomeApp');
 
           httpBackend.flush();
         });

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -83,14 +83,14 @@ define(['angular'], function(angular) {
           // there's an active theme: use it to determine the name of the portal
           portalTitle = $rootScope.portal.theme.title;
 
-          if (portalTitle !== NAMES.title) {
-            // we're setting the title in the context of an app
-            // within the portal rather than in the context of uPortal-home
-            windowTitle = NAMES.title + ' | ' + portalTitle;
-          } else {
+          if (portalTitle == NAMES.title) {
             // titles like "MyUW | MyUW" e.g. would be silly,
             // so just use e.g. "MyUW"
             windowTitle = NAMES.title;
+          } else {
+            // we're setting the title in the context of an app
+            // within the portal rather than in the context of uPortal-home
+            windowTitle = NAMES.title + ' | ' + portalTitle;
           }
         }
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -77,29 +77,42 @@ define(['angular'], function(angular) {
        */
       function setTitle() {
         var windowTitle = ''; // we finally set the window title to this.
+
+        // first, gather pieces of the desired window title
+
         var portalTitle = ''; // the name of the portal if we can determine it
+        var appTitle = ''; // the name of the app
 
         if ($rootScope.portal && $rootScope.portal.theme &&
               $rootScope.portal.theme.title) {
           // there's an active theme with a title.
           // consider that title the name of the portal
           portalTitle = $rootScope.portal.theme.title;
-
-          if (portalTitle == NAMES.title) {
-            // titles like "MyUW | MyUW" would be silly,
-            // so just use "MyUW", for example.
-            windowTitle = NAMES.title;
-          } else {
-            // app title differs from portal title, so include both in
-            // window title to communicate app-in-context-of-portal.
-            windowTitle = NAMES.title + ' | ' + portalTitle;
-          }
-        } else {
-          // there isn't an active theme with a title
-          // so just use the name of the app
-          windowTitle = NAMES.title;
         }
 
+        appTitle = NAMES.title;
+
+        // assemble the window title from the gathered pieces,
+        // starting from the end of the window title and working back to the
+        // beginning.
+
+        // if the portal has a name, end the window title with that
+        // (if the portal lacks a name, portalTitle is still empty string)
+        windowTitle = portalTitle;
+
+        // if the app name differs from the portal, prepend it.
+        // if it's the same name, omit it to avoid silly redundancy like
+        // "MyUW | MyUW"
+        if (appTitle !== portalTitle) {
+          // if the windowTitle already has content, first add a separator
+          if (windowTitle !== '') {
+            windowTitle = ' | ' + windowTitle;
+          }
+          windowTitle = appTitle + windowTitle;
+        }
+
+
+        // finally, use the built up windowTitle
         $document[0].title = windowTitle;
       }
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -67,15 +67,29 @@ define(['angular'], function(angular) {
        * set the window title
        *
        * results in title
-       * NAMES.title | theme.title (in an application), or
-       * theme.title (if these names are the same, e.g. in the root portal)
+       * page-title | app-title | portal-title (in an application), or
+       * page-title | portal-title (if the app has same name as the portal), or
+       * app-title | portal-title (if page name unknown or redundant)
+       * portal-title (if page name unknown or redundant and app name redundant)
        *
        * Examples:
-       * "STAR Time Entry | MyUW" , for an app named "STAR Time Entry" in
+       * "Timesheets | STAR Time Entry | MyUW" ,
+       * for the Timesheets page in an app named "STAR Time Entry" in
        * a portal named "MyUW", or
-       * "MyUW", for a uPortal-home named "MyUW" in a portal named "MyUW".
+       *
+       * "Notifications | MyUW",
+       * for the notifications page in an app named "MyUW" in
+       * a portal named "MyUW".
+       *
+       * "STAR Time Entry | MyUW"
+       * in an app named "STAR Time Entry" in a portal named "MyUW"
+       * when the page name is unspecified.
+       *
+       * "MyUW"
+       * in an app named "MyUW" in a portal named "MyUW"
+       * when the page name is unspecified.
        */
-      function setTitle() {
+      function setTitle(pageTitle) {
         var windowTitle = ''; // we finally set the window title to this.
 
         // first, gather pieces of the desired window title
@@ -111,6 +125,14 @@ define(['angular'], function(angular) {
           windowTitle = appTitle + windowTitle;
         }
 
+        // if there's a page name not redundant with the app name, prepend it.
+        if (pageTitle && pageTitle !== '' && pageTitle !== appTitle) {
+          // if the windowTitle already has content, first add a separator
+          if (windowTitle !== '') {
+            windowTitle = ' | ' + windowTitle;
+          }
+          windowTitle = pageTitle + windowTitle;
+        }
 
         // finally, use the built up windowTitle
         $document[0].title = windowTitle;

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -79,8 +79,10 @@ define(['angular'], function(angular) {
         var windowTitle = ''; // we finally set the window title to this.
         var portalTitle = ''; // the name of the portal if we can determine it
 
-        if ($rootScope.portal && $rootScope.portal.theme) {
-          // there's an active theme: use it to determine the name of the portal
+        if ($rootScope.portal && $rootScope.portal.theme &&
+              $rootScope.portal.theme.title) {
+          // there's an active theme with a title.
+          // consider that title the name of the portal
           portalTitle = $rootScope.portal.theme.title;
 
           if (portalTitle == NAMES.title) {

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -94,6 +94,10 @@ define(['angular'], function(angular) {
             // window title to communicate app-in-context-of-portal.
             windowTitle = NAMES.title + ' | ' + portalTitle;
           }
+        } else {
+          // there isn't an active theme with a title
+          // so just use the name of the app
+          windowTitle = NAMES.title;
         }
 
         $document[0].title = windowTitle;

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -23,11 +23,9 @@ define(['angular'], function(angular) {
 
   .factory('mainService', [
     '$http', '$log', '$sessionStorage',
-    'miscService', 'SERVICE_LOC', 'APP_FLAGS', '$rootScope', 'NAMES',
-    '$document',
+    'miscService', 'SERVICE_LOC', 'APP_FLAGS', 'NAMES',
     function($http, $log, $sessionStorage,
-             miscService, SERVICE_LOC, APP_FLAGS, $rootScope, NAMES,
-             $document) {
+             miscService, SERVICE_LOC, APP_FLAGS, NAMES) {
       var prom = $http.get(SERVICE_LOC.sessionInfo, {cache: true});
       var userPromise;
 
@@ -74,9 +72,9 @@ define(['angular'], function(angular) {
       }
 
       /**
-       * set the window title
+       * Compute the window title
        *
-       * results in title
+       * Returns
        * page-title | app-title | portal-title (in an application), or
        * page-title | portal-title (if the app has same name as the portal), or
        * app-title | portal-title (if page name unknown or redundant)
@@ -99,22 +97,8 @@ define(['angular'], function(angular) {
        * in an app named "MyUW" in a portal named "MyUW"
        * when the page name is unspecified.
        */
-      function setTitle(pageTitle) {
+      function computeWindowTitle(pageTitle, appTitle, portalTitle) {
         var windowTitle = ''; // we finally set the window title to this.
-
-        // first, gather pieces of the desired window title
-
-        var portalTitle = ''; // the name of the portal if we can determine it
-        var appTitle = ''; // the name of the app
-
-        if ($rootScope.portal && $rootScope.portal.theme &&
-              $rootScope.portal.theme.title) {
-          // there's an active theme with a title.
-          // consider that title the name of the portal
-          portalTitle = $rootScope.portal.theme.title;
-        }
-
-        appTitle = NAMES.title;
 
         // assemble the window title from the gathered pieces,
         // starting from the end of the window title and working back to the
@@ -122,14 +106,17 @@ define(['angular'], function(angular) {
 
         // if the portal has a name, end the window title with that
         // (if the portal lacks a name, portalTitle is still empty string)
-        windowTitle = portalTitle;
+
+        if (portalTitle) {
+          windowTitle = portalTitle;
+        }
 
         // if the app name differs from the portal, prepend it.
         // if it's the same name, omit it to avoid silly redundancy like
         // "MyUW | MyUW"
         if (appTitle && appTitle !== portalTitle) {
           // if the windowTitle already has content, first add a separator
-          if (windowTitle !== '') {
+          if (windowTitle) {
             windowTitle = ' | ' + windowTitle;
           }
           windowTitle = appTitle + windowTitle;
@@ -144,14 +131,14 @@ define(['angular'], function(angular) {
           windowTitle = pageTitle + windowTitle;
         }
 
-        // finally, use the built up windowTitle
-        $document[0].title = windowTitle;
+        // finally, return the built up windowTitle
+        return windowTitle;
       }
 
     return {
       getUser: getUser,
       isGuest: isGuest,
-      setTitle: setTitle,
+      computeWindowTitle: computeWindowTitle,
     };
   }]);
 });

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -117,7 +117,7 @@ define(['angular'], function(angular) {
         // if the app name differs from the portal, prepend it.
         // if it's the same name, omit it to avoid silly redundancy like
         // "MyUW | MyUW"
-        if (appTitle !== portalTitle) {
+        if (appTitle && appTitle !== portalTitle) {
           // if the windowTitle already has content, first add a separator
           if (windowTitle !== '') {
             windowTitle = ' | ' + windowTitle;

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -64,7 +64,16 @@ define(['angular'], function(angular) {
     };
 
       /**
-       * set the frame title using theme
+       * set the window title
+       *
+       * results in title
+       * NAMES.title | theme.title (in an application), or
+       * theme.title (in the root portal)
+       *
+       * Examples:
+       * "STAR Time Entry | MyUW" , for an app named "STAR Time Entry" in
+       * a portal named "MyUW", or
+       * "MyUW", for uPortal-home in a portal named "MyUW".
        */
       function setTitle() {
         var frameTitle = '';

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -76,17 +76,25 @@ define(['angular'], function(angular) {
        * "MyUW", for uPortal-home in a portal named "MyUW".
        */
       function setTitle() {
-        var frameTitle = '';
+        var windowTitle = ''; // we finally set the window title to this.
+        var portalTitle = ''; // the name of the portal if we can determine it
+
         if ($rootScope.portal && $rootScope.portal.theme) {
-          frameTitle = $rootScope.portal.theme.title;
-          if (frameTitle !== NAMES.title && !APP_FLAGS.isWeb) {
-            frameTitle = ' | ' + frameTitle;
+          // there's an active theme: use it to determine the name of the portal
+          portalTitle = $rootScope.portal.theme.title;
+
+          if (portalTitle !== NAMES.title && !APP_FLAGS.isWeb) {
+            // we're setting the title in the context of an app
+            // within the portal rather than in the context of uPortal-home
+            windowTitle = NAMES.title + ' | ' + portalTitle;
           } else {
-            // since frame title equals the title in NAMES lets not duplicate it
-            frameTitle = '';
+            // titles like "MyUW | MyUW" e.g. would be silly,
+            // so just use e.g. "MyUW"
+            windowTitle = NAMES.title;
           }
         }
-        $document[0].title = NAMES.title + frameTitle;
+
+        $document[0].title = windowTitle;
       }
 
     return {

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -86,8 +86,8 @@ define(['angular'], function(angular) {
           portalTitle = $rootScope.portal.theme.title;
 
           if (portalTitle == NAMES.title) {
-            // titles like "MyUW | MyUW" e.g. would be silly,
-            // so just use e.g. "MyUW"
+            // titles like "MyUW | MyUW" would be silly,
+            // so just use "MyUW", for example.
             windowTitle = NAMES.title;
           } else {
             // app title differs from portal title, so include both in

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -88,8 +88,8 @@ define(['angular'], function(angular) {
             // so just use e.g. "MyUW"
             windowTitle = NAMES.title;
           } else {
-            // we're setting the title in the context of an app
-            // within the portal rather than in the context of uPortal-home
+            // app title differs from portal title, so include both in
+            // window title to communicate app-in-context-of-portal.
             windowTitle = NAMES.title + ' | ' + portalTitle;
           }
         }

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -68,12 +68,12 @@ define(['angular'], function(angular) {
        *
        * results in title
        * NAMES.title | theme.title (in an application), or
-       * theme.title (in the root portal)
+       * theme.title (if these names are the same, e.g. in the root portal)
        *
        * Examples:
        * "STAR Time Entry | MyUW" , for an app named "STAR Time Entry" in
        * a portal named "MyUW", or
-       * "MyUW", for uPortal-home in a portal named "MyUW".
+       * "MyUW", for a uPortal-home named "MyUW" in a portal named "MyUW".
        */
       function setTitle() {
         var windowTitle = ''; // we finally set the window title to this.
@@ -83,7 +83,7 @@ define(['angular'], function(angular) {
           // there's an active theme: use it to determine the name of the portal
           portalTitle = $rootScope.portal.theme.title;
 
-          if (portalTitle !== NAMES.title && !APP_FLAGS.isWeb) {
+          if (portalTitle !== NAMES.title) {
             // we're setting the title in the context of an app
             // within the portal rather than in the context of uPortal-home
             windowTitle = NAMES.title + ' | ' + portalTitle;

--- a/components/portal/main/spec/main_controller_spec.js
+++ b/components/portal/main/spec/main_controller_spec.js
@@ -66,6 +66,16 @@ define(['angular-mocks', 'portal'], function() {
 
         it('should set document title to reflect portal name in theme',
             function() {
+            // this test is problematic in that it relies on too much
+            // knowledge of what mainService will tell PortalMainController
+            // the window title ought to be. It would be better if this tested
+            // 1. that PortalMainController called mainService with the correct
+            // arguments, and
+            // 2. that PortalMainController set the window title to whatever
+            // mainService told it the title ought to be.
+            // that is, mock mainService both to monitor arguments
+            // PortalMainController calls it with and to fake its response to
+            // see that PortalMainController honors it
             expect($document[0].title).toEqual('AppName | PortalName');
         });
     });

--- a/components/portal/main/spec/main_controller_spec.js
+++ b/components/portal/main/spec/main_controller_spec.js
@@ -21,8 +21,12 @@
 /* global inject */
 define(['angular-mocks', 'portal'], function() {
     describe('PortalMainController', function() {
-        var scope;
+        var $scope;
         var $localStorage;
+        var $document;
+        var mainService;
+        var NAMES;
+
         // eslint-disable-next-line no-unused-vars
         var controller;
 
@@ -30,21 +34,39 @@ define(['angular-mocks', 'portal'], function() {
           module('portal');
         });
 
-        beforeEach(inject(function($rootScope, $controller, _$localStorage_) {
-          scope = $rootScope.$new();
+        beforeEach(inject(function(
+          _$rootScope_, $controller, _$localStorage_, _$document_,
+          _mainService_, _NAMES_) {
+          $scope = _$rootScope_.$new();
           $localStorage = _$localStorage_;
+          $document = _$document_;
+          mainService = _mainService_;
+          NAMES = _NAMES_;
+
+          NAMES.title = 'AppName';
+          $scope.portal.theme.title = 'PortalName';
+
           controller = $controller('PortalMainController', {
             '$localStorage': $localStorage,
-            '$scope': scope,
+            '$scope': $scope,
+            '$rootScope': _$rootScope_,
+            '$document': $document,
+            'mainService': mainService,
+            'NAMES': NAMES,
           });
         }));
 
         it('should set storage in scope', function() {
-            expect(scope.$storage).not.toBeNull();
+            expect($scope.$storage).not.toBeNull();
         });
 
         it('should have an app name defined', function() {
-            expect(scope.NAMES.title).not.toBeNull();
+            expect($scope.NAMES.title).not.toBeNull();
+        });
+
+        it('should set document title to reflect portal name in theme',
+            function() {
+            expect($document[0].title).toEqual('AppName | PortalName');
         });
     });
 });

--- a/components/portal/misc/app_header_options_controller_spec.js
+++ b/components/portal/misc/app_header_options_controller_spec.js
@@ -51,14 +51,14 @@ define(['angular-mocks', 'portal'], function() {
           });
         }));
 
-        it('should expose an updateTitle function',
+        it('should expose an updateWindowTitle function',
             function() {
-               expect(controller.updateTitle).not.toBeNull();
+               expect(controller.updateWindowTitle).not.toBeNull();
         });
 
         it('should set document title reflecting page title',
             function() {
-            controller.updateTitle('SpecificPageName');
+            controller.updateWindowTitle('SpecificPageName');
             // this test is problematic in that it relies on too much
             // knowledge of what mainService will tell
             // AppHeaderOptionsController the window title ought to be. It

--- a/components/portal/misc/app_header_options_controller_spec.js
+++ b/components/portal/misc/app_header_options_controller_spec.js
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+/* eslint-env node */
+/* global inject */
+define(['angular-mocks', 'portal'], function() {
+    describe('AppHeaderOptionsController', function() {
+        var $scope;
+        var $document;
+        var mainService;
+        var NAMES;
+
+        var controller;
+
+        beforeEach(function() {
+          module('portal');
+        });
+
+        beforeEach(inject(function(
+          _$rootScope_, $controller, _$document_,
+          _mainService_, _NAMES_) {
+          $scope = _$rootScope_.$new();
+          $document = _$document_;
+          mainService = _mainService_;
+          NAMES = _NAMES_;
+
+          NAMES.title = 'AppName';
+          $scope.portal.theme.title = 'PortalName';
+
+          controller = $controller('AppHeaderOptionsController', {
+            '$rootScope': _$rootScope_,
+            '$document': $document,
+            'mainService': mainService,
+            'NAMES': NAMES,
+          });
+        }));
+
+        it('should expose an updateTitle function',
+            function() {
+               expect(controller.updateTitle).not.toBeNull();
+        });
+
+        it('should set document title reflecting page title',
+            function() {
+            controller.updateTitle('SpecificPageName');
+            // this test is problematic in that it relies on too much
+            // knowledge of what mainService will tell
+            // AppHeaderOptionsController the window title ought to be. It
+            // would be better if this tested
+            // 1. that the controller called mainService with the correct
+            // arguments, and
+            // 2. that the controller set the window title to whatever
+            // mainService told it the title ought to be.
+            // that is, mock mainService both to monitor arguments
+            // the controller calls it with and to fake its response to
+            // see that the controller honors it
+            expect($document[0].title)
+              .toEqual('SpecificPageName | AppName | PortalName');
+        });
+    });
+});

--- a/components/portal/misc/controllers.js
+++ b/components/portal/misc/controllers.js
@@ -74,13 +74,31 @@ define(['angular'], function(angular) {
         init();
       }])
 
-    .controller('AppHeaderOptionsController', ['APP_OPTIONS',
-      function(APP_OPTIONS) {
+    .controller('AppHeaderOptionsController',
+      ['APP_OPTIONS', 'NAMES', 'mainService', '$rootScope', '$document',
+      function(APP_OPTIONS, NAMES, mainService, $rootScope, $document) {
         var vm = this;
 
         // If an options template is specified, set scope variable
         if (APP_OPTIONS.optionsTemplateURL) {
           vm.optionsTemplate = require.toUrl(APP_OPTIONS.optionsTemplateURL);
         }
+
+        vm.updateTitle = function(pageTitle) {
+          var appTitle = NAMES.title;
+
+          var portalTitle = '';
+          if ($rootScope.portal && $rootScope.portal.theme &&
+                $rootScope.portal.theme.title) {
+            // there's an active theme with a title.
+            // consider that title the name of the portal
+            portalTitle = $rootScope.portal.theme.title;
+          }
+
+          var windowTitle =
+            mainService.computeWindowTitle(pageTitle, appTitle, portalTitle);
+
+          $document[0].title = windowTitle;
+        };
     }]);
 });

--- a/components/portal/misc/controllers.js
+++ b/components/portal/misc/controllers.js
@@ -84,7 +84,7 @@ define(['angular'], function(angular) {
           vm.optionsTemplate = require.toUrl(APP_OPTIONS.optionsTemplateURL);
         }
 
-        vm.updateTitle = function(pageTitle) {
+        vm.updateWindowTitle = function(pageTitle) {
           var appTitle = NAMES.title;
 
           var portalTitle = '';

--- a/components/portal/misc/directives.js
+++ b/components/portal/misc/directives.js
@@ -140,7 +140,8 @@ define(['angular', 'require'], function(angular, require) {
      * Supports 3 attributes:
      *
      * <ol>
-     * <li>app-title: displayed in an h1 child element</li>
+     * <li>app-title: displayed in an h1 child element
+     *    and reflected in window title</li>
      * <li>app-icon: the font awesome icon you want (e.g.: fa-google) </li>
      * <li>app-action-link-*;
      *    url: the url you want, if not set action link hides.
@@ -156,6 +157,8 @@ define(['angular', 'require'], function(angular, require) {
      *    if not provided it'll use NAMES.fname</li>
 
      * </ol>
+     *
+     *  Side effect: updates window title to reflect app-title.
      *
      * See ./partials/app-header.html.
      */

--- a/components/portal/misc/partials/app-header.html
+++ b/components/portal/misc/partials/app-header.html
@@ -26,6 +26,7 @@
   </h1>
 
   <div flex="50" flex-xs="35" class="header-links" ng-controller="AppHeaderOptionsController as vm">
+    <div uaf-side-effect="{{vm.updateTitle(title)}}"></div>
     <div ng-if="vm.optionsTemplate" ng-include="vm.optionsTemplate"></div>
 
      <!--ADD TO HOME BUTTON (HIDDEN XS) -->

--- a/components/portal/misc/partials/app-header.html
+++ b/components/portal/misc/partials/app-header.html
@@ -26,7 +26,7 @@
   </h1>
 
   <div flex="50" flex-xs="35" class="header-links" ng-controller="AppHeaderOptionsController as vm">
-    <div uaf-side-effect="{{vm.updateTitle(title)}}"></div>
+    <div uaf-side-effect="{{vm.updateWindowTitle(title)}}"></div>
     <div ng-if="vm.optionsTemplate" ng-include="vm.optionsTemplate"></div>
 
      <!--ADD TO HOME BUTTON (HIDDEN XS) -->

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -22,11 +22,16 @@ each of your application's main views.
 
 ### Params
 
-* **app-title**: The title that will be displayed in the app header
+* **app-title**: Will be displayed in the app header and reflected in document
+title
 * **app-icon**: The icon to use as a prefix to the app title. You can use Font Awesome (i.e. "fa-envelope") or Material Icons (i.e. "email").
 * **app-show-add-to-home**: If set to true, will include the add-to-home directive and its controller in the app header (used for apps that are part of the portal ecosystem).
 * **app-fname**: If provided, it will be used in the add-to-home feature. If not, it'll try to use NAMES.fname constant.
 * **white-background**: A boolean when set to true with give you a white background.
+
+### Side effects
+
+`frame-page` has the side effect of setting the document title to reflect its `app-title` attribute, by means of its use of `app-header`.
 
 ## Main menu
 


### PR DESCRIPTION
Purpose:

* Set the document title to values describing the location in a `uPortal-app-framework` application as the user navigates within the application, thereby enabling improving usability generally and fulfilling `WCAG2: 2.4.2` specifically (Page Titled: Web pages have titles that describe topic or purpose. (Level A)).

Done:

* Adds title computation to `mainService`, implementing our (goofy?) "rule" about page naming, e.g. `PageName | AppName | PortalName`, with oodles of failing gracefully, and unit testing.
* Refactors title setting in `PortalMainController`, relying upon `mainService` to compute the title and only gathering the inputs and doing the view (Document) modification in the controller layer. This continues to mutate document title on theme change, since theme change can mean a change in portal name. Unit tests the initial document title setting.
* Adds title setting in `AppHeaderOptionsController`, with unit test.
* In `app-header` directive calls the title setting in `AppHeaderOptionsController` to set the document title reflecting the title in the app header, which in some contexts corresponds to what the user would regard as the "page title" (and failing that, at least reflects the name of the app).

![app-header-sets-page-title](https://user-images.githubusercontent.com/952283/35579274-e3e8890a-05ab-11e8-9488-29be92eedaaa.png)

Deferred:

* Unit test the `PortalMainController` reacting to theme change by resetting document title. (This changeset didn't introduce this feature and hasn't so far as I can tell broken it.)
* Unit test `app-header` directive (didn't get to figuring out how to test directives and that directive is moribund.)
* Maybe do something less hacky than set the document title as the side effect of a div. (There's gotta be a more idiomatic way for a directive to call a controller function on rendering.)
* Reconcile with parallel efforts to eliminate the `app-header` directive ( #682 ). Will have to face down what that bigger change means for setting the Document title in the course of that bigger change.

----

Resolves #654 .

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
