### PR TITLE
fix: stop messages call for unauthenticated users

### DIFF
--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -118,10 +118,8 @@ define(['angular', 'require'], function(angular, require) {
       vm.profileUrl = data.profileUrl ? data.profileUrl : '';
     });
 
-    // Check if user is guest and if avatar is enabled
     mainService.getUser().then(function(result) {
       vm.user = result;
-      $rootScope.GuestMode = (vm.user.userName === NAMES.guestUserName);
 
       if (vm.user.firstName || vm.user.displayName) {
         vm.username = vm.user.firstName ?
@@ -138,6 +136,14 @@ define(['angular', 'require'], function(angular, require) {
       return result;
     }).catch(function() {
       $log.warn('could not get user');
+    });
+
+    // DEPRECATED
+    // Don't set GuestMode in rootScope. Remove in next major version.
+    mainService.isGuest().then(function(result) {
+      return $rootScope.GuestMode = result;
+    }).catch(function(err) {
+      $log.warn('could not check guest');
     });
   }])
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -61,7 +61,17 @@ define(['angular'], function(angular) {
             miscService.redirectUser(status, 'Get User Info');
           });
         return userPromise;
-    };
+      };
+
+      /**
+       * Retreives the user and checks against guestUserName
+       * @return {Promise<Boolean>} Resolves true if user matches guestUserName
+       */
+      function isGuest() {
+        return getUser().then(function(result) {
+          return result.userName === NAMES.guestUserName;
+        });
+      }
 
       /**
        * set the frame title using theme
@@ -82,6 +92,7 @@ define(['angular'], function(angular) {
 
     return {
       getUser: getUser,
+      isGuest: isGuest,
       setTitle: setTitle,
     };
   }]);

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -21,19 +21,20 @@
 define(['angular'], function(angular) {
   return angular.module('portal.messages.controllers', [])
 
-    .controller('MessagesController', ['$q', '$log', '$scope', '$rootScope',
-      '$location', '$localStorage', '$sessionStorage', '$filter', '$mdDialog',
-      'APP_FLAGS', 'MISC_URLS', 'SERVICE_LOC', 'miscService', 'messagesService',
+    .controller('MessagesController', [
+      '$q', '$log', '$scope', '$rootScope', '$location', '$localStorage',
+      '$sessionStorage', '$filter', '$mdDialog', 'APP_FLAGS', 'MISC_URLS',
+      'SERVICE_LOC', 'mainService', 'miscService', 'messagesService',
       function($q, $log, $scope, $rootScope, $location, $localStorage,
                $sessionStorage, $filter, $mdDialog, APP_FLAGS, MISC_URLS,
-               SERVICE_LOC, miscService, messagesService) {
+               SERVICE_LOC, mainService, miscService, messagesService) {
         // //////////////////
         // Local variables //
         // //////////////////
         var allMessages = [];
         $scope.APP_FLAGS = APP_FLAGS;
         $scope.MISC_URLS = MISC_URLS;
-        $scope.showMessagesFeatures = true;
+        $scope.showMessagesFeatures = false;
 
         // ////////////////
         // Local methods //
@@ -130,17 +131,15 @@ define(['angular'], function(angular) {
           $scope.hasMessages = false;
           $scope.messages = {};
 
-          if (!$rootScope.GuestMode && SERVICE_LOC.messagesURL
-            && SERVICE_LOC.messagesURL !== '') {
-            getMessages();
-          } else {
-            // Messages features aren't configured properly, possibly
-            // on purpose. Communicate this and hide features.
-            $scope.showMessagesFeatures = false;
-            $scope.messagesError = 'SERVICE_LOC.messageURL is not configured ' +
-              '-- hiding messages features.';
-            $scope.hasMessages = true;
-          }
+          mainService.isGuest().then(function(isGuest) {
+            if (!isGuest && SERVICE_LOC.messagesURL) {
+              $scope.showMessagesFeatures = true;
+              getMessages();
+            }
+            return isGuest;
+          }).catch(function() {
+            $log.warn('Problem checking guestMode');
+          });
         };
 
         init();


### PR DESCRIPTION
Pulling the check for guest user into a service. Also, setting the default for the notification bell to be off until we verify it's an authenticated user.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
