### PR TITLE
Fix example config

### DIFF
--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -437,8 +437,8 @@ Example:
   <name>widgetConfig</name>
   <value>
     <![CDATA[{
-      'launchText' : 'See all the Weather',
-      'maintenanceMode' : true
+      "launchText" : "See all the Weather",
+      "maintenanceMode" : true
     }]]>
   </value>
 </portlet-preference>


### PR DESCRIPTION
The example launchText had single quotes instead of the required double quotes

{Substantive content goes here. Summarize the changeset and *why* the changeset.}

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
