### PR TITLE
feat: add analytics to widget interactions

### DIFF
--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -24,7 +24,7 @@ define(['angular', 'require'], function(angular, require) {
   /**
    * Just the widget card -- gets the widget type from scope
    */
-  .directive('widget', function() {
+  .directive('widget', ['miscService', function(miscService) {
     return {
       restrict: 'E',
       transclude: true,
@@ -33,13 +33,26 @@ define(['angular', 'require'], function(angular, require) {
       },
       templateUrl: require.toUrl('./partials/widget-card.html'),
       controller: 'WidgetCardController',
+      link: {
+        post: function(scope, element, attrs) {
+          element.on('click', function(event) {
+            var el = event.target;
+            while (el && (!el.tagName || el.tagName.toLowerCase() !== 'a')) {
+              el = el.parentNode;
+            }
+            if (el) {
+              miscService.pushGAEvent(attrs.fname, 'widget click', el.href);
+            }
+          });
+        },
+      },
     };
-  })
+  }])
 
   /**
    * Just the widget card -- gets the widget type from the scope
    */
-  .directive('compactWidget', function() {
+  .directive('compactWidget', ['miscService', function(miscService) {
     return {
       restrict: 'E',
       transclude: true,
@@ -48,8 +61,22 @@ define(['angular', 'require'], function(angular, require) {
       },
       templateUrl: require.toUrl('./partials/compact-widget-card.html'),
       controller: 'WidgetCardController',
+      link: {
+        post: function(scope, element, attrs) {
+          element.on('click', function(event) {
+            var el = event.target;
+            while (el && (!el.tagName || el.tagName.toLowerCase() !== 'a')) {
+              el = el.parentNode;
+            }
+            if (el) {
+              miscService.pushGAEvent(
+                attrs.fname, 'compact widget click', el.href);
+            }
+          });
+        },
+      },
     };
-  })
+  }])
 
   /**
    * Show an external message


### PR DESCRIPTION
We've got outbound link analytics, but we don't have any analytics on internal widget interactions. This adds them to `a` tags within expanded and compact widgets.

I broke with outbound link style and used the href as the event label. I'd welcome an opinion as to why hrefs should be the event action.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
