### PR TITLE
fix: fix add-to-home toast

### DIFF
--- a/components/css/buckyless/directives/add-to-home.less
+++ b/components/css/buckyless/directives/add-to-home.less
@@ -24,6 +24,9 @@ add-to-home {
 
     md-toast {
       .md-toast-content {
+        color: @white;
+        background: @grayscale10;
+
         .material-icons {
           color: @white;
         }

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -18,7 +18,8 @@
     under the License.
 
 -->
-<frame-page app-fname="example-page-fname"
+<frame-page app-fname="'example-page-fname'"
+            app-show-add-to-home="true"
             white-background="false">
   <style>
     .widget-container {

--- a/components/portal/misc/controllers.js
+++ b/components/portal/misc/controllers.js
@@ -25,7 +25,12 @@ define(['angular'], function(angular) {
     .controller('AddToHomeController', [
       '$log', '$scope', '$timeout', '$mdToast', 'PortalAddToHomeService',
       function($log, $scope, $timeout, $mdToast, PortalAddToHomeService) {
-        var checkInHome = function(fname) {
+        /**
+         * Check if the given app is in the user's home layout already.
+         * If not, trigger the prompt to add it.
+         * @param {String} fname
+         */
+      var checkInHome = function(fname) {
           PortalAddToHomeService.inHome(fname)
             .then(function(data) {
               $scope.inHome = data;
@@ -43,6 +48,10 @@ define(['angular'], function(angular) {
             });
         };
 
+        /**
+         * Show a dismissible toast prompting the user to add the app to their
+         * home layout. Dismissing toast persists for the session.
+         */
         var showAddToHomeToast = function() {
           $mdToast.show({
             position: 'top right',
@@ -50,9 +59,8 @@ define(['angular'], function(angular) {
             scope: $scope,
             preserveScope: true,
             parent: angular.element(document).find('div.add-to-home-parent')[0],
-            toastClass: 'my-uw',
             templateUrl:
-              require.toUrl('portal/misc/partials/toast-add-to-home.html'),
+              require.toUrl('/portal/misc/partials/toast-add-to-home.html'),
             controller: function ToastAddToHomeController(
               $scope,
               $mdToast,
@@ -60,9 +68,9 @@ define(['angular'], function(angular) {
             ) {
               $scope.addToHome = function() {
                 if (!$scope.inHome
-                  && PortalAddToHomeService.canAddToHome($scope.fname)) {
+                  && PortalAddToHomeService.canAddToHome($scope.appFname)) {
                   $scope.savingAddToHome = true;
-                  PortalAddToHomeService.addToHome($scope.fname).then(
+                  PortalAddToHomeService.addToHome($scope.appFname).then(
                     function() {
                       // success
                       $scope.inHome = true;
@@ -87,22 +95,26 @@ define(['angular'], function(angular) {
           });
         };
 
+        /**
+         * Check for if current app can be added to home and user
+         * hasn't already dismissed a chance to do so during this session.
+         */
         var init = function() {
-          // default it to being in your home to avoid service loading lag
+          // Default it to being in your home to avoid service loading lag
           $scope.inHome = true;
 
           if (PortalAddToHomeService.canAddToHome()) {
             // Make sure user didn't already dismiss
             // add to home toast
             if (!PortalAddToHomeService.isDismissed()) {
-              if ($scope.fname) {
+              if ($scope.appFname) {
                 // Check if in home layout
-                checkInHome($scope.fname);
+                checkInHome($scope.appFname);
               } else {
-                $scope.$watch('fname', function() {
+                $scope.$watch('appFname', function() {
                   // Must be using 2 way binding, add a watch on the fname
-                  if ($scope.fname) {
-                    checkInHome($scope.fname);
+                  if ($scope.appFname) {
+                    checkInHome($scope.appFname);
                   }
                 });
               }

--- a/components/portal/misc/partials/toast-add-to-home.html
+++ b/components/portal/misc/partials/toast-add-to-home.html
@@ -23,6 +23,7 @@
     <span class="md-toast-text" flex>Add to home?</span>
     <div layout="row">
       <md-button ng-click="addToHome()"
+                 aria-label="Add this app to home"
                  class="md-raised md-accent">
         <span ng-if="!successfullyAdded && !addToHomeFailed && !savingAddToHome"><md-icon>add</md-icon> Add</span>
         <span ng-if="!successfullyAdded && !addToHomeFailed && savingAddToHome" ng-disabled="true">
@@ -31,7 +32,7 @@
         <span ng-if="successfullyAdded" ng-disabled="true"><md-icon>check</md-icon> Added to home</span>
         <span ng-if="addToHomeFailed" ng-disabled="true"><md-icon>error</md-icon> Add to home failed</span>
       </md-button>
-      <md-button ng-click="dismissToast()">
+      <md-button ng-click="dismissToast()" aria-label="not right now">
         <md-icon>close</md-icon>
       </md-button>
     </div>


### PR DESCRIPTION
[MUMUP-3299](https://jira.doit.wisc.edu/jira/browse/MUMUP-3299): As a person viewing an app via /web/exclusive or /web/static who does not yet have that app pinned to my home page, I would like to be able to add that app to my home page while viewing the app, so I can easily get back to the app later.

Also addresses the problem that the toast wasn't working as intended anywhere...

**In this PR**:
- Corrected template URL for custom toast
- Ensured dismissing it persists for session
- Ensured toast doesn't trigger if app already added to home

## Screenshot/Demo
<img width="323" alt="screen shot 2018-02-02 at 3 25 30 pm" src="https://user-images.githubusercontent.com/5818702/35755674-d64cb882-082d-11e8-98ae-12e92d49e6da.png">

![add-to-home](https://user-images.githubusercontent.com/5818702/35755741-1a14df68-082e-11e8-86a2-8baad5650a95.gif)
----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
