### PR TITLE
fix: reflect portal title in header

### DIFF
--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -52,7 +52,7 @@
       <!-- If in separate app -->
       <div ng-if="portal.theme.title != NAMES.title" layout="column" class="title-link__two-lines">
         <a class="title-link__small" ng-href="{{ MISC_URLS.rootURL }}" target="_self" aria-label="{{ portal.theme.ariaLabelTitle }}">
-          MyUW
+          {{ portal.theme.title }}
         </a>
         <h1 class="md-title">{{ NAMES.title }}</h1>
       </div>


### PR DESCRIPTION
Rather than hard-coding "MyUW", use `portal.theme.title`.

Defect:

![defect-hard-coded-myuw](https://user-images.githubusercontent.com/952283/35809788-482f2a5c-0a4f-11e8-9d3c-bfc238be04d4.png)

Fixed:

![fixed-reflect-portal-name](https://user-images.githubusercontent.com/952283/35809648-fa097170-0a4e-11e8-82ea-55aa40ddb911.png)


One tiny step towards `uPortal-app-framework`'s aspirations for adoption beyond MyUW.

I think this is a regression since prior release rather than a fix of a previously existing bug, so no `CHANGELOG.md` update.

(Bug doesn't seem to exist in on-most-recent-release `qa.my.wisc.edu` e.g.)

![bug-not-previously-exist](https://user-images.githubusercontent.com/952283/35809627-e7bbda62-0a4e-11e8-958c-94348274f82c.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
