### PR TITLE
fix: move notification variable to appropriate logical point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ tag with the app icon and title to the page (#684)
 + The `show-add-to-home` attribute on the `<frame-page>` directive now displays
 a dismissible-for-session toast message prompting users to add the app to their
 home page, instead of a button. (#684)
++ `vm.showMessagesFeatures` variable moved out of default and into more 
+logically appropriate spot (#694)
 
 ### Fixed
 

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -132,7 +132,8 @@ define(['angular'], function(angular) {
           $scope.messages = {};
 
           mainService.isGuest().then(function(isGuest) {
-            if (!isGuest && SERVICE_LOC.messagesURL) {
+            if (!isGuest && SERVICE_LOC.messagesURL &&
+              SERVICE_LOC.messagesURL.length > 0) {
               $scope.showMessagesFeatures = true;
               getMessages();
             }
@@ -176,7 +177,6 @@ define(['angular'], function(angular) {
         vm.status = 'View notifications';
         vm.isLoading = true;
         vm.renderLimit = 3;
-        vm.showMessagesFeatures = true;
         vm.titleLengthLimit = 140;
 
         // //////////////////
@@ -227,6 +227,7 @@ define(['angular'], function(angular) {
         var configureNotificationsScope = function() {
           if ($scope.$parent.messages.notifications) {
             allNotifications = $scope.$parent.messages.notifications;
+            vm.showMessagesFeatures = true;
             // Get seen message IDs, then configure scope
             $q.all(promiseSeenMessageIds)
               .then(getSeenMessageIdsSuccess)


### PR DESCRIPTION
moved showMessagesFeatures variable setting out of default, thus fixing a localhost bug

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [X] Updates `CHANGELOG.md` to reflect this PR's change.
- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
