### PR TITLE
WIP: fix: "Skip to main content" skip closer to main content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ logically appropriate spot (#694)
 
 ### Fixed
 
++ "Skip to main content" link now skips more repeated navigation to reach
+closer to the main content.
 + Label widget cover dismiss button as "OK" rather than "Continue" (#675)
 
 ## [8.0.0][] - 2018-01-08

--- a/components/portal/main/partials/body.html
+++ b/components/portal/main/partials/body.html
@@ -20,7 +20,8 @@
 -->
 <div class="my-uw" md-theme="{{ portal.theme.name || 'default' }}" tabindex="0" aria-live="polite" aria-atomic="false">
   <div class="skip-to-content">
-    <a href="#main-content">Skip to main content</a>
+    <!-- skips to body of frame-page directive -->
+    <a href="#skip-to-here">Skip to main content</a>
   </div>
   <div class="my-uw-body">
     <portal-header></portal-header>

--- a/components/portal/misc/partials/frame-page.html
+++ b/components/portal/misc/partials/frame-page.html
@@ -29,9 +29,12 @@
       </h1>
       <add-to-home ng-if="appShowAddToHome"></add-to-home>
     </div>
-    <div class="content-wrapper__push-content" ng-if="menuPushContent">
-      <ng-transclude></ng-transclude>
+    <div id="skip-to-here">
+      <div class="content-wrapper__push-content"
+        ng-if="menuPushContent">
+        <ng-transclude></ng-transclude>
+      </div>
+      <ng-transclude ng-if="!menuPushContent"></ng-transclude>
     </div>
-    <ng-transclude ng-if="!menuPushContent"></ng-transclude>
   </div>
 </div>

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -5,6 +5,9 @@
 Frame page should be used for all pages in a uportal-app-framework application. It comes with much of the rest of the framework's skeleton and CSS layout styles built in, including main-menu directives. You should use it as the outermost element for
 each of your application's main views.
 
+`<frame-page>` automatically includes a div with the `skip-to-here` id,
+targeted by the "Skip to main content" link included in the body template.
+
 ### Template:
 
 ```html


### PR DESCRIPTION
Problem being solved: existing "Skip to main content" link doesn't skip enough of the header stuff, leaving the user with more stuff to step through before reaching the main content.

Solution:

+ Invents a new `skip-to-here` ID closer to what a user would regard as the beginning of the main content, in the `frame-page` directive.
+ Changes the "Skip to main content" link to link to that ID.

Locally tested using `npm run static:dev`, but the proof will be in seeing `uPortal-home` built on a `uPortal-app-framework` with this change.

WIP because I'm seeing a lot of header vertical space that I'd like to prove this didn't cause before offering this for merge.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
