### PR TITLE
docs(changelog): de-emphasize meta change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ closer to the main content.
 
 ### Breaking Changes
 
-+ Moves the data object in messages out of the audience object and into a separate
-object.  This will affect installations that have configured a messages.json
-file. (#649)
++ Moves the data object in messages out of the audience object and into a
+separate object.  This will affect installations that have configured a
+messages.json file. (#649)
 
 ### Added
 
@@ -85,10 +85,12 @@ Updates to the side navigation feature in this release introduce a hard
 dependency on the `<frame-page>` directive for unbroken menu experience (#588).
 
 **If upgrading from 6.1.0**
-and the application already configures side navigation (by setting values for either
-`appMenuTemplateURL` or `appMenuItems` in `override.js`), every main
+and the application already configures side navigation (by setting values for
+either `appMenuTemplateURL` or `appMenuItems` in `override.js`), every main
 view in the app must use the `<frame-page>` directive as its outermost container
-element. Applications that have not previously configured side navigation and do not begin using side navigation with this upgrade should not be affected by this change.
+element. Applications that have not previously configured side navigation and
+do not begin using side navigation with this upgrade should not be affected by
+this change.
 
 There are also CSS changes to the layout container elements that precede the
 `<ng-view>` element (where the app's on-page content is pulled in) to prefer a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,7 @@ tag with the app icon and title to the page (#684)
 
 ### Changed
 
-+ `<frame-page>` existing `app-title` attribute now used to set document title
-(#682)
++ `<frame-page>` sets document title per existing `app-title` attribute (#682)
 + The `show-add-to-home` attribute on the `<frame-page>` directive now displays
 a dismissible-for-session toast message prompting users to add the app to their
 home page, instead of a button. (#684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,6 @@ messages.json file. (#649)
 
 ### Added
 
-+ add documentation stating intent to use Conventional commits and tips on how
-to comply (#634)
 + track clicks on sidenav footer links (#642)
 + add documentation clarifying major upgrades (#647)
 + add the ability to set message title via an external data source (#649)
@@ -60,13 +58,7 @@ source (#649)
 
 ### Changed
 
-+ leverage commitlint travis helper (#621)
-+ update to latest version (6.0.0) of lint-staged (#631)
 + update documentation to read more and state intent more clearly (#632)
-+ move some git commit hooks to be optionally installed (#635)
-+ suppress `eslint` on `docs/` when linting staged changes (#636)
-+ require npm 5.6.0 or higher (#644)
-+ resolved appveyor require.js flakiness (#645)
 + update to latest version (2.0) of karma (#652)
 
 ### Fixed
@@ -76,6 +68,17 @@ source (#649)
 + allow priority notification buttons to display full button text (#640)
 + catch localStorage error with IE (#643)
 + implemented filter messages by date (#650)
+
+### Build engineering
+
++ add documentation stating intent to use Conventional commits and tips on how
+to comply (#634)
++ leverage commitlint travis helper (#621)
++ update to latest version (6.0.0) of lint-staged (#631)
++ move some git commit hooks to be optionally installed (#635)
++ suppress `eslint` on `docs/` when linting staged changes (#636)
++ require npm 5.6.0 or higher (#644)
++ resolved appveyor require.js flakiness (#645)
 
 ## [7.0.0][] - 2017-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ a dismissible-for-session toast message prompting users to add the app to their
 home page, instead of a button. (#684)
 + `vm.showMessagesFeatures` variable moved out of default and into more 
 logically appropriate spot (#694)
-+ External links in mascot announcements now work again. (#697)
 
 ### Fixed
 
++ External links in mascot announcements now work again. (#697)
 + "Skip to main content" link now skips more repeated navigation to reach
 closer to the main content.
 + Label widget cover dismiss button as "OK" rather than "Continue" (#675)


### PR DESCRIPTION
This change: Reserve "Added" and "Changed" for features *of the product* added and changed. Move stuff about commit message style, linting, build automation, dependencies, etc. to a "Build engineering" section.

Context:

I was trying to put together the agenda for today's incubation check-in call, and found the `CHANGELOG.md` just a bit too noisy, not focusing enough on what changed *in the product*. KeepAChangeLog.com literally specifies just six categories of change to log, "Release engineering" not among them. But in spirit it's about "Changelogs are for humans not machines", and I think they're primarily for *adopter* humans. I think this change better addresses that spirit.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change. (Doesn't, actually. Rather this PR is about updating the CHANGELOG. :smile:
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
