### PR TITLE
style: improve appearance of add-to-home toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ a dismissible-for-session toast message prompting users to add the app to their
 home page, instead of a button. (#684)
 + `vm.showMessagesFeatures` variable moved out of default and into more
 logically appropriate spot (#694)
++ Improved appearance of add-to-home toast message (#706)
 
 ### Fixed
 

--- a/components/css/buckyless/directives/add-to-home.less
+++ b/components/css/buckyless/directives/add-to-home.less
@@ -30,6 +30,10 @@ add-to-home {
         .material-icons {
           color: @white;
         }
+
+        md-progress-circular {
+          margin: auto;
+        }
       }
     }
   }

--- a/components/portal/misc/partials/toast-add-to-home.html
+++ b/components/portal/misc/partials/toast-add-to-home.html
@@ -20,18 +20,18 @@
 -->
 <md-toast>
   <div class="md-toast-content">
-    <span class="md-toast-text" flex>Add to home?</span>
+    <span class="md-toast-text" ng-if="!successfullyAdded && !addToHomeFailed && !savingAddToHome" flex>Add to home?</span>
+    <span class="md-toast-text" ng-if="savingAddToHome && !successfullyAdded && !addToHomeFailed">Adding to home</span>
+    <span class="md-toast-text" ng-if="successfullyAdded"><md-icon>check</md-icon> Added to home</span>
+    <span class="md-toast-text" ng-if="addToHomeFailed"><md-icon>error</md-icon> Add to home failed</span>
     <div layout="row">
       <md-button ng-click="addToHome()"
                  aria-label="Add this app to home"
-                 class="md-raised md-accent">
-        <span ng-if="!successfullyAdded && !addToHomeFailed && !savingAddToHome"><md-icon>add</md-icon> Add</span>
-        <span ng-if="!successfullyAdded && !addToHomeFailed && savingAddToHome" ng-disabled="true">
-        <i class="fa fa-fw fa-spin fa-circle-o-notch" ng-show="savingAddToHome"></i>
-      </span>
-        <span ng-if="successfullyAdded" ng-disabled="true"><md-icon>check</md-icon> Added to home</span>
-        <span ng-if="addToHomeFailed" ng-disabled="true"><md-icon>error</md-icon> Add to home failed</span>
+                 class="md-raised md-accent"
+                 ng-if="!successfullyAdded && !addToHomeFailed && !savingAddToHome">
+        <span>Okay</span>
       </md-button>
+      <md-progress-circular ng-if="savingAddToHome && !successfullyAdded && !addToHomeFailed" md-mode="indeterminate" md-diameter="30px"></md-progress-circular>
       <md-button ng-click="dismissToast()" aria-label="not right now">
         <md-icon>close</md-icon>
       </md-button>


### PR DESCRIPTION
**In this PR**:
- Make toast message less cluttered by moving conditional text into toast text instead of into the button

### Screenshots
![screen shot 2018-02-27 at 11 09 58 am](https://user-images.githubusercontent.com/5818702/36744165-bb87b794-1bb1-11e8-9273-d2a6d5e9c346.png)
![screen shot 2018-02-27 at 11 29 55 am](https://user-images.githubusercontent.com/5818702/36744166-bb9ce024-1bb1-11e8-9d92-d7ecea3ae05b.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
