### PR TITLE
feat: trap focus order within opened side navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This may require minor layout/appearance adjustments in the template. (#684)
 + `mainService` now offers `computeWindowTitle(...)` (#679)
 + `<frame-page>` directive now offers `page-title` attribute to add a `<h1>`
 tag with the app icon and title to the page (#684)
++ When side navigation is open, keyboard focus will remain inside the menu and 
+cycle through menu options until it's closed (#707)
 
 ### Changed
 

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -217,19 +217,27 @@ define(['angular', 'require'], function(angular, require) {
       vm.openMenuByDefault = false;
       vm.showMessagesFeatures = true;
 
+      /**
+       * Listen for unseen notifications
+       */
       $scope.$on('HAS_PRIORITY_NOTIFICATIONS', function(event, data) {
         if (angular.isDefined(data.hasNotifications)) {
           vm.hasPriorityNotifications = data.hasNotifications;
         }
       });
 
+      /**
+       * Listen for unseen announcements
+       */
       $scope.$on('HAS_UNSEEN_ANNOUNCEMENTS', function(event, data) {
         if (angular.isDefined(data.hasNotifications)) {
           vm.hasUnseenAnnouncements = data.hasAnnouncements;
         }
       });
 
-      // Close side nav on scroll to avoid awkward UI
+      /**
+       * Close side nav on scroll to avoid awkward interaction
+       */
       $window.onscroll = function() {
         if (vm.isMenuOpen() && !$mdMedia('gt-sm')) {
           vm.closeMainMenu();
@@ -250,6 +258,27 @@ define(['angular', 'require'], function(angular, require) {
       vm.closeMainMenu = function() {
         if (vm.isMenuOpen()) {
           $mdSidenav('main-menu').close();
+        }
+      };
+
+      /**
+       * Intercept focus when it would move outside the side nav,
+       * then reset it to the desired position within the side nav.
+       * @param {object} event
+       * @param {string} position
+       */
+      vm.trapFocus = function(event, position) {
+        var anchor = angular.element('.main-menu__focus-anchor' + position);
+        // Check if screen size is greater than small
+        if ($mdMedia('gt-sm')) {
+          // Don't trap focus if push content is enabled
+          if (!APP_OPTIONS.enablePushContentMenu) {
+            event.preventDefault();
+            anchor.focus();
+          }
+        } else {
+          event.preventDefault();
+          anchor.focus();
         }
       };
 

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -18,11 +18,13 @@
     under the License.
 
 -->
+<div class="main-menu__focus-trap" ng-focus="vm.trapFocus($event, '-bottom')" tabindex="0"></div>
 <md-sidenav class="md-sidenav-left main-menu__sidenav"
             md-component-id="main-menu"
             md-is-open="vm.openMenuByDefault"
             md-whiteframe="4"
             ng-hide="vm.hideMainMenu">
+  <div class="main-menu__focus-anchor-top" tabindex="0" md-autofocus></div>
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
     <md-button href="features"
                ng-if="vm.hasUnseenAnnouncements && vm.showMessagesFeatures"
@@ -73,4 +75,6 @@
   <div class="links-separated">
     <a ng-repeat="link in vm.footerLinks" ng-href="{{ link.url }}" target="{{ link.target }}" rel="noopener noreferrer" ng-click="vm.pushGAEvent('sidenav-footer-link', link.title, link.url)">{{ link.title }}</a>
   </div>
+  <div class="main-menu__focus-anchor-bottom" tabindex="0"></div>
 </md-sidenav>
+<div class="main-menu__focus-trap" ng-focus="vm.trapFocus($event, '-top')" tabindex="0"></div>


### PR DESCRIPTION
[MUMUP-3295](https://jira.doit.wisc.edu/jira/browse/MUMUP-3295): "As a person navigating MyUW via keyboard, I would like focus to remain in (cycle through) the open hamburger menu until I dismiss the menu, so that the menu is more usable and so that my navigation is less confusing."

**In this PR**:
- When normal side navigation menu (i.e. _not_ push-content version) is open, keyboard navigation is trapped within the menu
- Tabbing past the bottom-most item results in focus resuming at the top-most item, and vice versa


### Demo
![sidenav-trap](https://user-images.githubusercontent.com/5818702/36914209-1d54c4f0-1e12-11e8-82aa-fd2f43553dd3.gif)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
