### PR TITLE
fix: Corrected name of optional configuration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 + Core Infrastructure Initiative badge (#711)
 
+### Fixed
+
++ Fixed widget in-app messagge example (#714)
+
 ## [9.0.0][] - 2018-3-7
 
 ### Breaking changes

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -136,7 +136,7 @@ Example widget configuration
     <value>["result", 0, "message"]</value>
 </portlet-preference>
 <portlet-preference>
-    <name>widgetURL</name>
+    <name>widgetExternalMessageLearnMoreUrl</name>
     <value>["learnMoreUrl"]</value>
 </portlet-preference>
 


### PR DESCRIPTION
The example referenced widgetURL but should really reference widgetExternalMessageLearnMoreUrl.
----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
