### PR TITLE
feat: log bad dynamic response on dynamic list-of-links failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
++ Logs the dynamic list-of-links response in some dynamic list-of-links error
+  cases (#715)
 + Core Infrastructure Initiative badge (#711)
 
 ### Fixed

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -43,6 +43,10 @@ define(['angular', 'moment'], function(angular, moment) {
           if (widget.widgetConfig.getLinksURL) {
             widgetService.getWidgetJson(widget).then(
               function(links) {
+                if (!(links.content && links.content.links)) {
+                  $log.warn('Undefined dynamic links content for '
+                  + widget.fname + ': dynamic response was [' + links + ']');
+                }
                 widget.widgetConfig.links = links.content.links;
                 return links.content.links;
               })


### PR DESCRIPTION
Adding the logging I think I wish I'd had to support dynamic `list-of-links` troubleshooting.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
