### PR TITLE
feat: add circle-button tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,26 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 * Adds resetters to user-settings page (#724)
+* `circle-button` now offers tooltip with full title when title is truncated
+  (#727)
 
 ### Changed
 
+* Out of the box example `list-of-links` widget now more self-documenting (#727)
 
 ### Fixed
 
+* `circle-button` no longer truncates `aria-label` representation of title
+  (#727)
 
 ### Build engineering
 
 
 ### Documentation
 
+* DEPRECATED: Font Awesome icons for `list-of-links` links. Use Material Icons
+  instead. (#727)
+* Modest improvements to `list-of-links` widget type documentation (#727)
 
 ## [9.0.0][] - 2018-3-21
 

--- a/components/portal/misc/partials/circle-button.html
+++ b/components/portal/misc/partials/circle-button.html
@@ -26,6 +26,10 @@
            ng-disabled="cbDisabled">
   <md-icon ng-if="mdIcon" aria-label="">{{ mdIcon }}</md-icon>
   <i ng-if="faIcon && !mdIcon" class="fa {{ faIcon }}" aria-hidden="true"></i>
+  <md-tooltip ng-if="title.length > trunclen"
+    md-direction="top">
+    {{ title }}
+  </md-tooltip>
 </md-button>
 <p ng-show="title">
   {{title | truncate:trunclen}}

--- a/components/portal/misc/partials/circle-button.html
+++ b/components/portal/misc/partials/circle-button.html
@@ -22,7 +22,7 @@
            target="{{cbDisabled ? '' : target}}"
            rel='noopener noreferrer'
            class="md-icon-button md-accent md-raised"
-           aria-label="open {{title | truncate:trunclen}}"
+           aria-label="open {{ title }}"
            ng-disabled="cbDisabled">
   <md-icon ng-if="mdIcon" aria-label="">{{ mdIcon }}</md-icon>
   <i ng-if="faIcon && !mdIcon" class="fa {{ faIcon }}" aria-hidden="true"></i>

--- a/components/staticFeeds/list-of-links-via-url.json
+++ b/components/staticFeeds/list-of-links-via-url.json
@@ -13,7 +13,13 @@
                 "href": "https://public.my.wisc.edu/widget-creator/",
                 "title": "Make one",
                 "target": "_blank"
-            }
+            },
+            {
+              "icon": "short_text",
+              "href": "https://www.example.edu",
+              "title": "Truncates excessively long titles",
+              "target": "_blank"
+          }
         ]
     }
 }

--- a/components/staticFeeds/list-of-links-via-url.json
+++ b/components/staticFeeds/list-of-links-via-url.json
@@ -3,15 +3,15 @@
     "content": {
         "links": [
             {
-                "icon": "fa-at",
-                "href": "https://www.google.com",
-                "title": "THIS IS GOOGLE",
+                "icon": "fa-book",
+                "href": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#list-of-links",
+                "title": "Learn more",
                 "target": "_blank"
             },
             {
-                "icon": "mail_outline",
-                "href": "http://www.lonelyplanet.com",
-                "title": "Go Places",
+                "icon": "create",
+                "href": "https://public.my.wisc.edu/widget-creator/",
+                "title": "Make one",
                 "target": "_blank"
             }
         ]

--- a/components/staticFeeds/sample-widget__list-of-links.json
+++ b/components/staticFeeds/sample-widget__list-of-links.json
@@ -1,14 +1,14 @@
 {
   "entry": {
-    "canAdd": false,
+    "canAdd": true,
     "layoutObject": {
       "nodeId": "-1",
-      "title": "Learning and Talent Development",
-      "description": "View professional development opportunities for faculty and staff on the UW-Madison campus.",
-      "url": "https://www.ohrd.wisc.edu/Catalog/Default.aspx",
+      "title": "List of Links widget type",
+      "description": "Convenient access to up to seven hyperlinks, sourced from widget configuration or from URL",
+      "url": "staticFeeds/list-of-links-via-url.json",
       "iconUrl": null,
       "faIcon": "fa-briefcase",
-      "fname": "my-professional-development",
+      "fname": "list-of-links-type",
       "lifecycleState": "PUBLISHED",
       "target": null,
       "widgetURL": "/staticFeeds/list-of-links-via-url.json",
@@ -16,34 +16,28 @@
       "widgetTemplate": null,
       "widgetConfig": {
         "getLinksURL": "true",
-        "launchText": "Launch talent development"
+        "launchText": "View widget JSON"
       },
       "widgetExternalMessageUrl": "/staticFeeds/sample-widget_message.json",
       "widgetExtneralMessageTextObjectLocation": ["result", 0, "message"],
       "widgetExternalMessageLearnMoreUrl": ["learnMoreUrl"],
-      "staticContent": "\n            <div>\n                <p><a href='https://www.ohrd.wisc.edu/Catalog/Default.aspx' target='_blank'>Search for talent development opportunities</a></p>\n            </div>        \n            \n        ",
-      "pithyStaticContent": null,
+      "staticContent": "<div><p>Static content goes here.</p></div>",
       "altMaxUrl": true,
       "renderOnWeb": false
     },
     "categories": [
-      "Work"
+      "Widget types"
     ],
     "portletName": "cms",
-    "title": "Learning and Talent Development",
+    "title": "List of Links widget type",
     "keywords": [
-      "development",
-      "learning",
-      "opportunities",
-      "transcript",
-      "professional",
-      "faculty",
-      "staff",
-      "work record",
-      "talent",
-      "my professional development"
+      "list",
+      "links",
+      "ordered",
+      "icons",
+      "few"
     ],
-    "fname": "my-professional-development",
+    "fname": "list-of-links-type",
     "rating": 0.0,
     "lifecycleState": "PUBLISHED",
     "portletReleaseNotes": {
@@ -51,15 +45,15 @@
       "initialReleaseDate": null,
       "releaseNotes": null
     },
-    "renderUrl": "https://www.ohrd.wisc.edu/Catalog/Default.aspx",
+    "renderUrl": "https://www.example.edu",
     "portletWebAppName": "/SimpleContentPortlet",
-    "maxUrl": "https://www.ohrd.wisc.edu/Catalog/Default.aspx",
+    "maxUrl": "https://www.example.edu",
     "shortUrl": null,
     "marketplaceScreenshots": [],
     "userRated": 0,
     "faIcon": "fa-briefcase",
-    "description": "View professional development opportunities for faculty and staff on the UW-Madison campus.",
-    "name": "Learning and Talent Development",
+    "description": "Convenient access to up to seven hyperlinks, sourced from widget configuration or from URL",
+    "name": "List of Links widget type",
     "id": "76",
     "type": "Portlet",
     "target": null

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -140,6 +140,17 @@ Follow these steps for each of the predefined widget types described in this doc
 </portlet-preference>
 ```
 
+#### Icons
+
+Preferred: icons are Material Icons, referenced like `invert_colors` (lowercase,
+no prefix, underscores in place of spaces. )
+
+Deprecated: icons can be Font Awesome icons, referenced like `fa-envelope-o`
+(lowercase, `fa-` prefix, dashes as is typical for Font Awesome references).
+
+Using both Material and Font Awesome icons together can yield visual
+misalignment of the link icons.
+
 #### Sourcing list of links content from a URL
 
 The `list-of-links` content can be stored directly in `widgetConfig`, as above.


### PR DESCRIPTION
Modest `list-of-links` quality of life improvements identified in the course of recently working on a list-of-links widget.

![list-of-links-with-tooltip](https://user-images.githubusercontent.com/952283/37913821-6ab8ba36-30db-11e8-91c0-edf236d7994b.png)

* **Formally deprecate Font Awesome icons in the context of `list-of-links`.**
* Accessibility improvement: don't truncate the `aria-label` view on the link title. Truncation navigates the tradeoffs of the visual effect of excessively long titles. In the case of a non-visual browser, this tradeoff should be navigated differently, in favor of the fuller title of what the thing is that's linked.
* Feature: add tooltip on `circle-button` offering the full link title in the case where the visual display of the title is truncated.
* Document `icon` in the context of `list-of-links` widget. (Also responsive to recent @jimhelwig feedback about the limitations of documentation-solely-by-example).
* Improve out-of-the-box `list-of-links` example to be less random content copied from MyUW and more about `list-of-links`, including demonstrating link title truncation.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
