### PR TITLE
docs: demo ampersand in list-of-links link title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-* Out of the box example `list-of-links` widget now more self-documenting (#727)
+* Out of the box example `list-of-links` widget now more self-documenting 
+  (#727, #729)
 
 ### Fixed
 

--- a/components/staticFeeds/list-of-links-via-url.json
+++ b/components/staticFeeds/list-of-links-via-url.json
@@ -11,7 +11,7 @@
             {
                 "icon": "create",
                 "href": "https://public.my.wisc.edu/widget-creator/",
-                "title": "Make one",
+                "title": "Make & experiment",
                 "target": "_blank"
             },
             {

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -194,6 +194,12 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
         "icon": "fa-calendar-times-o",
         "target": "_blank",
         "title": "Production"
+      },
+      {
+        "href": "https://it.wisc.edu/services/myuw",
+        "icon": "fa-calendar-times-o",
+        "target": "_blank",
+        "title": "Learn more & make contact"
       }
     ]
   }


### PR DESCRIPTION
Demonstrate that a bare ampersand in the `list-of-links` JSON is just fine.

![bare-ampersand-is-fine](https://user-images.githubusercontent.com/952283/38060790-ec8e6f88-32b1-11e8-8ad9-1ebec91e002f.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
