### PR TITLE
fix: iterate through messages rather than filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 * Out of the box example `list-of-links` widget now more self-documenting 
-  (#727, #729)
+  (#727, #729)  
 
 ### Fixed
 
 * `circle-button` no longer truncates `aria-label` representation of title
   (#727)
+* Message filtering now more precise (#730)
 
 ### Build engineering
 

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -113,16 +113,13 @@ define(['angular'], function(angular) {
                       if (!added) {
                         // Check for matches against the groups returned
                         // by portalGroupService
-                        var intersectedGroups = $filter('filter')(
-                          groups,
-                          {name: messageGroup}
-                        );
-                        if (intersectedGroups && intersectedGroups.length > 0) {
-                          // If user is in this group, he should see this
-                          // notification
-                          messagesByGroup.push(message);
-                          added = true;
-                        }
+                        angular.forEach(groups,
+                          function(group) {
+                            if (!added && (group.name === messageGroup)) {
+                              messagesByGroup.push(message);
+                              added = true;
+                            }
+                          });
                       }
                     });
                 } else {


### PR DESCRIPTION
When filtering messages where one group name is a substring of another group name (e.g. "HRS Accessible Users" is a substring of "UW System HRS Accessible Users") - a bug exists where members of the longer group will also see messages intended only for members of the shorter group. 

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [X] Updates `CHANGELOG.md` to reflect this PR's change.
- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
