### PR TITLE
fix: handle zero-links edge case in list-of-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
+### Fixed
+
+* `list-of-links` widgets are `basic` widgets in the zero links edge case.
+
 ## [9.0.2][] - 2018-3-30
 
 This release is to mop up some weirdness which happened with 9.0.1 and get a clean artifact.

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -42,6 +42,9 @@
         <widget fname="sample-widget__list-of-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__list-of-no-links"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__search-with-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -18,10 +18,24 @@
     under the License.
 
 -->
-<div class="widget-body list-of-links">
+<!-- ZERO LINKS: emulate a basic widget -->
+<div ng-show="config.links.length == 0">
+  <a tabindex="-1"
+    ng-href="{{ widget.url }}"
+    target="{{ widget.target ? widget.target : '_self' }}"
+    rel="noopener noreferrer"
+    class="basic-widget">
+    <div class="widget-icon-container"
+      layout="column" layout-align="center center">
+      <widget-icon></widget-icon>
+    </div>
+  </a>
+</div>
+
+<div class="widget-body list-of-links" ng-show="config.links.length > 0">
 
   <!-- FOUR LINKS OR LESS -->
-  <div ng-show="config.links.length <= 4" class="list-of-links__{{config.links.length}}">
+  <div ng-show="config.links.length > 0 && config.links.length <= 4" class="list-of-links__{{config.links.length}}">
     <circle-button ng-if="item.icon.indexOf('fa-') > -1"
                    ng-repeat="item in config.links"
                    data-href="{{item.href}}"

--- a/components/staticFeeds/list-of-no-links-via-url.json
+++ b/components/staticFeeds/list-of-no-links-via-url.json
@@ -1,0 +1,6 @@
+{
+    "result": "ok",
+    "content": {
+        "links": []
+    }
+}

--- a/components/staticFeeds/sample-widget__list-of-no-links.json
+++ b/components/staticFeeds/sample-widget__list-of-no-links.json
@@ -1,0 +1,61 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "List of Links widget type with no links",
+      "description": "Demonstrates list-of-links edge case of zero links.",
+      "url": "staticFeeds/list-of-no-links-via-url.json",
+      "iconUrl": null,
+      "faIcon": "fa-briefcase",
+      "fname": "list-of-links-type-zero-links",
+      "lifecycleState": "PUBLISHED",
+      "target": null,
+      "widgetURL": "/staticFeeds/list-of-no-links-via-url.json",
+      "widgetType": "list-of-links",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "getLinksURL": "true",
+        "launchText": "View widget JSON"
+      },
+      "widgetExternalMessageUrl": "/staticFeeds/sample-widget_message.json",
+      "widgetExtneralMessageTextObjectLocation": ["result", 0, "message"],
+      "widgetExternalMessageLearnMoreUrl": ["learnMoreUrl"],
+      "staticContent": "<div><p>Static content goes here.</p></div>",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "categories": [
+      "Widget types",
+      "Edge cases"
+    ],
+    "portletName": "cms",
+    "title": "List of Links widget type with no links",
+    "keywords": [
+      "list",
+      "links",
+      "ordered",
+      "icons",
+      "zero"
+    ],
+    "fname": "list-of-links-type-zero-links",
+    "rating": 0.0,
+    "lifecycleState": "PUBLISHED",
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://www.example.edu",
+    "portletWebAppName": "/SimpleContentPortlet",
+    "maxUrl": "https://www.example.edu",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 0,
+    "faIcon": "fa-briefcase",
+    "description": "Demonstrates list-of-links edge case of zero links.",
+    "id": "37",
+    "type": "Portlet",
+    "target": null
+  }
+}

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -212,7 +212,8 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
 when there's nothing more to launch, that is, when the list-of-links widget simply presents all the intended links and that's all there is to it.
 * Avoid using a `list-of-links` widget when you only need to display one link. Instead, use the name and `alternativeMaximizedLink` of [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory) to represent the link.
 This provides a more usable click surface, a simpler and cleaner user experience, and achieves better consistency with other just-a-link widgets in MyUW.
-* The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive.
+* The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive. A `list-of-links` widget with zero links presents
+as a basic widget.
 * Use sentence case in the titles of the links.
 
 ### Search with links


### PR DESCRIPTION
`list-of-links` widgets can be configured with an array of zero links. This is especially plausible when sourcing the list of links from a dynamic remote feed (and indeed actually happens in representing HRS Portlet roles as a list-of-links).

Handle this case, degrading gracefully to present `list-of-links` widgets with zero internal links as `basic` widgets.

Before: blank widget face.

After (demo included in localhost example set):

![list-of-no-links](https://user-images.githubusercontent.com/952283/38226857-323519d4-36c1-11e8-9000-157c9973ae9e.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
