### PR TITLE
feat: list-of-links tooltip when link truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
+### Added
+
+* `list-of-links` now offers tooltip with full title when it truncates any link
+  title, not just those presented via `circle-button`s (#736)
+
 ### Fixed
 
 * `list-of-links` now `aria-label`s links, ensuring a non-truncated version of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * `list-of-links` no longer truncates `aria-label` representation of link title
+  (#736)
 
 ## [9.0.2][] - 2018-3-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
+### Fixed
+
+* `list-of-links` no longer truncates `aria-label` representation of link title
+
 ## [9.0.2][] - 2018-3-30
 
 This release is to mop up some weirdness which happened with 9.0.1 and get a clean artifact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* `list-of-links` no longer truncates `aria-label` representation of link title
-  (#736)
+* `list-of-links` now `aria-label`s links, ensuring a non-truncated version of
+  the link label is available to browsers (#736)
 
 ## [9.0.2][] - 2018-3-30
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -42,6 +42,9 @@
         <widget fname="sample-widget__list-of-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__list-of-8-links"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__search-with-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -53,6 +53,10 @@
           target="{{item.target}}" rel="noopener noreferrer">
           {{item.title | truncate:24}}
         </a>
+        <md-tooltip ng-if="item.title.length > 24"
+          md-direction="top">
+          {{ item.title }}
+        </md-tooltip>
       </li>
     </ul>
   </div>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -48,7 +48,9 @@
       <li ng-repeat='item in config.links | limitTo: 7' class="link-icon">
         <i ng-if="item.icon.indexOf('fa-') > -1" class="fa {{item.icon}}"></i>
         <md-icon ng-if="item.icon.indexOf('fa-') <= -1">{{item.icon}}</md-icon>
-        <a ng-href="{{item.href}}" target="{{item.target}}" rel="noopener noreferrer">
+        <a aria-label="{{ item.title }}"
+          ng-href="{{item.href}}"
+          target="{{item.target}}" rel="noopener noreferrer">
           {{item.title | truncate:24}}
         </a>
       </li>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -53,8 +53,7 @@
           target="{{item.target}}" rel="noopener noreferrer">
           {{item.title | truncate:24}}
         </a>
-        <md-tooltip ng-if="item.title.length > 24"
-          md-direction="top">
+        <md-tooltip ng-if="item.title.length > 24">
           {{ item.title }}
         </md-tooltip>
       </li>

--- a/components/staticFeeds/list-of-8-links-via-url.json
+++ b/components/staticFeeds/list-of-8-links-via-url.json
@@ -1,0 +1,55 @@
+{
+  "result": "ok",
+  "content": {
+    "links": [
+      {
+        "icon": "create",
+        "href": "https://www.apereo.org/projects/uportal",
+        "title": "uPortal website",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#list-of-links",
+        "title": "uPortal manual",
+        "target": "_blank"
+      },
+      {
+        "icon": "short_text",
+        "href": "https://www.example.edu",
+        "title": "Truncates excessively long titles",
+        "target": "_blank"
+      },
+      {
+        "icon": "create",
+        "href": "https://www.apereo.org/projects/uportal",
+        "title": "uPortal website",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#list-of-links",
+        "title": "uPortal manual",
+        "target": "_blank"
+      },
+      {
+        "icon": "short_text",
+        "href": "https://www.example.edu",
+        "title": "Truncates excessively long titles",
+        "target": "_blank"
+      },
+      {
+        "icon": "create",
+        "href": "https://www.apereo.org/projects/uportal",
+        "title": "uPortal website",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#list-of-links",
+        "title": "uPortal manual",
+        "target": "_blank"
+      }
+    ]
+  }
+}

--- a/components/staticFeeds/sample-widget__list-of-8-links.json
+++ b/components/staticFeeds/sample-widget__list-of-8-links.json
@@ -1,0 +1,61 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "List of (many) Links widget type",
+      "description": "Demonstrates presentation when seven or more links",
+      "url": "staticFeeds/list-of-8-links-via-url.json",
+      "iconUrl": null,
+      "faIcon": "fa-briefcase",
+      "fname": "list-of-links-type",
+      "lifecycleState": "PUBLISHED",
+      "target": null,
+      "widgetURL": "/staticFeeds/list-of-8-links-via-url.json",
+      "widgetType": "list-of-links",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "getLinksURL": "true",
+        "launchText": "View widget JSON"
+      },
+      "widgetExternalMessageUrl": "/staticFeeds/sample-widget_message.json",
+      "widgetExtneralMessageTextObjectLocation": ["result", 0, "message"],
+      "widgetExternalMessageLearnMoreUrl": ["learnMoreUrl"],
+      "staticContent": "<div><p>Static content goes here.</p></div>",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "categories": [
+      "Widget types"
+    ],
+    "portletName": "cms",
+    "title": "List of (many) Links widget type",
+    "keywords": [
+      "list",
+      "links",
+      "ordered",
+      "icons",
+      "many"
+    ],
+    "fname": "list-of-links-type",
+    "rating": 0.0,
+    "lifecycleState": "PUBLISHED",
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://www.example.edu",
+    "portletWebAppName": "/SimpleContentPortlet",
+    "maxUrl": "https://www.example.edu",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 0,
+    "faIcon": "fa-briefcase",
+    "description": "Demonstrates presentation when seven or more links",
+    "name": "List of Links widget type",
+    "id": "763",
+    "type": "Portlet",
+    "target": null
+  }
+}

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -221,7 +221,8 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
 * The length of your list of links will affect the widget's appearance. If you
   have more than 4 links, they will be displayed in a more traditional-style
   list, rather than with the `<circle-button>` directive.
-* Use sentence case in the titles of the links.
+* Use brief sentence-case link titles. `list-of-links` truncates link titles to
+  24 characters.
 
 ### Search with links
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -208,11 +208,19 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
 
 #### Guidance
 
-* `launchText` is optional. Omitting `launchText` suppresses the launch button at the bottom of the list-of-links widget. This is appropriate
-when there's nothing more to launch, that is, when the list-of-links widget simply presents all the intended links and that's all there is to it.
-* Avoid using a `list-of-links` widget when you only need to display one link. Instead, use the name and `alternativeMaximizedLink` of [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory) to represent the link.
-This provides a more usable click surface, a simpler and cleaner user experience, and achieves better consistency with other just-a-link widgets in MyUW.
-* The length of your list of links will affect the widget's appearance. If you have more than 4 links, they will be displayed in a more traditional-style list, rather than with the `<circle-button>` directive.
+* `launchText` is optional. Omitting `launchText` suppresses the launch button
+  at the bottom of the list-of-links widget. This is appropriate when there's
+  nothing more to launch, that is, when the list-of-links widget simply presents
+  all the intended links and that's all there is to it.
+* Avoid using a `list-of-links` widget when you only need to display one link.
+  Instead, use the name and `alternativeMaximizedLink` of
+  [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory)
+  to represent the link. This provides a more usable click surface, a simpler
+  and cleaner user experience, and achieves better consistency with other
+  just-a-link widgets in MyUW.
+* The length of your list of links will affect the widget's appearance. If you
+  have more than 4 links, they will be displayed in a more traditional-style
+  list, rather than with the `<circle-button>` directive.
 * Use sentence case in the titles of the links.
 
 ### Search with links

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -107,7 +107,8 @@ Follow these steps for each of the predefined widget types described in this doc
 
 #### When to use
 
-* You only need your widget to display a list of 2-7 links
+Use `list-of-links` to present 2 to 7 links, dynamically sourced or statically
+configured.
 
 #### Additional entity file configuration
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -208,19 +208,19 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
 
 #### Guidance
 
-* `launchText` is optional. Omitting `launchText` suppresses the launch button
+* Omitting `launchText` suppresses the launch button
   at the bottom of the list-of-links widget. This is appropriate when there's
-  nothing more to launch, that is, when the list-of-links widget simply presents
+  nothing more to launch, that is, when the list-of-links widget presents
   all the intended links and that's all there is to it.
-* Avoid using a `list-of-links` widget when you only need to display one link.
+* Avoid using a `list-of-links` widget to display one link.
   Instead, use the name and `alternativeMaximizedLink` of
   [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory)
   to represent the link. This provides a more usable click surface, a simpler
   and cleaner user experience, and achieves better consistency with other
   just-a-link widgets in MyUW.
-* The length of your list of links will affect the widget's appearance. If you
-  have more than 4 links, they will be displayed in a more traditional-style
-  list, rather than with the `<circle-button>` directive.
+* `list-of-links` presents different quantities of links differently. 1 to 4
+  links present as `circle-button`s. 5 to 7 links present as a more
+  traditional-style list.
 * Use brief sentence-case link titles. `list-of-links` truncates link titles to
   24 characters.
 


### PR DESCRIPTION
Recent work ( #727 ) added `md-tooltip` when titles presented via `circle-button` are truncated.

However, when `list-of-links` presents more than four links, it doesn't use `circle-button`s, it uses an ad-hoc list. This changeset adds an `md-tooltip` to cover this case as well. Also adds an un-truncated `aria-label`.

After:

![tooltip-when-many-list-of-links-truncated](https://user-images.githubusercontent.com/952283/38228403-cb02ace2-36c8-11e8-903c-b4268abcb0a8.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
