### PR TITLE
feat: add md-tooltip when RSS item titles truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
+### Changed
+
+* RSS widgets now offer tooltip with full title when truncating item titles
+  (#737)
+
 ## [9.0.2][] - 2018-3-30
 
 This release is to mop up some weirdness which happened with 9.0.1 and get a clean artifact.

--- a/components/portal/widgets/partials/type__rss.html
+++ b/components/portal/widgets/partials/type__rss.html
@@ -31,7 +31,7 @@
         <div class="date bold" ng-if="config.showdate" layout="column" layout-align="center end">
           <span>{{ getPrettyDate(item.pubDate) | date:'shortDate' }}</span>
         </div>
-        <md-tooltip ng-if="trim(item.title).length > config.lim">
+        <md-tooltip ng-if="trim(item.title).length > config.titleLim">
           {{ item.title }}
         </md-tooltip>
       </a>

--- a/components/portal/widgets/partials/type__rss.html
+++ b/components/portal/widgets/partials/type__rss.html
@@ -31,6 +31,9 @@
         <div class="date bold" ng-if="config.showdate" layout="column" layout-align="center end">
           <span>{{ getPrettyDate(item.pubDate) | date:'shortDate' }}</span>
         </div>
+        <md-tooltip ng-if="trim(item.title).length > config.lim">
+          {{ item.title }}
+        </md-tooltip>
       </a>
     </li>
     <li ng-if="config.showShowing && config.lim && data.items.length > config.lim" class="no-highlight">

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -308,6 +308,8 @@ This provides a more usable click surface, a simpler and cleaner user experience
 
 * **lim**: The number of items to show. Any number greater than 6 will default to 6 (due to space limitations). Use a smaller number for feeds that are infrequently updated.
 * **titleLim**: Limit the length (in characters, including spaces) of feed titles. This number should be between 30 and 60 (depending on whether you're showing dates or not).
+When this limit results in truncation, `rss` adds an `md-tooltip` with the full
+title.
 * **showdate**: T/F show each feed item's published date. The date format is "M/d/yy" (localizable) due to space consideration.
 * **showShowing**: T/F Show the "Showing \[x] out of \[y]" message (to communicate that there is more to see). Set this to true if your feed has frequent updates.
 


### PR DESCRIPTION
In production MyUW, RSS widget news item titles truncate frequently. This improves, is necessary even, for home page display, but it's also annoying and erodes usability. Adding tooltips should allow university participants to better skim news as presented by the RSS widget type to decide whether to click to read articles.

Before ([publicly demonstrable on predev](https://public.predev.my.wisc.edu/web/apps/details/campus-news?q=news)):

![predev-campus-news-no-tooltip](https://user-images.githubusercontent.com/952283/38274249-d45cd89a-3753-11e8-978d-01a2238fa164.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
