### PR TITLE
fix: data urls processed only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   title, not just those presented via `circle-button`s (#736)
 * RSS widgets now offer tooltip with full title when truncating item titles
   (#737)
+* Data urls only called when necessary (#741)  
 
 ### Fixed
 

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -95,23 +95,24 @@ define(['angular'], function(angular) {
             .catch(filterMessagesFailure);
           };
 
-
-        /**
+         /**
          * Separate the message types in scope for child controllers
          * @param {Object} result
          */
         var filterMessagesSuccess = function(result) {
           $scope.seenMessageIds = result[0];
-          var dataMessages = result[1];
-          var groupedMessages = result[2];
-          var filteredMessages = $filter('filterForCommonElements')(
-            groupedMessages,
-            dataMessages
-          );
-          var dateFilteredMessages =
-            $filter('filterByDate')(filteredMessages);
-            $scope.messages =
-              $filter('separateMessageTypes')(dateFilteredMessages);
+          var groupedMessages = result[1];
+
+          var dateFilterMessages =
+            $filter('filterByDate')(groupedMessages);
+          $q.all(promiseMessagesByData(dateFilterMessages))
+            .then(dataMessageSuccess)
+            .catch(filterMessagesFailure);
+        };
+
+        var dataMessageSuccess = function(result) {
+          $scope.messages =
+            $filter('separateMessageTypes')(result);
           $scope.hasMessages = true;
         };
 


### PR DESCRIPTION
Only calls data urls for user-appropriate messages

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [X] Updates `CHANGELOG.md` to reflect this PR's change.
- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
