### PR TITLE
feat: add showAllMessages beta setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
+### Added
+
+* `showAllMessages` beta setting. When true disables all client-side message
+  filtering. Useful for demos and testing.
+
 ### Changed
 
 * `list-of-links` now offers tooltip with full title when it truncates any link
@@ -20,6 +25,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * `list-of-links` widgets are now `basic` widgets in the zero links edge case (#735)
 * `list-of-links` now `aria-label`s links, ensuring a non-truncated version of
   the link label is available to browsers (#736)
+
+### Deprecated
+
+The `disableGroupFilteringForMessages` beta setting is deprecated. While it
+still works in this release, the new `showAllMessages` beta setting is intended
+to replace it. `disableGroupFilteringForMessages` will have no effect in some
+future release.
 
 ## [9.0.2][] - 2018-3-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 * `showAllMessages` beta setting. When true disables all client-side message
-  filtering. Useful for demos and testing.
+  filtering. Useful for demos and testing. (#742)
 
 ### Changed
 
@@ -31,7 +31,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 The `disableGroupFilteringForMessages` beta setting is deprecated. While it
 still works in this release, the new `showAllMessages` beta setting is intended
 to replace it. `disableGroupFilteringForMessages` will have no effect in some
-future release.
+future release. (#742)
 
 ## [9.0.2][] - 2018-3-30
 

--- a/components/js/frame-config.js
+++ b/components/js/frame-config.js
@@ -1078,10 +1078,18 @@ define(['angular'], function(angular) {
           {
             'id': 'disableGroupFilteringForMessages',
             'title': 'Disable Client-side Message Filtering By Group',
+            'description': 'DEPRECATED. ' +
+              'Disable client-side filtering of portal-wide ' +
+              'messages by group. Replaced by the more comprehensive ' +
+              'showAllMessages. (page refresh required)',
+          },
+          {
+            'id': 'showAllMessages',
+            'title': 'Show all messages',
             'description': 'Disable client-side filtering of portal-wide ' +
-              'messages (e.g. notifications, mascot announcements) by group. ' +
-              'Useful for demoing or testing messages you would not normally ' +
-              'see. (page refresh required)',
+              'messages (i.e. notifications, mascot announcements). ' +
+              'Useful for demoing or testing messages you would not ' +
+              'otherwise see. (page refresh required)',
           },
         ]);
 });

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -51,7 +51,19 @@ define(['angular'], function(angular) {
               } else if (angular.isString(result)) {
                 $scope.messagesError = result;
               }
-              filterMessages(allMessages);
+
+              if ( $localStorage.showAllMessages ) {
+                // simulate the side effect of filterMessages
+                $scope.messages = $filter('separateMessageTypes')(allMessages);
+                $scope.hasMessages = true;
+                $scope.seenMessageIds = messagesService.getSeenMessageIds();
+              } else {
+                filterMessages(allMessages);
+                // side effects:
+                // sets $scope.messages and $scope.hasMessages
+                // and $scope.seenMessageIds
+              }
+
               return allMessages;
             })
             .catch(function(error) {


### PR DESCRIPTION
+ Adds `showAllMessages` beta setting.
+ **Deprecates `disableGroupFilteringForMessages`** beta setting, which implements a subset of the effects of the new `showAllMessages` setting.

![seeallmessages](https://user-images.githubusercontent.com/952283/38388527-1903e8ba-38e1-11e8-93eb-fe488eb82780.png)

Client-side message filtering has evolved beyond just filtering by group membership. It now filters by date and by dynamic data. This new beta setting opts out of all that client-side filtering, enabling better demoing and testing of messages content.

Graceful deprecation. `disableGroupFilteringForMessages` still does exactly what it did before.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
