### PR TITLE
fix: only call message dataurls when needed

### DIFF
--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -78,7 +78,9 @@ define(['angular'], function(angular) {
 
         // Promise to resolve urls in messages
         var promiseMessagesByData = function(messages) {
-          return messagesService.getMessagesByData(messages);
+          messagesService.getMessagesByData(messages)
+            .then(dataMessageSuccess)
+            .catch(filterMessagesFailure);
         };
 
         // Promise to resolve group memberships
@@ -110,11 +112,9 @@ define(['angular'], function(angular) {
           var groupedMessages = result[1];
 
           var seenAndUnseen = $filter('filterSeenAndUnseen')
-            (result[1], $scope.seenMessageIds);
+            (groupedMessages, $scope.seenMessageIds);
  
-          $q.all(promiseMessagesByData(seenAndUnseen.unseen))
-            .then(dataMessageSuccess)
-            .catch(filterMessagesFailure);
+          $q.all(promiseMessagesByData(seenAndUnseen.unseen));
         };
         
         var dataMessageSuccess = function(result) {

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -127,6 +127,9 @@ define(['angular'], function(angular) {
           $scope.hasMessages = true;
         };
 
+        var dateFilterSuccess = function(dateFilterMessages) {
+          
+        }
         /**
          * Handle errors that occur while resolving promises to
          * get notifications

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -91,14 +91,9 @@ define(['angular'], function(angular) {
          * @param {Object} allMessages
          */
         var filterMessages = function(allMessages) {
-          var groupFiltersEnabled =
-            !$localStorage.disableGroupFilteringForMessages;
-          var groupPromise = null;
-          if (!groupFiltersEnabled) {
-            groupPromise = $q.resolve(allMessages);
-          } else {
-            groupPromise = promiseMessagesByGroup(allMessages);
-          }
+          var dateFilterMessages =
+            $filter('filterByDate')(allMessages);
+          var groupPromise = promiseMessagesByGroup(dateFilterMessages);
 
           $q.all([promiseSeenMessageIds(),
                   groupPromise])
@@ -114,22 +109,20 @@ define(['angular'], function(angular) {
           $scope.seenMessageIds = result[0];
           var groupedMessages = result[1];
 
-          var dateFilterMessages =
-            $filter('filterByDate')(groupedMessages);
-          $q.all(promiseMessagesByData(dateFilterMessages))
+          var seenAndUnseen = $filter('filterSeenAndUnseen')
+            (result[1], $scope.seenMessageIds);
+ 
+          $q.all(promiseMessagesByData(seenAndUnseen.unseen))
             .then(dataMessageSuccess)
             .catch(filterMessagesFailure);
         };
-
+        
         var dataMessageSuccess = function(result) {
           $scope.messages =
             $filter('separateMessageTypes')(result);
           $scope.hasMessages = true;
         };
 
-        var dateFilterSuccess = function(dateFilterMessages) {
-          
-        }
         /**
          * Handle errors that occur while resolving promises to
          * get notifications

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -231,7 +231,7 @@ define(['angular'], function(angular) {
               return filteredMessages;
             });
         };
-
+        
         /**
          * Get list of seen message IDs from K/V store or session storage
          * @return {*}

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -231,7 +231,7 @@ define(['angular'], function(angular) {
               return filteredMessages;
             });
         };
-        
+
         /**
          * Get list of seen message IDs from K/V store or session storage
          * @return {*}


### PR DESCRIPTION
Performance enhancement so that only messages which are relevant to the current user have their data urls called. 

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [ ] Updates `CHANGELOG.md` to reflect this PR's change.
- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
