### PR TITLE
fix: tooltip when truncating priority notification title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 ### Changed
 ### Fixed
+
+* When priority notification title is truncated, provide full title as tooltip
+  (#754)
+
 ### Removed
 
 * no loger used LoginOnLoad option removed (#753)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 ### Fixed
 ### Removed
-* no loger used LoginOnLoad option removed (#753)  
+
+* no loger used LoginOnLoad option removed (#753)
+
 ### Deprecated
 
 ## [9.1.0][] - 2018-4-17

--- a/components/portal/messages/partials/notifications-bell.html
+++ b/components/portal/messages/partials/notifications-bell.html
@@ -117,6 +117,9 @@
       <div class="notification-message">
         <span>{{ priority.title | limitTo: vm.titleLengthLimit | trim }}</span>
         <span ng-if="priority.title.length > vm.titleLengthLimit">...</span>
+        <md-tooltip ng-if="priority.title.length > vm.titleLengthLimit">
+          {{ priority.title }}
+        </md-tooltip>
       </div>
       <div layout="row" class="compact-buttons">
         <md-button class="md-raised md-accent"


### PR DESCRIPTION
Gives the user access to the full notification title when it's truncated for presentation in a priority notification banner across the top of the screen.

![tooltip on truncated priority notification title](https://user-images.githubusercontent.com/952283/39454503-4a0f009c-4ca1-11e8-9082-ddf2eab16888.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
