### PR TITLE
fix: repair link binding and rename version info page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 * When priority notification title is truncated, provide full title as tooltip
   (#754)
+* Fix route to newly-added version info page (#758)
 
 ### Removed
 

--- a/components/portal/about/partials/about.html
+++ b/components/portal/about/partials/about.html
@@ -28,7 +28,7 @@
       <h2>Useful links:</h2>
       <ul>
         <li ng-repeat="link in aboutLinks">
-          <a ng-href="link.url">{{ link.text }}</a>
+          <a ng-href="{{ link.url }}">{{ link.text }}</a>
         </li>
       </ul>
     </div>

--- a/components/portal/about/partials/session-info.html
+++ b/components/portal/about/partials/session-info.html
@@ -19,8 +19,8 @@
 
 -->
 <frame-page
-  app-title="Session info"
-  page-title="Session information"
+  app-title="Version info"
+  page-title="Version information"
   white-background="true">
   <md-content ng-controller="SessionInfoController as sessionInfoCtrl" class="session-info__content">
     <p>The information on this page is intended to assist Help Desk personnel while troubleshooting.</p>


### PR DESCRIPTION
**In this PR:**
- Links on "About" page work
- "Session info" page changed to "version info" (to match the name that content used to have when it was part of the "About" page)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
