### PR TITLE
fix: adjust z-indices to make widget actions available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,18 @@ Versioning](http://semver.org/spec/v2.0.0.html).
  
 ### Changed
 * "About" page now sources meaningful content from `aboutPageURL` (#755)
+* z-index values adjusted from highest (101) to lowest (51) stated values to play nicer with Angular Material (#760)
 
 ### Fixed
 
 * When priority notification title is truncated, provide full title as tooltip
   (#754)
 * Fix route to newly-added version info page (#758)
-
+* Widgets with overlays can be removed (#760)
+ 
 ### Removed
 
-* no loger used LoginOnLoad option removed (#753)
+* No logger used LoginOnLoad option removed (#753)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
  
 ### Removed
 
-* No logger used LoginOnLoad option removed (#753)
+* No longer used LoginOnLoad option removed (#753)
 
 ### Deprecated
 

--- a/components/css/buckyless/directives/main-menu.less
+++ b/components/css/buckyless/directives/main-menu.less
@@ -57,7 +57,6 @@ main-menu {
           position: relative;
           height: 32px;
           width: 32px;
-          z-index: 0;
           line-height: 32px;
           font-size: 18px;
           font-weight: 400;
@@ -121,7 +120,7 @@ main-menu {
     md-sidenav.main-menu__sidenav:not(.push-content) {
       position: fixed;
       top: 0;
-      z-index: 80;
+      z-index: @sidenav-depth;
     }
   }
 
@@ -130,7 +129,7 @@ main-menu {
       md-sidenav.main-menu__sidenav {
         position: fixed;
         top: 56px;
-        z-index: 70;
+        z-index: @sidenav-depth;
       }
     }
 

--- a/components/css/buckyless/directives/username-menu.less
+++ b/components/css/buckyless/directives/username-menu.less
@@ -41,7 +41,6 @@ portal-header {
             position: relative;
             height: 32px;
             width: 32px;
-            z-index: 0;
             line-height: 32px;
             font-size: 18px;
             font-weight: 400;

--- a/components/css/buckyless/features.less
+++ b/components/css/buckyless/features.less
@@ -127,5 +127,5 @@ portal-header md-toolbar .md-toolbar-tools mascot-announcement {
 }
 
 .md-dialog-container {
-  z-index: 101;
+  z-index: @dialog-depth-1;
 }

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -26,7 +26,7 @@
   color: @white;
   background: transparent;
   transition: top 1s ease-out, background 1s linear;
-  z-index: 100;
+  z-index: @dialog-depth-2;
 
   &:focus {
     position: absolute;

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -19,7 +19,7 @@
 portal-header {
   display: block;
   position: sticky;
-  z-index: 80;
+  z-index: @top-bar-1;
   top: 0;
   overflow-y: hidden;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
@@ -123,7 +123,7 @@ portal-header {
       width: 100%;
       position: absolute;
       top: 56px;
-      z-index: 80;
+      z-index: @top-bar-1;
       overflow: hidden;
       transition: @transition-height;
       background: rgba(0, 0, 0, 0.4);

--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -136,7 +136,7 @@
       border-radius: 50%;
       padding: 0;
       color: @color1;
-      z-index: 80;
+      z-index: @top-bar-1;
       top: 0;
       right: 26px;
 
@@ -158,7 +158,7 @@
       color: @color1;
       font-weight: 400;
       font-size: 20px;
-      z-index: 80;
+      z-index: @top-bar-1;
       position: absolute;
       line-height: 40px;
       left: 14px;
@@ -201,7 +201,7 @@
 .priority-gt-xs .priority-notifications {
   height: 46px;
   width: 100%;
-  z-index: 80;
+  z-index: @top-bar-1;
   padding: 4px 4px 0;
   display: flex;
   justify-content: center;

--- a/components/css/buckyless/search.less
+++ b/components/css/buckyless/search.less
@@ -103,7 +103,7 @@ search {
       right: 0;
       top: 0;
       padding: 6px 4px;
-      z-index: 80;
+      z-index: @top-bar-1;
       overflow: hidden;
       transition: @transition-width;
 

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -118,7 +118,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 58;
+    z-index: @widget-depth-2;
     border-radius: 3px;
     top: 0;
 
@@ -496,6 +496,7 @@
     top: 0;
     margin: 0;
     transition: @transition-opacity;
+    z-index: @widget-depth-1;
 
     &.widget-info {
       left: 0;

--- a/components/css/themes/common-variables.less
+++ b/components/css/themes/common-variables.less
@@ -51,9 +51,21 @@
 @box-shadow-4: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
 @box-shadow-5: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 
+/* z-index values for dialogs/toasts/tooltips (top-level elements) */
+@dialog-depth-1: 101;
+@dialog-depth-2: 100;
+
+/* z-index values for elements that sit on top of focus trap */
+@sidenav-depth: 59;
+
+/* z-index values for top bar elements */
 @top-bar-1: 55;
 @top-bar-2: 54;
 @top-bar-3: 53;
+
+/* z-index values for widget elements */
+@widget-depth-1: 52;
+@widget-depth-2: 51;
 
 /* Footer */
 @footer-background-color: #404040;

--- a/components/portal/about/partials/about.html
+++ b/components/portal/about/partials/about.html
@@ -28,7 +28,7 @@
       <h2>Useful links:</h2>
       <ul>
         <li ng-repeat="link in aboutLinks">
-          <a ng-href="link.url">{{ link.text }}</a>
+          <a ng-href="{{ link.url }}">{{ link.text }}</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
[MUMUP-3345](https://jira.doit.wisc.edu/jira/browse/MUMUP-3345): "Allow users to remove widgets that have an overlay"

**In this PR**:
- Widget remove button has higher priority than widget overlays
- Top-down adjustment of z-indices throughout app CSS (with LESS variables)
    - Dialogs/toasts always on top
    - Top bar higher than content
    - Menus higher than the menu focus trap
    - Widget actions higher than widget overlay
- Removed a couple unused/unnecessary z-index statements

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
