### PR TITLE
feat: Add and use Roboto web font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 * New "session info" page containing the former content of the "About" page (uportal-app-framework version info, app info JSON) (#755)
 * App config option `aboutPageURL` to get text and links for "About" page (#755)
+* Made Google's Roboto web font available (#761)
  
 ### Changed
 * "About" page now sources meaningful content from `aboutPageURL` (#755)
+* Use Roboto font family (#761)
 
 ### Fixed
 

--- a/components/css/buckyless/frame.less
+++ b/components/css/buckyless/frame.less
@@ -43,6 +43,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  font-family: @font-family;
 
   .page-content {
     background-color: @grayscale4;

--- a/components/css/buckyless/general.less
+++ b/components/css/buckyless/general.less
@@ -19,11 +19,6 @@
 
 /* General MyUW Styles */
 
-body {
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
 a {
   transition: @transition-color;
 

--- a/components/css/themes/common-variables.less
+++ b/components/css/themes/common-variables.less
@@ -70,8 +70,5 @@
 @transition-all: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 @transition-color: color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 
-/* Custom mix-ins */
-.border (@color: @grayscale3, @size: 1px) {
-  border: @size solid @color;
-}
-@border: 1px solid @grayscale3;
+/* Font(s) */
+@font-family: Roboto, Helvetica Neue, sans-serif;

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -29,4 +29,5 @@
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
[MUMUP-3349](https://jira.doit.wisc.edu/jira/browse/MUMUP-3349): "As a uportal-app-framework developer, I'd like the Roboto web font preferred by default, so that my app can better adhere to Google Material guidelines."

**In this PR:**
- Made Roboto font available 
- Default to using Roboto
- Removed unused/inaccessible CSS

### Screenshot
<img width="462" alt="screen shot 2018-05-15 at 11 29 59 am" src="https://user-images.githubusercontent.com/5818702/40070509-e0f97f4e-5833-11e8-8b06-026f0c589a2b.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
