### PR TITLE
fix: open notification links in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   (#754)
 * Fix route to newly-added version info page (#758)
 * Widgets with overlays can be removed (#760)
+* Notifications' action buttons now open in new tab (#762)
  
 ### Removed
 

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -37,7 +37,9 @@
     <md-button class="md-raised md-accent"
                ng-href="{{ notification.actionButton.url }}"
                ng-if="notification.actionButton && notification.actionButton.url"
-               ng-click="pushGAEvent('notifications page', 'take action', notification.actionButton.url)">
+               ng-click="pushGAEvent('notifications page', 'take action', notification.actionButton.url)"
+               target="_blank"
+               rel="noopener noreferrer">
       {{ notification.actionButton.label }}
     </md-button>
     <md-button class="md-raised md-default"


### PR DESCRIPTION
[MUMMNG-4140](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4140): "As an end user clicking on external notification links, I want them to open in a new window so that I don't want to lose track of my MyUW session."

**In this PR**:
- Action button links on notifications page open in new tab
    - *Note: This is the same behavior as notifications in the bell menu.*

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
