### PR TITLE
feat: source meta info from about page url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * "About" page now sources meaningful content from `aboutPageURL` (#755)
 * Use Roboto font family (#761)
 * z-index values adjusted from highest (101) to lowest (51) stated values to play nicer with Angular Material (#760)
+* To better support open source commitment and downstream apps, replaced hard-coded MyUW/UW-Madison specific language in meta tags (now sourced from the same JSON file as the app's About page information) (#763) 
 
 ### Fixed
 

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -23,11 +23,12 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
 <meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
-<meta name="description" content="MyUW"/>
-<meta name="keywords" content="portal, myuw, wisconsin"/>
+<!--Meta information sourced from app's aboutPageURL -->
+<meta ng-if="about.description" name="description" content="{{ about.description }}"/>
+<meta ng-if="about.keywords" name="keywords" content="{{ about.keywords }}"/>
 
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min.css"/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic"/>
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>

--- a/components/portal/about/controllers.js
+++ b/components/portal/about/controllers.js
@@ -43,28 +43,25 @@ define(['angular', 'require'], function(angular, require) {
         }
       }])
 
-    .controller('AboutPageController', ['$log', '$scope', 'portalAboutService',
-      'SERVICE_LOC', function($log, $scope, portalAboutService, SERVICE_LOC) {
+    .controller('AboutPageController', ['$log', '$scope', '$rootScope',
+      function($log, $scope, $rootScope) {
       /**
        * Get 'about' page information to display
        */
       var init = function() {
         $scope.aboutText = [];
         $scope.aboutLinks = [];
-
-        if (SERVICE_LOC.aboutPageURL) {
-          portalAboutService.getAboutPage(SERVICE_LOC.aboutPageURL)
-            .then(function(result) {
-              if (result.aboutText && result.aboutText.length > 0) {
-                $scope.aboutText = result.aboutText;
-              }
-              if (result.aboutLinks && result.aboutLinks.length > 0) {
-                $scope.aboutLinks = result.aboutLinks;
-              }
-              return result;
-            }).catch(function() {
-            $log.warn('issue getting app info');
-          });
+        // If app has an aboutPageURL specified, portal/main.js
+        // should get the data and set the rootScope values
+        if ($rootScope.about) {
+          if ($rootScope.about.aboutText
+            && $rootScope.about.aboutText.length > 0) {
+            $scope.aboutText = $rootScope.about.aboutText;
+          }
+          if ($rootScope.about.aboutLinks
+            && $rootScope.about.aboutLinks.length > 0) {
+            $scope.aboutLinks = $rootScope.about.aboutLinks;
+          }
         }
       };
 

--- a/components/portal/about/services.js
+++ b/components/portal/about/services.js
@@ -46,25 +46,9 @@ define(['angular'], function(angular) {
         });
     };
 
-      /**
-       * Get info for about page
-       * @param {String} url
-       * @returns {*}
-       */
-    var getAboutPage = function(url) {
-      return $http.get(url, {cache: true})
-        .then(function(result) {
-          return result.data;
-        })
-        .catch(function(error) {
-          miscService.redirectUser(error.status, url);
-        });
-    };
-
     return {
       getFrameDetails: getFrameDetails,
       getDetails: getDetails,
-      getAboutPage: getAboutPage,
     };
   }]);
 });

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -211,8 +211,10 @@ define([
           $rootScope.portal.loading.hidden = true;
         }, 1500);
 
-        // save theme to session storage so we don't have to do below again
+        // save theme and meta info to session storage so we don't
+        // have to do below again
         $sessionStorage.portal.theme = $rootScope.portal.theme;
+        $sessionStorage.about = $rootScope.about;
       };
 
       // Safari in Private Browsing Mode throws a QuotaExceededError
@@ -416,13 +418,36 @@ define([
         }
       };
 
+      /**
+       * Get app information from aboutPageURL, set
+       * description and keywords tags if they exist
+       */
+      var setMetaTags = function(url) {
+        $http.get(url, {cache: true})
+          .then(function(result) {
+            $rootScope.about = result.data;
+            $sessionStorage.about = result.data;
+            return result.data;
+          })
+          .catch(function(error) {
+            if (APP_FLAGS.debug) {
+              $log.error('Failed to get app meta info');
+            }
+          });
+      };
+
       // loading sequence
       var init = function() {
         searchRouteParameterInit();
         $rootScope.portal = $rootScope.portal || {};
+        $rootScope.about = $rootScope.about || {};
         $sessionStorage.portal = $sessionStorage.portal || {};
+        $sessionStorage.about = $sessionStorage.about || {};
         configureAppConfig();
         themeLoading();
+        if (SERVICE_LOC.aboutPageURL) {
+          setMetaTags(SERVICE_LOC.aboutPageURL);
+        }
       };
       init();
     });

--- a/components/static.html
+++ b/components/static.html
@@ -47,7 +47,7 @@
         padding-top: 45vh;
         font-size: xx-large;
         margin: -8px;
-        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;"
+        font-family: Roboto, Helvetica Neue, sans-serif;"
       id="loading-splash">
         <!--Bad browser error message-->
         <!--[if lt IE 10]>

--- a/components/staticFeeds/about-page.json
+++ b/components/staticFeeds/about-page.json
@@ -1,4 +1,6 @@
 {
+  "description": "MyUW",
+  "keywords": "portal, myuw, wisconsin",
   "aboutText": [
     "MyUW is the central hub where the campus community can go to conduct university business and get things done. We help UW work smarter, faster, and safer by providing a secure, personalized platform for easy navigation to services, applications, and resources. In an increasingly complex digital environment, MyUW presents a unified, modern user experience.",
     "MyUW welcomes the opportunity to work with any group, department, or division to get your information in our hub. From something as simple as providing a link to your department’s intranet, to partnering with another development team to create an application for a specific business need, MyUW can help. With over 2 million logins a month and strong campus-wide awareness, MyUW can help you reach your audiences, improve workflow, and provide ease and clarity in a complex digital environment."

--- a/docs/about-page.md
+++ b/docs/about-page.md
@@ -41,6 +41,6 @@ To direct your app to a JSON source, add the URL to your app's "override.js" fil
 **Attribute breakdown**
 
 - **description**: App description to be used in the description meta tag.
-- **keywords**: App keywords to be used in the description meta tag.
+- **keywords**: App keywords to be used in the keywords meta tag.
 - **aboutText**: An array of strings. Each entry in the array will be displayed as a new paragraph.
 - **aboutLinks**: An array of link objects. Links can have a URL and text to display, and will appear in a list under the "Useful links" heading.

--- a/docs/about-page.md
+++ b/docs/about-page.md
@@ -3,6 +3,8 @@
 The "About" page pulls information from a JSON source to tell users about your app. The page supports plain text
 and a list of links.
 
+The data in the JSON source is also used to set the app's "description" and "keywords" `<meta>` tags. 
+
 To direct your app to a JSON source, add the URL to your app's "override.js" file under `SERVICE_LOC.aboutPageURL`. For example:
 
 ```javascript
@@ -17,6 +19,8 @@ To direct your app to a JSON source, add the URL to your app's "override.js" fil
 
 ```json
 {
+  "description": "MyUW",
+  "keywords": "portal, myuw, wisconsin",
   "aboutText": [
     "MyUW is the central hub where the campus community can go to conduct university business and get things done. We help UW work smarter, faster, and safer by providing a secure, personalized platform for easy navigation to services, applications, and resources. In an increasingly complex digital environment, MyUW presents a unified, modern user experience.",
     "MyUW welcomes the opportunity to work with any group, department, or division to get your information in our hub. From something as simple as providing a link to your department’s intranet, to partnering with another development team to create an application for a specific business need, MyUW can help. With over 2 million logins a month and strong campus-wide awareness, MyUW can help you reach your audiences, improve workflow, and provide ease and clarity in a complex digital environment."
@@ -36,5 +40,7 @@ To direct your app to a JSON source, add the URL to your app's "override.js" fil
 
 **Attribute breakdown**
 
+- **description**: App description to be used in the description meta tag.
+- **keywords**: App keywords to be used in the description meta tag.
 - **aboutText**: An array of strings. Each entry in the array will be displayed as a new paragraph.
 - **aboutLinks**: An array of link objects. Links can have a URL and text to display, and will appear in a list under the "Useful links" heading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ this is constructed.
 ### SERVICE_LOC
 
 + **aboutURL**: Additional data to show in **/session-info**.
-+ **aboutPageURL**: Where to get text/link content for the app's "About" page. See [About page](about-page.md) for more information.
++ **aboutPageURL**: A URL to get JSON data about the app. This data is used on the text/link content for the app's "About" page, as well as the app's "description" and "keywords" `<meta>` tags. See [About page](about-page.md) for more information.
 + **sessionInfo**: Where the frame gets data about the logged in user. [Example][session.json].
 + **messagesURL**: An end point to a feed of messages.
 [Example][sample-messages.json]. Messages at the


### PR DESCRIPTION
[MUMUP-3348](https://jira.doit.wisc.edu/jira/browse/MUMUP-3348): "As a uaf developer, I'd prefer my app to not include UW-Madison-related meta information, so that my non-UW app doesn't have a MyUW description/keywords."

**In this PR:**
- Replace hard-coded meta tags with tags sourced from the new `aboutPageURL`
    - Downstream impact should be negligible, as the existing implementation identifies all apps as "MyUW." Companion PRs for actual MyUW can be found [here](https://git.doit.wisc.edu/myuw-overlay/uportal-home-overlay/merge_requests).
- Set "About" information during bootstrapping phase (with app-wide availability)
- Remove now-unused service method to get "About" information
- Update docs to describe new functionality
- Set Roboto font in static loading page (for consistency's sake)

Proof that it works:
![screen shot 2018-05-18 at 11 00 37 am](https://user-images.githubusercontent.com/5818702/40245776-282f1a04-5a8c-11e8-8520-4965178781cb.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
