### PR TITLE
feat: update svg functionality to use mdIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * New "session info" page containing the former content of the "About" page (uportal-app-framework version info, app info JSON) (#755)
 * App config option `aboutPageURL` to get text and links for "About" page (#755)
 * Made Google's Roboto web font available (#761)
- 
+
 ### Changed
 * "About" page now sources meaningful content from `aboutPageURL` (#755)
 * Use Roboto font family (#761)
 * z-index values adjusted from highest (101) to lowest (51) stated values to play nicer with Angular Material (#760)
+* SVG widget icons use the md-icon directive to scale properly (#764)
 
 ### Fixed
 
@@ -26,7 +27,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * Fix route to newly-added version info page (#758)
 * Widgets with overlays can be removed (#760)
 * Notifications' action buttons now open in new tab (#762)
- 
+
 ### Removed
 
 * No longer used LoginOnLoad option removed (#753)
@@ -58,9 +59,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Removed
 
 * Support for `APP_OPTIONS.optionsTemplateURL` configuration is removed in this
-  release. It had previously been documented as "deprecated" but the 
+  release. It had previously been documented as "deprecated" but the
   backwards-compatibility support didn't work out (#744), so in practice support
-  for this feature was already removed as a breaking change for the `9.x` 
+  for this feature was already removed as a breaking change for the `9.x`
   version series. (#745)
 
 ### Deprecated
@@ -113,24 +114,24 @@ This release is to mop up some weirdness which happened with 9.0.1 and get a cle
 ### Breaking changes
 
 * Removed jQuery UI sortable dependency (#721)
-* Removed `<app-header>` directive. This affects any framework apps using that 
-  directive outside of `<frame-page>`. `<frame-page>` usages should be 
+* Removed `<app-header>` directive. This affects any framework apps using that
+  directive outside of `<frame-page>`. `<frame-page>` usages should be
   unaffected. (#684)
-* With the removal of the `<app-header>`, the `APP_OPTIONS.optionsTemplateURL` 
+* With the removal of the `<app-header>`, the `APP_OPTIONS.optionsTemplateURL`
   config has been removed, superseded by a new `APP_OPTIONS.appMenuTemplateURL`.
-  Templates may require minor layout/appearance adjustments for use in the new 
+  Templates may require minor layout/appearance adjustments for use in the new
   way. (#684)
 
 To upgrade:
 
-* Add jQueryUI Sortable to frame app, or refer to 
+* Add jQueryUI Sortable to frame app, or refer to
   [an example of angular-drag-and-drop-lists][uportal-home #795]
 * If using the "app-title" attribute on frame-page directive, that title will be
   used as the document title
-* Pages formerly using `app-header` can use the `page-title` attribute on 
+* Pages formerly using `app-header` can use the `page-title` attribute on
   `frame-page` to achieve a similar within-page `h1` heading as before.
-* Port forward `APP_OPTIONS.optionsTemplateURL` usages to 
-  `APP_OPTIONS.appMenuTemplateURL` usages. This content will now appear in the 
+* Port forward `APP_OPTIONS.optionsTemplateURL` usages to
+  `APP_OPTIONS.appMenuTemplateURL` usages. This content will now appear in the
   side navigation and may likely need a bit of tweaking if using a rigid
   CSS layout.
 
@@ -183,7 +184,7 @@ To upgrade:
 
 *   To upgrade:
     - If your app's main.js file uses the `'/sorry-safari'` route, remove it
-    - Also remove the corresponding url-pattern from your app's web.xml file 
+    - Also remove the corresponding url-pattern from your app's web.xml file
 
 ### Added
 

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -100,6 +100,10 @@
     .material-icons {
       color: @grayscale10;
       font-size: 70px;
+      height: 70px;
+      width: 70px;
+      min-height: 70px;
+      min-width: 70px;
     }
   }
 
@@ -555,12 +559,17 @@
   .icon-container {
     width: 100%;
     height: 67%;
+    padding-top: 30px;
 
-    i {
+    i,
+    .material-icons {
       color: #333;
       vertical-align: middle;
-      padding: 30px 10px;
       font-size: 50px;
+      height: 50px;
+      width: 50px;
+      min-height: 50px;
+      min-width: 50px;
     }
   }
 

--- a/components/portal/widgets/partials/widget-icon.html
+++ b/components/portal/widgets/partials/widget-icon.html
@@ -21,5 +21,5 @@
 <i ng-if="widget.mdIcon" class="material-icons">{{ widget.mdIcon }}</i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')===0" class="fa {{ ::widget.faIcon }}"></i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')!==0" class="{{ ::widget.faIcon }}"></i>
-<img ng-src="{{widget.iconUrl}}" ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl" alt="Widget icon">
+<md-icon ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl" md-svg-src="{{widget.iconUrl}}" class="material-icons"></md-icon>
 <i ng-if="!widget.mdIcon && !widget.faIcon && !widget.iconUrl" class="fa fa-star"></i>

--- a/components/portal/widgets/partials/widget-icon.html
+++ b/components/portal/widgets/partials/widget-icon.html
@@ -21,5 +21,6 @@
 <i ng-if="widget.mdIcon" class="material-icons">{{ widget.mdIcon }}</i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')===0" class="fa {{ ::widget.faIcon }}"></i>
 <i ng-if="!widget.mdIcon && widget.faIcon && widget.faIcon.indexOf('fa-')!==0" class="{{ ::widget.faIcon }}"></i>
-<md-icon ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl" md-svg-src="{{widget.iconUrl}}" class="material-icons"></md-icon>
+<img ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl && widget.iconUrl.indexOf('.svg') < 0" ng-src="{{widget.iconUrl}}" alt="Widget icon">
+<md-icon ng-if="!widget.mdIcon && !widget.faIcon && widget.iconUrl && widget.iconUrl.indexOf('.svg') >= 0" md-svg-src="{{widget.iconUrl}}" class="material-icons"></md-icon>
 <i ng-if="!widget.mdIcon && !widget.faIcon && !widget.iconUrl" class="fa fa-star"></i>


### PR DESCRIPTION
Fixing/adding functionality to be able to use custom SVGs.
Retained ability to display PNG images as icons.

![image](https://user-images.githubusercontent.com/937952/40258976-2ed44410-5ab9-11e8-9d27-d376f2a5ea41.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
