### PR TITLE
Remove "What's New" from footer(s) and adjust header CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app name (i.e. "STAR"), the two names now appear inline (#766)
+* Removed link to Features page ("What's New") from default app configuration (#770)
 
 
 ### Fixed

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -89,12 +89,9 @@ portal-header {
           }
         }
 
-        ~ .title-link__two-lines {
-          @media (min-width: @xs) {
-            h1,
-            a.title-link__small {
-              margin-left: 0;
-            }
+        ~ .title-link__two-names {
+          a.title-link__theme-name {
+            margin-left: 0;
           }
         }
       }

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -76,6 +76,12 @@ define(['angular'], function(angular) {
             },
 
         })
+        .value('FOOTER_URLS', [
+          {'url': '/web/features',
+            'target': '_blank',
+            'title': 'What\'s New',
+          },
+        ])
         .value('APP_BETA_FEATURES', [
           {
             'id': 'toggleSomething',

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -76,12 +76,6 @@ define(['angular'], function(angular) {
             },
 
         })
-        .value('FOOTER_URLS', [
-          {'url': '/web/features',
-            'target': '_blank',
-            'title': 'What\'s New',
-          },
-        ])
         .value('APP_BETA_FEATURES', [
           {
             'id': 'toggleSomething',

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -74,14 +74,8 @@ define(['angular'], function(angular) {
                 '/portal/web/layout?tabName=UW Bucky Home' +
                 '&action=addPortlet&fname=',
             },
-
         })
-        .value('FOOTER_URLS', [
-          {'url': '/web/features',
-            'target': '_blank',
-            'title': 'What\'s New',
-          },
-        ])
+        .value('FOOTER_URLS', [])
         .value('APP_BETA_FEATURES', [
           {
             'id': 'toggleSomething',

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -26,6 +26,13 @@
             ng-hide="vm.hideMainMenu">
   <div class="main-menu__focus-anchor-top" tabindex="0" md-autofocus></div>
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
+    <md-button href="features"
+               ng-if="vm.hasUnseenAnnouncements && vm.showMessagesFeatures"
+               ng-click="vm.closeMainMenu();"
+               aria-label="view all announcements">
+      <span><md-icon>new_releases</md-icon></span>
+      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">New features</md-tooltip>
+    </md-button>
     <!-- Regular notifications button -->
     <md-button ng-href="{{ vm.notificationsPageUrl }}"
                ng-click="vm.pushGAEvent('Sidenav notifications bell (normal state)', 'Click link', 'Normal state');vm.closeMainMenu();"

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -26,13 +26,6 @@
             ng-hide="vm.hideMainMenu">
   <div class="main-menu__focus-anchor-top" tabindex="0" md-autofocus></div>
   <div class="main-menu__mobile-bar" layout="row" layout-align="end center" hide-gt-xs>
-    <md-button href="features"
-               ng-if="vm.hasUnseenAnnouncements && vm.showMessagesFeatures"
-               ng-click="vm.closeMainMenu();"
-               aria-label="view all announcements">
-      <span><md-icon>new_releases</md-icon></span>
-      <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">New features</md-tooltip>
-    </md-button>
     <!-- Regular notifications button -->
     <md-button ng-href="{{ vm.notificationsPageUrl }}"
                ng-click="vm.pushGAEvent('Sidenav notifications bell (normal state)', 'Click link', 'Normal state');vm.closeMainMenu();"


### PR DESCRIPTION
[MUMUP-3363](https://jira.doit.wisc.edu/jira/browse/MUMUP-3363): "As a user of MyUW, I would like to not see the 'What's New' link in MyUW that links to an empty page, so that I'm not confused at the empty page."

**In this PR:**
- Remove link to /features from default footer configuration
- Remove left-margin from theme/portal name on small screens (save space)

### Screenshot
![screen shot 2018-06-05 at 12 18 16 pm](https://user-images.githubusercontent.com/5818702/40991980-072b38c8-68bb-11e8-8611-f0d9edda8b30.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
