### PR TITLE
Fix presentation of dialogs (and other CSS tweaks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased][]
 
 ### Added
-
+ 
 
 ### Changed
 * Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app name (i.e. "STAR"), the two names now appear inline (#766)
@@ -18,6 +18,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * Fixed potential upgrade path difficulty by making changes to "/about" and "/session-info" routes backward compatible (#765)
+* Increased z-index of all dialogs to highest value (101) to ensure they appear above other content (#771)
+* Added basic `<body>` styles (override Bootstrap values) to ensure Roboto is always preferred (#771)
 
 
 ### Removed

--- a/components/css/angular.less
+++ b/components/css/angular.less
@@ -40,3 +40,4 @@
 }
 @import "buckyless/md-generated.less";
 @import "buckyless/md-icons.less";
+@import "buckyless/base.less";

--- a/components/css/buckyless/base.less
+++ b/components/css/buckyless/base.less
@@ -1,0 +1,28 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+  General styles that need to live on the html/body level
+  (broader than the CSS appended to the ".my-uw" class element)
+*/
+body {
+  font-family: Roboto, Helvetica Neue, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+}

--- a/components/css/buckyless/features.less
+++ b/components/css/buckyless/features.less
@@ -125,7 +125,3 @@ portal-header md-toolbar .md-toolbar-tools mascot-announcement {
     outline: none;
   }
 }
-
-.md-dialog-container {
-  z-index: @dialog-depth-1;
-}

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -63,8 +63,21 @@ md-menu-content {
   }
 }
 
-md-dialog {
-  background: @white;
+div.md-dialog-container {
+  z-index: @dialog-depth-1;
+
+  md-dialog {
+    background: @white;
+  }
+}
+
+body > md-backdrop {
+  background-color: @grayscale10;
+  opacity: 0;
+
+  &.md-dialog-backdrop {
+    z-index: @dialog-depth-2;
+  }
 }
 
 .md-open-menu-container.md-whiteframe-z2 {

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -141,6 +141,7 @@
 
       p {
         margin-bottom: 0;
+        text-align: center;
 
         .material-icons {
           height: 40px;

--- a/components/portal/misc/controllers.spec.js
+++ b/components/portal/misc/controllers.spec.js
@@ -57,6 +57,7 @@ define(['angular-mocks', 'portal'], function() {
       spyOn($location, 'hash');
       spyOn(elementToFocus[0], 'scrollIntoView');
       scope.skipToHere('focus');
+
       expect(elementToFocus[0].focus).toHaveBeenCalled();
       expect($location.hash).toHaveBeenCalledWith('focus');
       expect(elementNotToFocus[0].focus).not.toHaveBeenCalled();
@@ -65,12 +66,14 @@ define(['angular-mocks', 'portal'], function() {
 
     it('should fail set focus to non existent element', function() {
       spyOn($location, 'hash');
+
       expect(scope.skipToHere.bind('focus')).toThrowError(TypeError);
       expect($location.hash).not.toHaveBeenCalledWith('focus');
     });
 
     it('should fail set focus to an element referenced by null', function() {
       spyOn($location, 'hash');
+
       expect(scope.skipToHere.bind(null)).toThrowError(TypeError);
       expect($location.hash).not.toHaveBeenCalledWith('focus');
     });

--- a/components/portal/timeout/controllers.js
+++ b/components/portal/timeout/controllers.js
@@ -58,19 +58,21 @@ define(['angular'], function(angular) {
      * Trigger a Session Expired dialog box
      */
     function triggerDialog() {
-      var alert = $mdDialog.alert({
-        title: 'Session Expired',
-        textContent: 'Your session has expired. ' +
-          'Please click below to login, or close this window to logout.',
-        ok: 'Login',
-      });
-      $mdDialog
-        .show( alert )
-        .finally(function() {
-          alert = undefined;
-          $window.location.replace(MISC_URLS.loginURL);
-        })
-        .catch($log.error);
+      $mdDialog.show({
+        templateUrl:
+          'portal/timeout/session-expired.html',
+        parent: angular.element(document).find('div.my-uw')[0],
+        clickOutsideToClose: false,
+        openFrom: 'left',
+        closeTo: 'right',
+        controller: function DialogController($scope, $mdDialog) {
+          $scope.closeDialog = function() {
+            $mdDialog.hide();
+          };
+        },
+      }).finally(function() {
+        $window.location.replace(MISC_URLS.loginURL);
+      }).catch($log.error);
     }
 
     init();

--- a/components/portal/timeout/session-expired.html
+++ b/components/portal/timeout/session-expired.html
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <md-dialog class="dialog__session-expired" aria-label="session expired">
   <md-toolbar>
     <div class="md-toolbar-tools">

--- a/components/portal/timeout/session-expired.html
+++ b/components/portal/timeout/session-expired.html
@@ -1,0 +1,16 @@
+<md-dialog class="dialog__session-expired" aria-label="session expired">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h2>Session expired</h2>
+    </div>
+  </md-toolbar>
+  <md-dialog-content class="md-dialog-content">
+    <p>Your session has expired. If you navigate away from this page or close your browser tab or window, you will be logged out.</p>
+    <p>Please click the "Login" button below to login.</p>
+  </md-dialog-content>
+  <md-dialog-actions layout="row">
+    <md-button aria-label="close dialog and login" ng-click="closeDialog()">
+      LOGIN
+    </md-button>
+  </md-dialog-actions>
+</md-dialog>


### PR DESCRIPTION
[MUMUP-3364](https://jira.doit.wisc.edu/jira/browse/MUMUP-3364): "As a user of Advising Gateway, I would like the session expired message to not be blocked by other items such as drop downs, so I can interact with the session expired message and log in again."

**In this PR:**
- Increased z-index of all dialogs to the highest in-framework value (101)
    - *Note: Any downstream apps that still have problems with content obscuring these dialogs should adjust the z-index value of that content*
- Made session timeout dialog look like other dialogs used in the framework
- Fixed a bug that was causing the backdrop behind dialogs to appear transparent
- Add new `<body>` styles to replace the ones being brought in by Bootstrap
    - Ensures Robot font is used everywhere (never overridden by Bootstrap)
    - Sets base font size and line height values to match current ones (brought in by Bootstrap)
    - *Note: One step closer to safely removing Bootstrap as a dependency*
- Centered text on widget overlay messages

### Screenshots
![screen shot 2018-06-06 at 9 31 34 am](https://user-images.githubusercontent.com/5818702/41048886-5858516c-6975-11e8-9941-867e9fda70a0.png)
![screen shot 2018-06-06 at 10 22 56 am](https://user-images.githubusercontent.com/5818702/41048888-586ab50a-6975-11e8-84c4-04265a5d6644.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
