### PR TITLE
docs: document in list-of-links that limit reduced to 6

### DIFF
--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -107,7 +107,7 @@ Follow these steps for each of the predefined widget types described in this doc
 
 #### When to use
 
-Use `list-of-links` to present 2 to 7 links, dynamically sourced or statically
+Use `list-of-links` to present 2 to 6 links, dynamically sourced or statically
 configured.
 
 #### Additional entity file configuration
@@ -220,7 +220,7 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
   and cleaner user experience, and achieves better consistency with other
   just-a-link widgets in MyUW.
 * `list-of-links` presents different quantities of links differently. 1 to 4
-  links present as `circle-button`s. 5 to 7 links present as a more
+  links present as `circle-button`s. 5 to 6 links present as a more
   traditional-style list. Zero links presents as a basic widget.
 * Use brief sentence-case link titles. `list-of-links` truncates link titles to
   24 characters.


### PR DESCRIPTION
Documents in the widget-developer-facing documentation #772 's change to reduce `list-of-links` link quantity limit to 6 from 7.

The functional change is to address a display issue where, depending on icon choice, the list could vertically exceed the widget  box.