### PR TITLE
style: set no overflow on rss titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 
 ### Fixed
+* Dates and titles in RSS widget no longer overlap each other (#780) 
 
 
 ### Removed

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -280,6 +280,7 @@
             width: 80%;
             font-size: 12px;
             white-space: nowrap;
+            overflow: hidden;
           }
 
           div.headline.nodate {


### PR DESCRIPTION
**In this PR:**
- Fixes date text overlapping title text on some screen sizes


### Screenshot
![screen shot 2018-06-26 at 10 24 03 am](https://user-images.githubusercontent.com/5818702/41922608-17cc3fda-792b-11e8-82fc-e479bc27731e.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
