### PR TITLE
feat: add contextual menu for widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * Changes list of links limit to 6 items. (#773)
 * Removes rootScope guest mode (#777)
 * Fixed list of links widget buttons clipping on some screen sizes (#781)
+* Moved widget info (description) and remove button into contextual menu to reduce burden on keyboard users (#785)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 * Changes list of links limit to 6 items. (#773)
 * Removes rootScope guest mode (#777)
 * Fixed list of links widget buttons clipping on some screen sizes (#781)
-* Moved widget info (description) and remove button into contextual menu to reduce burden on keyboard users (#785)
+* Moved widget info (description) and remove button into contextual menu to reduce burden on keyboard users (#786)
 
 
 ### Fixed

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -67,6 +67,19 @@ md-menu-content {
 
     .widget-description {
       height: auto;
+
+      .material-icons {
+        width: auto;
+        margin: auto 24px auto 0;
+        padding: 0 0 0 16px;
+      }
+      > span {
+        padding-left: 0;
+      }
+
+      &:focus {
+        outline: none;
+      }
     }
   }
 }

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -61,6 +61,14 @@ md-menu-content {
       }
     }
   }
+
+  &.widget-menu {
+    max-width: 290px;
+
+    .widget-description {
+      height: auto;
+    }
+  }
 }
 
 div.md-dialog-container {

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -73,6 +73,7 @@ md-menu-content {
         margin: auto 24px auto 0;
         padding: 0 0 0 16px;
       }
+
       > span {
         padding-left: 0;
       }

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -502,6 +502,8 @@
     right: 0;
     margin: 0;
     z-index: @widget-depth-1;
+    opacity: 0;
+    transition: @transition-opacity;
 
     .md-button {
       margin: 6px;
@@ -510,6 +512,16 @@
         font-size: 18px;
         line-height: 24px;
       }
+    }
+
+    &:focus {
+      opacity: 1;
+    }
+  }
+
+  &:hover {
+    .widget-action {
+      opacity: 1;
     }
   }
 }

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -498,24 +498,18 @@
   .widget-action {
     position: absolute;
     display: inline;
-    opacity: 0;
     top: 0;
+    right: 0;
     margin: 0;
-    transition: @transition-opacity;
     z-index: @widget-depth-1;
 
-    &.widget-info {
-      left: 0;
-    }
+    .md-button {
+      margin: 6px;
 
-    .material-icons {
-      font-size: 18px;
-    }
-  }
-
-  &:hover {
-    .widget-action {
-      opacity: 1;
+      .material-icons {
+        font-size: 18px;
+        line-height: 24px;
+      }
     }
   }
 }

--- a/components/js/override.js
+++ b/components/js/override.js
@@ -25,6 +25,9 @@ define(['angular'], function(angular) {
         // 'enablePushContentMenu': true,
       },
       'SERVICE_LOC': {
+        // 'widgetApi': {
+        //   'entry': 'staticFeeds/',
+        // },
         // 'aboutURL': 'staticFeeds/about-frame.json',
         // 'aboutPageURL': 'staticFeeds/about-page.json'
         // 'messagesURL': 'staticFeeds/sample-messages.json',

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -53,11 +53,12 @@
         <md-icon>more_vert</md-icon>
       </md-button>
       <md-menu-content class="widget-menu" width="4">
-        <md-menu-item class="widget-description" md-autofocus tabindex="1">
+        <md-menu-item class="widget-description" md-autofocus tabindex="1" layout="row" layout-align="start center">
+          <md-icon>info</md-icon>
           <span><b>{{ widget.title }}:</b> {{ widget.description }}</span>
         </md-menu-item>
         <!-- Remove widget button -->
-        <div ng-transclude id="widget-removal"></div>
+        <div ng-transclude id="widget-removal">
       </md-menu-content>
     </md-menu>
   </md-card-header>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -37,22 +37,29 @@
 
   <!-- HEADER -->
   <md-card-header class="widget-header">
-    <!-- Widget description tooltip -->
-    <md-button class="widget-action widget-info md-icon-button" aria-label="{{ widget.title }}: {{ widget.description }}" role="tooltip" ng-hide="widget.lifecycleState === 'MAINTENANCE'">
-      <md-tooltip md-direction="top" class="widget-action-tooltip">
-        {{ widget.description }}
-      </md-tooltip>
-      <md-icon>info</md-icon>
-    </md-button>
-    <!-- Remove widget button -->
-    <div ng-transclude id="widget-removal">
-    </div>
 
-    <md-card-header-text aria-hidden="true">
-      <span class="md-title" style="text-align: center;" tabindex="-1">
+    <md-card-header-text>
+      <span class="md-title" style="text-align: center;">
 	      {{ widget.title }}
       </span>
     </md-card-header-text>
+
+    <!-- Widget contextual menu -->
+    <md-menu class="widget-action" md-position-mode="target-right bottom">
+      <md-button class="md-icon-button" aria-label="open {{ widget.title }} menu" ng-click="$mdOpenMenu($event)">
+        <md-tooltip class="widget-action-tooltip" md-direction="top" role="tooltip">
+          Open {{ widget.title }} menu
+        </md-tooltip>
+        <md-icon>more_vert</md-icon>
+      </md-button>
+      <md-menu-content class="widget-menu" width="4">
+        <md-menu-item class="widget-description" md-autofocus tabindex="1">
+          <span><b>{{ widget.title }}:</b> {{ widget.description }}</span>
+        </md-menu-item>
+        <!-- Remove widget button -->
+        <div ng-transclude id="widget-removal"></div>
+      </md-menu-content>
+    </md-menu>
   </md-card-header>
 
   <!-- BODY -->

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -55,7 +55,7 @@
       <md-menu-content class="widget-menu" width="4">
         <md-menu-item class="widget-description" md-autofocus tabindex="1" layout="row" layout-align="start center">
           <md-icon>info</md-icon>
-          <span><b>{{ widget.title }}:</b> {{ widget.description }}</span>
+          <span><strong>{{ widget.title }}:</strong> {{ widget.description }}</span>
         </md-menu-item>
         <!-- Remove widget button -->
         <div ng-transclude id="widget-removal">


### PR DESCRIPTION
[https://jira.doit.wisc.edu/jira/browse/MUMUP-3297](MUMUP-3297): "As a person navigating MyUW via keyboard, I would like the less-often-used controls associated with widgets on my home tucked away into a contextual menu, so that the primary navigation is simpler."

**Companion PR:** [uportal-home #840](https://github.com/uPortal-Project/uportal-home/pull/840)

**In this PR:**
- Move widget info (description) and remove button into single contextual menu
- Make widget title focusable 
- Added another demo configuration for local development to `override.js` 

### Demo
![widget-menu](https://user-images.githubusercontent.com/5818702/42523809-7048b17a-8434-11e8-92f2-f2f5548da454.gif)


### Screenshot
![screen shot 2018-07-10 at 11 22 52 am](https://user-images.githubusercontent.com/5818702/42523804-6c6a9c76-8434-11e8-9455-5dc47634de08.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
