### PR TITLE
fix: rm unused not-unique "widget-removal" div id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * Dates and titles in RSS widget no longer overlap each other (#780) 
+* Removes unused `id` on the widget-removal div, thereby removing a source of
+  HTML element `id` uniqueness constraint violations in the markup. (#787)
 
 
 ### Removed

--- a/components/portal/widgets/partials/compact-widget-card.html
+++ b/components/portal/widgets/partials/compact-widget-card.html
@@ -25,7 +25,7 @@
     </md-tooltip>
     <md-icon>info</md-icon>
   </md-button>
-  <div ng-transclude id="widget-removal"></div>
+  <div ng-transclude></div>
   <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
     <div class="icon-container">
       <widget-icon></widget-icon>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -58,7 +58,7 @@
           <span><strong>{{ widget.title }}:</strong> {{ widget.description }}</span>
         </md-menu-item>
         <!-- Remove widget button -->
-        <div ng-transclude id="widget-removal">
+        <div ng-transclude>
       </md-menu-content>
     </md-menu>
   </md-card-header>


### PR DESCRIPTION
The div will exist many times in the page, yielding [duplicate div ids forbidden by HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) .

Fortunately, we're not using this div (it has no references in `uportal-app-framework` nor in `uPortal-home`). So drop the `id` attribute, resolving the uniqueness constraint violation and simplifying the code. Win-win.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
