### PR TITLE
feat: add canAdd filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* new filter `canAdd`, useful for filtering portlets on whether user can or
+  cannot add them to layout (#791)
 
 ### Changed
 * Changes list of links limit to 6 items. (#773)

--- a/components/portal/misc/filters.js
+++ b/components/portal/misc/filters.js
@@ -55,30 +55,26 @@ define(['angular'], function(angular) {
 
     .filter('showApplicable', function() {
         return function(portlets, showAll) {
-            var filteredPortlets = [];
             if (showAll === true) {
               return portlets;
             }
             if (showAll === false) {
-              angular.forEach(portlets, function(portlet) {
-                if ( portlet.canAdd === true) {
-                  filteredPortlets.push(portlet);
+              return portlets.filter(
+                function(portlet) {
+                  return portlet.canAdd;
                 }
-              });
-              return filteredPortlets;
+              );
             }
         };
     })
     .filter('canAdd', function() {
       // filters to portlets with a .canAdd matching the passed boolean
       return function(portlets, canAddOrNot) {
-        var filteredPortlets = [];
-        angular.forEach(portlets, function(portlet) {
-          if (portlet.canAdd === canAddOrNot) {
-            filteredPortlets.push(portlet);
+        return portlets.filter(
+          function(portlet) {
+            return portlet.canAdd === canAddOrNot;
           }
-        });
-        return filteredPortlets;
+        );
       };
     })
     .filter('showCategory', function() {

--- a/components/portal/misc/filters.js
+++ b/components/portal/misc/filters.js
@@ -69,6 +69,18 @@ define(['angular'], function(angular) {
             }
         };
     })
+    .filter('canAdd', function() {
+      // filters to portlets with a .canAdd matching the passed boolean
+      return function(portlets, canAddOrNot) {
+        var filteredPortlets = [];
+        angular.forEach(portlets, function(portlet) {
+          if (portlet.canAdd === canAddOrNot) {
+            filteredPortlets.push(portlet);
+          }
+        });
+        return filteredPortlets;
+      };
+    })
     .filter('showCategory', function() {
       return function(portlets, category) {
         if (category === '') {


### PR DESCRIPTION
add filter on whether the user can or cannot add the given portlet to layout.

Potentially useful in resolving the mismatch between reported and shown quantity of app directory search results, since that turns out to be a difference of including items one cannot add in the badge count while not displaying such items.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
