### PR TITLE
feat: add compact mode examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
++ Out of the box example page now includes compact mode widget examples, rather
+  than just expanded mode widget examples. (#791)
 
 ### Changed
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -28,6 +28,7 @@
       margin: 4px 8px;
     }
   </style>
+  <h2>Example expanded mode widgets</h2>
   <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
       <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__benefits"></widget>
@@ -54,4 +55,31 @@
         <widget fname="sample-widget__basic"></widget>
       </div>
     </div>
+    <h2>Example compact mode widgets</h2>
+    <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__benefits"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__custom"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__rss"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__list-of-links"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__list-of-8-links"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__list-of-no-links"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__search-with-links"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__basic"></compact-widget>
+        </div>
+      </div>
 </frame-page>


### PR DESCRIPTION
Adds compact mode widget examples to the existing examples page that had only shown expanded mode widget examples.

![added-example-compact-mode-widgets](https://user-images.githubusercontent.com/952283/42715094-f9826dfe-86ba-11e8-885b-d7d88f4e2783.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
