### PR TITLE
fix: use contextual menu in compact widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
++ Fixed display bug in compact widgets. Compact widgets now correctly use the per-widget contextual menu. (#794)
+
 
 ### Removed
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -28,7 +28,7 @@
       margin: 4px 8px;
     }
   </style>
-  <h2>Example expanded mode widgets</h2>
+  <h2 style="margin-left:26px">Example expanded mode widgets</h2>
   <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
       <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__benefits"></widget>

--- a/components/portal/widgets/partials/compact-widget-card.html
+++ b/components/portal/widgets/partials/compact-widget-card.html
@@ -19,13 +19,24 @@
 
 -->
 <md-card class="list-content" id="widget-id-{{::widget.nodeId}}">
-  <md-button class="widget-action widget-info md-icon-button" aria-label="{{ widget.title }}: {{ widget.description }}" role="tooltip" ng-hide="widget.lifecycleState === 'MAINTENANCE'">
-    <md-tooltip md-direction="top" class="widget-action-tooltip">
-      {{ widget.description }}
-    </md-tooltip>
-    <md-icon>info</md-icon>
-  </md-button>
-  <div ng-transclude></div>
+  <!-- Widget contextual menu -->
+  <md-menu class="widget-action" md-position-mode="target-right bottom">
+    <md-button class="md-icon-button" aria-label="open {{ widget.title }} menu" ng-click="$mdOpenMenu($event)">
+      <md-tooltip class="widget-action-tooltip" md-direction="top" role="tooltip">
+        Open {{ widget.title }} menu
+      </md-tooltip>
+      <md-icon>more_vert</md-icon>
+    </md-button>
+    <md-menu-content class="widget-menu" width="4">
+      <md-menu-item class="widget-description" md-autofocus tabindex="1" layout="row" layout-align="start center">
+        <md-icon>info</md-icon>
+        <span><strong>{{ widget.title }}:</strong> {{ widget.description }}</span>
+      </md-menu-item>
+      <!-- Remove widget button -->
+      <div ng-transclude></div>
+    </md-menu-content>
+  </md-menu>
+  <!-- Widget clickable area -->
   <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
     <div class="icon-container">
       <widget-icon></widget-icon>


### PR DESCRIPTION
[MUMUP-3374](https://jira.doit.wisc.edu/jira/browse/MUMUP-3374): "As a compact mode user, I would like the widgets to not all say 'Remove from home', so that I know what my widgets are and can use them confidently."

**In this PR**:
- Compact widgets now use contextual menu (like expanded widgets)
- Added a margin to example page heading

### Screenshots
<img width="293" alt="screen shot 2018-07-16 at 12 53 17 pm" src="https://user-images.githubusercontent.com/5818702/42774687-f1903e8e-88f7-11e8-9898-eca004f7e2bf.png">

<img width="557" alt="screen shot 2018-07-16 at 12 53 26 pm" src="https://user-images.githubusercontent.com/5818702/42774683-ec9c674a-88f7-11e8-83e4-07eddd15d537.png">


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [ ] Updates `CHANGELOG.md` to reflect this PR's change.
- [ ] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
