### PR TITLE
fix: enable activating remove button with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 + Fixed display bug in compact widgets. Compact widgets now correctly use the per-widget contextual menu. (#794)
 + Make widget removal button focusable by keyboard when present (#797)
++ Enable keyboard activation of widget removal button, when present (#800)
 
 
 ### Removed

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -27,8 +27,10 @@ define(['angular', 'moment'], function(angular, moment) {
    * the type and sets launch button url for un-typed (basic) widgets.
    */
   .controller('WidgetCardController', [
-    '$scope', '$log', '$localStorage', '$transclude', '$timeout', 'widgetService',
-    function($scope, $log, $localStorage, $transclude, $timeout, widgetService) {
+    '$scope', '$log', '$localStorage', '$transclude', '$timeout',
+    'widgetService',
+    function($scope, $log, $localStorage, $transclude, $timeout,
+             widgetService) {
     /**
      * Check for widget types that require extra configuration
      * (including null/undefined case), default to provided
@@ -83,7 +85,8 @@ define(['angular', 'moment'], function(angular, moment) {
     $scope.triggerRemoveButton = function(event) {
       // If user pressed enter key, manually trigger the remove button
       if (event.keyCode === 13) {
-        var removeButton = angular.element(event.target.querySelector('.widget-remove'));
+        var removeButton =
+          angular.element(event.target.querySelector('.widget-remove'));
         // Make sure we correctly targeted a button
         if (removeButton[0].tagName === 'BUTTON') {
           // Break current $apply cycle to ensure this fires
@@ -117,7 +120,6 @@ define(['angular', 'moment'], function(angular, moment) {
           }
           // If there's a remove button, make it focusable by keyboard
           if ($transclude.isSlotFilled('removeButton')) {
-            console.log('slot is filled');
             $scope.tabindex = '1';
           }
           return data;

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -83,6 +83,7 @@ define(['angular', 'moment'], function(angular, moment) {
        * @param {object} event The DOM event that called the function
        */
     $scope.triggerRemoveButton = function(event) {
+      event.preventDefault();
       // If user pressed enter key, manually trigger the remove button
       if (event.keyCode === 13) {
         var removeButton =

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -27,8 +27,8 @@ define(['angular', 'moment'], function(angular, moment) {
    * the type and sets launch button url for un-typed (basic) widgets.
    */
   .controller('WidgetCardController', [
-    '$scope', '$log', '$localStorage', '$transclude', 'widgetService',
-    function($scope, $log, $localStorage, $transclude, widgetService) {
+    '$scope', '$log', '$localStorage', '$transclude', '$timeout', 'widgetService',
+    function($scope, $log, $localStorage, $transclude, $timeout, widgetService) {
     /**
      * Check for widget types that require extra configuration
      * (including null/undefined case), default to provided
@@ -75,6 +75,25 @@ define(['angular', 'moment'], function(angular, moment) {
       }
     };
 
+      /**
+       * Enable keyboard activation of transcluded remove button
+       * so it plays nice with the aria-role "button"
+       * @param {object} event The DOM event that called the function
+       */
+    $scope.triggerRemoveButton = function(event) {
+      // If user pressed enter key, manually trigger the remove button
+      if (event.keyCode === 13) {
+        var removeButton = angular.element(event.target.querySelector('.widget-remove'));
+        // Make sure we correctly targeted a button
+        if (removeButton[0].tagName === 'BUTTON') {
+          // Break current $apply cycle to ensure this fires
+          $timeout(function() {
+            removeButton.triggerHandler('click');
+          }, 0);
+        }
+      }
+    };
+
     /**
      * Initial widget setup -- gets data for a single widget
      * from the provided fname attribute, makes transcluded content
@@ -98,6 +117,7 @@ define(['angular', 'moment'], function(angular, moment) {
           }
           // If there's a remove button, make it focusable by keyboard
           if ($transclude.isSlotFilled('removeButton')) {
+            console.log('slot is filled');
             $scope.tabindex = '1';
           }
           return data;

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -64,7 +64,7 @@
           <span><strong>{{ widget.title }}:</strong> {{ widget.description }}</span>
         </md-menu-item>
         <!-- Remove widget button -->
-        <div role="button" tabindex="{{ tabindex }}" ng-transclude="removeButton"></div>
+        <div role="button" tabindex="{{ tabindex }}" ng-transclude="removeButton" ng-keyup="triggerRemoveButton($event)"></div>
       </md-menu-content>
     </md-menu>
   </md-card-header>


### PR DESCRIPTION
**In this PR:**
- Pressing "enter" when focusing the widget removal transclude slot now correctly triggers a click event on the transcluded button

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
