### PR TITLE
fix: show readable errors at all points of failure

### DIFF
--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -323,6 +323,10 @@
           font-size: 20px;
           margin-right: 10px;
         }
+
+        .action-item__error-quantity {
+          margin-right: 16px;
+        }
       }
 
       p.action-item__showing {

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -354,8 +354,8 @@ define(['angular', 'moment'], function(angular, moment) {
 
   // ACTION ITEMS widget type
   .controller('ActionItemsController', [
-    '$scope', '$log', '$window', 'widgetService',
-    function($scope, $log, $window, widgetService) {
+    '$scope', '$log', '$window', '$filter', 'widgetService',
+    function($scope, $log, $window, $filter, widgetService) {
     // Scope functions
     /**
      * Navigate to the url provided by the action item
@@ -380,13 +380,25 @@ define(['angular', 'moment'], function(angular, moment) {
         .then(function(data) {
           // Make sure we got a something back
           if (data) {
-            // Add an action item to scope array
-            $scope.actionItems.push({
-              textSingular: item.textSingular,
-              textPlural: item.textPlural,
-              actionUrl: item.actionUrl,
-              quantity: data.quantity,
-            });
+            // Make sure quantity is a number
+            if (isNaN(data.quantity)) {
+              // Log problem and don't include in list
+              $log.warn('Got non-number data from ' + item.feedUrl);
+              // Reduce display limit (only once) to make room for error
+              if (!$scope.errorQuantity) {
+                $scope.itemsLimit -= 1;
+              }
+              // Show error
+              $scope.errorQuantity = true;
+            } else {
+              // Add an action item to scope array
+              $scope.actionItems.push({
+                textSingular: item.textSingular,
+                textPlural: item.textPlural,
+                actionUrl: item.actionUrl,
+                quantity: data.quantity,
+              });
+            }
           }
 
           return data;
@@ -394,7 +406,6 @@ define(['angular', 'moment'], function(angular, moment) {
         .catch(function(error) {
           // Log a service failure error
           $log.warn('Problem getting action item data from: ' + item.feedUrl);
-          $log.error(error);
           $scope.error = true;
           $scope.loading = false;
         });
@@ -421,7 +432,9 @@ define(['angular', 'moment'], function(angular, moment) {
         }
 
         // If this is the last time through the loop, turn off loading spinner
+        // and reorder the list by quantity
         if (i === $scope.config.actionItems.length - 1) {
+          $scope.actionItems = $filter('orderBy')($scope.actionItems, 'quantity', true);
           $scope.loading = false;
         }
       }
@@ -436,6 +449,7 @@ define(['angular', 'moment'], function(angular, moment) {
       $scope.actionItems = [];
       $scope.loading = true;
       $scope.error = false;
+      $scope.errorQuantity = false;
       $scope.itemsLimit = 3;
 
       // Make sure we got a widget and necessary config

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -24,10 +24,16 @@
     <!-- Loading case -->
     <loading-gif data-object="actionItems" ng-show="loading"></loading-gif>
 
-    <!-- Error case -->
+    <!-- Error case (endpoint failure) -->
     <div class="error" layout="row" layout-align="start center" ng-show="error">
       <div><md-icon class="md-warn">warning</md-icon></div>
       <span>There was an issue loading the information. Click See all for more info.</span>
+    </div>
+
+    <!-- Error case (non-number quantity for all items) -->
+    <div class="error" layout="row" layout-align="start center" ng-show="errorQuantity">
+      <div><md-icon class="md-warn">warning</md-icon></div>
+      <span>One or more items failed to retrieve quantity data. Click see all for more info.</span>
     </div>
   </div>
 
@@ -43,9 +49,14 @@
           <p ng-if="item.quantity != 1">{{ item.textPlural }}</p>
         </div>
       </md-list-item>
+      <!-- Error case (non-number quantity item) -->
+      <md-list-item ng-show="errorQuantity">
+        <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
+        <p>At least one item failed to retrieve quantity data</p>
+      </md-list-item>
     </md-list>
     <!-- Over limit case -->
-    <p ng-show="actionItems.length > itemsLimit" class="action-item__showing">Showing {{ itemsLimit }} of {{ actionItems.length }}</p>
+    <p ng-show="actionItems.length > itemsLimit" class="action-item__showing">Showing {{ errorQuantity ? itemsLimit + 1 : itemsLimit }} of {{ actionItems.length }}</p>
   </div>
 
 </div>


### PR DESCRIPTION
[MUMUP-3368 & #785 ](https://jira.doit.wisc.edu/jira/browse/MUMUP-3368): "As an employee viewing the HRS Approvals widget, I would like the widget to fail cogently when for whatever reason it cannot read a quantity of approvals from HRS, so I am not confused and discouraged by a goofy failure experience."

**In this PR**:
- Compensate for user-provided service URL returning non-number data
- New error state for when all items return non-number data
- Order items by quantity
    - When a widget has more than three action items, items requiring attention take priority

### Screenshots
#### Single-error state
![screen shot 2018-08-02 at 10 28 24 am](https://user-images.githubusercontent.com/5818702/43596138-0f4b032e-9644-11e8-9904-a01d916e8aa2.png)
#### Single-error state showing display limit compensation
![screen shot 2018-08-02 at 10 39 46 am](https://user-images.githubusercontent.com/5818702/43596139-0f60a0e4-9644-11e8-9735-c385e5f72c00.png)
#### Ordering by quantity
![screen shot 2018-08-02 at 10 55 14 am](https://user-images.githubusercontent.com/5818702/43596140-0f7384de-9644-11e8-8935-65358adf7347.png)
#### All items returned non-number quantity
![screen shot 2018-08-02 at 10 57 25 am](https://user-images.githubusercontent.com/5818702/43596141-0f87aa2c-9644-11e8-9c1e-8bfcedce33d8.png)


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
