### PR TITLE
MUMUP-3379: removes unused avatar setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
++ Removes unused photo opt-out on settings page (#811)
 
 ### Deprecated
 

--- a/components/portal/settings/controllers.js
+++ b/components/portal/settings/controllers.js
@@ -88,16 +88,6 @@ define(['angular'], function(angular) {
         });
       };
 
-      $scope.avatarOptOut = function() {
-        $rootScope.optAvatar = false;
-        $sessionStorage.optAvatar = false;
-      };
-
-      $scope.avatarOptIn = function() {
-        $rootScope.optAvatar = true;
-        $sessionStorage.optAvatar = true;
-      };
-
       init();
     }]);
  });

--- a/components/portal/settings/partials/user-settings.html
+++ b/components/portal/settings/partials/user-settings.html
@@ -50,19 +50,7 @@
           <small>Click to reset your portal layout.</small>
         </div>
       </div>
-      <div ng-show="optAvatar" layout="column" layout-gt-xs="row" layout-align="start center">
-          <md-button class="md-accent md-raised" layout-align-xs="center start"   ng-click="avatarOptOut()">
-            Do Not Use My Photo
-          </md-button>
-          <small>Requires page refresh to take effect.</small>
-        </div>
-      <div ng-show="!optAvatar" layout-align-xs="center start" layout="column" layout-align="start center" layout-gt-xs="row">
-          <md-button class="md-accent md-raised" ng-click="avatarOptIn()">
-            Use My Photo
-          </md-button>
-          <small>Requires page refresh to take effect.</small>
-        </div>
-        <h4 class="md-subhead">Reset In-Browser State<br>
+      <h4 class="md-subhead">Reset In-Browser State<br>
           <small>Clear in-browser session storage and local storage. This is perfectly safe and may cause some changes to take effect faster.</small>
         </h4>
         <div layout="column" layout-gt-xs="row">


### PR DESCRIPTION
This change removes the unused photo option from the user-settings page. (We can always put it back if we plan to implement that feature.)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [X] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
