### PR TITLE
docs(messages): clarify that at most one of each button type per message

### DIFF
--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -76,7 +76,7 @@ Widget messaging is based on JSON input configured in a [widget's configuration]
   - **dataArrayFilter**: Will only be looked at if `dataUrl` is present, otherwise ignored. Used as an optional further refinement from dataUrl. If your object return is an array, you can filter on the array. Does support multiple filtering criteria as shown in the example. If used in conjunction with `dataObject`, will filter to `dataObject` first.  [AngularJS array filtering documentation] (https://docs.angularjs.org/api/ng/filter/filter)
   - **dataMessageTitle** Will be used if dataUrl is specified. Used to set the title of the message from the data response from `dataUrl`.  Expects an array for where to find the title in the data response from `dataUrl`.
   - **dataMessageMoreInfoUrl** Will be used if `dataUrl` is specified and the `more info button` is configured.  Used to set the url of the `more info button`.  Expects an array for where to find the `more info button url` in the data response from `dataUrl`.
-- **actionButton**: Used to display a call to action button and to provide the URL for a notification when clicked. **Required if the `messageType` is "notification".
+- **actionButton**: Used to display a call to action button and to provide the URL for a notification when clicked. **Required if the `messageType` is "notification".**
   - **label**: The button's text
   - **url**: The URL to go to when clicked
     - **addToHome** For an "Add To Home" action button, where the user is asked to add a widget to their home layout, the url is formatted: "addToHome/{fName}", where fName = the fname of the widget.

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -83,6 +83,9 @@ Widget messaging is based on JSON input configured in a [widget's configuration]
 - **moreInfoButton**: Used to display a button link to a place where the user can read more, see more, or interact with the subject of the message. Uses the same format as `actionButton`.
 - **confirmButton**: Used to display a confirmation button on popup announcements. Uses the same format as `actionButton`. **Required for `messageType` "announcement" with `priority` "high".**
 
+A given message can have at most one each of the `actionButton`,
+`moreInfoButton`, and `confirmButton` buttons.
+
 ## Configuring the mascot announcer
 
 The `mascotImg` variable in [the theme](theming.md) sets the theme-specific mascot. If `mascotImg` is unset, it defaults to a generic robot mascot.


### PR DESCRIPTION
Captures to documentation clarification that arose in answering a question about whether multiple action buttons are available per message.

Also fixes a text styling glitch.