### PR TITLE
docs(widgets): list all documented widget types

### DIFF
--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -75,6 +75,8 @@ The above attributes are all you need to configure a basic widget!
 + List of links
 + Search with links
 + RSS widget
++ Action items
++ Time-sensitive-content
 
 ## Advantages of widget types
 


### PR DESCRIPTION
Fix the "Predefined widget types" bulleted list in
`make-a-widget.md` to include bullets for the "Action items" and "Time-sensitive-content" types, which types are documented in that file.