### PR TITLE
feat(switch): add "switch" widget type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
++ New `switch` widget type.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-+ New `switch` widget type, for composing composite widgets by dynamically
-  switching over other types and configurations of widgets. (#820)
++ New `switch` widget type ( `<switch-widget>` directive), for composing
+  composite widgets by dynamically switching over other types and configurations
+  of widgets. (#820)
 + New `<widget-content>` directive, factored out from the inline `ng-switch` in
   `<widget-card>`. Not a breaking change: `widget-card` behaves the same as
   before, its implementation now delegates to `<widget-content>` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 + New `switch` widget type, for composing composite widgets by dynamically
   switching over other types and configurations of widgets. (#820)
++ New `<basic-widget>` directive, refactored out from the inline template in
+  `<widget-card>`. Not a breaking change: `<widget-card>` behaves the same as
+  before, its implementation now delegates to `<basic-widget>` in the basic
+  widget case. (#820)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 + New `switch` widget type, for composing composite widgets by dynamically
   switching over other types and configurations of widgets. (#820)
++ New `<widget-content>` directive, factored out from the inline `ng-switch` in
+  `<widget-card>`. Not a breaking change: `widget-card` behaves the same as
+  before, its implementation now delegates to `<widget-content>` for the
+  `md-card-content` part of the template. (#820)
 + New `<basic-widget>` directive, refactored out from the inline template in
   `<widget-card>`. Not a breaking change: `<widget-card>` behaves the same as
   before, its implementation now delegates to `<basic-widget>` in the basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-+ New `switch` widget type.
++ New `switch` widget type, for composing composite widgets by dynamically
+  switching over other types and configurations of widgets. (#820)
 
 ### Changed
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -61,6 +61,28 @@
         <widget fname="sample-widget__maintenance-custom"></widget>
       </div>
     </div>
+
+    <h3 style="margin-left:26px">Example switch widgets in expanded mode</h3>
+    <div style="margin-left:26px">Switch widgets dynamically change runtime type depending upon the
+      response from a JSON callback. They are useful for composing existing
+      widget types to create composite widgets that fulfill more complicated
+      use cases without proliferating new widget types or opting out of the
+      type system to use an entirely custom widget.</div>
+    <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
+      <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__switch"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__switch_2"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__switch_otherwise"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__switch_broken"></widget>
+      </div>
+    </div>
+
     <h2 style="margin-left:26px">Example compact mode widgets</h2>
     <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
         <div flex-xs="100" class="widget-container">
@@ -94,6 +116,9 @@
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__maintenance-custom">
           </compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__switch"></compact-widget>
         </div>
       </div>
 </frame-page>

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -715,7 +715,7 @@ define(['angular', 'moment'], function(angular, moment) {
        * Fetch additional widget data
        */
       var initializeSwitchWidget = function() {
-      $log.warn("Initializing switch widget.");
+      $log.warn('Initializing switch widget.');
       // save widgetConfig as switchConfig so switch can then conditionally
       // mess with widgetConfig in activating a different widget type
       $scope.switchConfig = $scope.widget.widgetConfig;
@@ -729,7 +729,7 @@ define(['angular', 'moment'], function(angular, moment) {
         widgetService.getWidgetJson($scope.widget).then(function(data) {
           // if there's a case matching the returned JSON, activate it
 
-          $log.warn("Switch widget got JSON " + data);
+          $log.warn('Switch widget got JSON ' + data);
 
           var parsedExpression = $parse($scope.switchConfig.expression);
 
@@ -747,7 +747,7 @@ define(['angular', 'moment'], function(angular, moment) {
           if (!caseToActivate && $scope.switchConfig &&
             $scope.switchConfig.caseotherwise) {
             $log.debug($scope.widget.fname +
-              " switching to otherwise case after no case matched value " +
+              ' switching to otherwise case after no case matched value ' +
               dynamicValueToMatch);
             caseToActivate = $scope.switchConfig.caseotherwise;
           }
@@ -765,7 +765,7 @@ define(['angular', 'moment'], function(angular, moment) {
               // switch to the new type
               $scope.widget.widgetType = caseToActivate.widgetType;
             } else {
-              $scope.widget.widgetType = "basic";
+              $scope.widget.widgetType = 'basic';
             }
 
             if (caseToActivate.widgetConfig) {
@@ -785,35 +785,35 @@ define(['angular', 'moment'], function(angular, moment) {
           } else {
 
             $log.debug($scope.widget.fname +
-              " did not switch to any case (not even an otherwise case) " +
-              "for activation, so falling back to being a basic widget.");
+              ' did not switch to any case (not even an otherwise case) ' +
+              'for activation, so falling back to being a basic widget.');
 
-            $scope.widget.widgetType = "basic";
-            $scope.widget.widgetConfig = "";
+            $scope.widget.widgetType = 'basic';
+            $scope.widget.widgetConfig = '';
           }
 
         }).catch(function(error) {
 
           $log.error($scope.widget.fname +
-            " errored fetching or processing JSON [" + $scope.widget.widgetURL
-            + "] to switch on; falling back on being a basic widget.");
+            ' errored fetching or processing JSON [' + $scope.widget.widgetURL
+            + '] to switch on; falling back on being a basic widget.');
           $log.error(error);
 
-          $scope.widget.widgetType = "basic";
-          $scope.widget.widgetConfig = "";
+          $scope.widget.widgetType = 'basic';
+          $scope.widget.widgetConfig = '';
         }).finally(function() {
           // nothing to do
         });
       } else {
 
-        $log.warn($scope.widget.fname + " not configured with " +
-        "URL from which to load JSON [" + $scope.widget.widgetURL + "]," +
-        " expression [" + $scope.switchConfig.expression + "]" +
-        " to parse from that JSON, or cases to match against," +
-        " so falling back on being a basic widget.");
+        $log.warn($scope.widget.fname + ' not configured with ' +
+        'URL from which to load JSON [' + $scope.widget.widgetURL + '],' +
+        ' expression [' + $scope.switchConfig.expression + ']' +
+        ' to parse from that JSON, or cases to match against,' +
+        ' so falling back on being a basic widget.');
 
-        $scope.widget.widgetType = "basic";
-        $scope.widget.widgetConfig = "";
+        $scope.widget.widgetType = 'basic';
+        $scope.widget.widgetConfig = '';
       }
     };
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -156,6 +156,32 @@ define(['angular', 'moment'], function(angular, moment) {
       $scope.initializeWidget($scope.fname);
   }])
 
+  /**
+   * Controller for un-typed (basic) widgets.
+   * Sets launch button url for these widgets.
+   */
+  .controller('BasicWidgetController', [
+    '$scope', '$log', '$localStorage', 'widgetService',
+    function($scope, $log, $localStorage, widgetService) {
+      /**
+       * Set the launch button url for static content,
+       * exclusive mode, and basic widgets
+       * @return {*}
+       */
+      $scope.renderUrl = function renderUrl() {
+        var widget = $scope.widget;
+        // Check for static content or exclusive mode portlets (rare)
+        if (widget.altMaxUrl == false) {
+          if (widget.staticContent != null) {
+            return 'static/' + widget.fname;
+          } else if (widget.renderOnWeb || $localStorage.webPortletRender) {
+            return 'exclusive/' + widget.fname;
+          }
+        }
+        return widget.url;
+      };
+    }])
+
     // External Message Controller
   .controller('WidgetExternalMessageController', [
     '$scope', '$log', 'widgetService',

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -797,8 +797,6 @@ define(['angular', 'moment'], function(angular, moment) {
 
           $scope.widget.widgetType = 'basic';
           $scope.widget.widgetConfig = '';
-        }).finally(function() {
-          // nothing to do
         });
       } else {
         $log.warn($scope.widget.fname + ' not configured with ' +

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -727,7 +727,7 @@ define(['angular', 'moment'], function(angular, moment) {
         // and case(s) to match against,
         // so load that dynamic JSON, do the parsing and selecting
         widgetService.getWidgetJson($scope.widget).then(function(data) {
-          // if there's a case matching the returned JSON, activate it
+          // returns the new $scope.widget.widgetType, e.g. 'list-of-links'
 
           $log.warn('Switch widget got JSON ' + data);
 
@@ -788,6 +788,7 @@ define(['angular', 'moment'], function(angular, moment) {
             $scope.widget.widgetType = 'basic';
             $scope.widget.widgetConfig = '';
           }
+          return $scope.widget.widgetType;
         }).catch(function(error) {
           $log.error($scope.widget.fname +
             ' errored fetching or processing JSON [' + $scope.widget.widgetURL

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -735,8 +735,12 @@ define(['angular', 'moment'], function(angular, moment) {
 
           var dynamicValueToMatch = parsedExpression(data);
 
-          // select the first matching case, if any
-
+          /**
+           * True when the case under consideration has a matchValue matching
+           * dynamicValueToMatch. Used for finding the relevant case to switch
+           * to, if any.
+           * @param {*} caseToCheck
+           */
           function matchesValue(caseToCheck) {
             return caseToCheck.matchValue === dynamicValueToMatch;
           }

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -710,6 +710,8 @@ define(['angular', 'moment'], function(angular, moment) {
   .controller('SwitchWidgetController', [
     '$scope', '$log', '$parse', 'widgetService',
     function($scope, $log, $parse, widgetService) {
+      $scope.switching = true;
+
       /**
        * Fetch additional widget data
        */
@@ -791,6 +793,7 @@ define(['angular', 'moment'], function(angular, moment) {
             $scope.widget.widgetType = 'basic';
             $scope.widget.widgetConfig = '';
           }
+          $scope.switching = false;
           return $scope.widget.widgetType;
         }).catch(function(error) {
           $log.error($scope.widget.fname +
@@ -800,6 +803,7 @@ define(['angular', 'moment'], function(angular, moment) {
 
           $scope.widget.widgetType = 'basic';
           $scope.widget.widgetConfig = '';
+          $scope.switching = false;
         });
       } else {
         $log.warn($scope.widget.fname + ' not configured with ' +
@@ -810,6 +814,7 @@ define(['angular', 'moment'], function(angular, moment) {
 
         $scope.widget.widgetType = 'basic';
         $scope.widget.widgetConfig = '';
+        $scope.switching = false;
       }
     };
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -709,8 +709,8 @@ define(['angular', 'moment'], function(angular, moment) {
 
   // SWITCH widget type
   .controller('SwitchWidgetController', [
-    '$scope', '$log', '$parse', 'widgetService',
-    function($scope, $log, $parse, widgetService) {
+    '$scope', '$log', '$parse', '$localStorage', 'widgetService',
+    function($scope, $log, $parse, $localStorage, widgetService) {
       /**
        * Fetch additional widget data
        */

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -757,7 +757,7 @@ define(['angular', 'moment'], function(angular, moment) {
             if (caseToActivate.widgetUrl) {
               // switch the widget URL and re-fetch JSON using that new config
               $scope.widget.widgetURL = caseToActivate.widgetUrl;
-              $widgetService.getWidgetJson($scope.widget);
+              widgetService.getWidgetJson($scope.widget);
             }
 
             if (caseToActivate.widgetType) {

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -245,13 +245,6 @@ define(['angular', 'moment'], function(angular, moment) {
     $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
   }])
 
-  // SWITCH widget type
-  .controller('SwitchController', [
-    '$scope', '$sce', function($scope, $sce) {
-    // Have faith our entity files aren't trying to bamboozle us
-    $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
-  }])
-
   // RSS widget type
   .controller('RssWidgetController', [
     '$scope', '$log', 'widgetService', function($scope, $log, widgetService) {

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -754,7 +754,6 @@ define(['angular', 'moment'], function(angular, moment) {
 
           // a case was selected for activation, so let's activate it
           if (caseToActivate) {
-
             if (caseToActivate.widgetUrl) {
               // switch the widget URL and re-fetch JSON using that new config
               $scope.widget.widgetURL = caseToActivate.widgetUrl;
@@ -781,9 +780,7 @@ define(['angular', 'moment'], function(angular, moment) {
                 $scope.widget.widgetConfig.launchText =
                   $scope.switchConfig.launchText;
               }
-
           } else {
-
             $log.debug($scope.widget.fname +
               ' did not switch to any case (not even an otherwise case) ' +
               'for activation, so falling back to being a basic widget.');
@@ -791,9 +788,7 @@ define(['angular', 'moment'], function(angular, moment) {
             $scope.widget.widgetType = 'basic';
             $scope.widget.widgetConfig = '';
           }
-
         }).catch(function(error) {
-
           $log.error($scope.widget.fname +
             ' errored fetching or processing JSON [' + $scope.widget.widgetURL
             + '] to switch on; falling back on being a basic widget.');
@@ -805,7 +800,6 @@ define(['angular', 'moment'], function(angular, moment) {
           // nothing to do
         });
       } else {
-
         $log.warn($scope.widget.fname + ' not configured with ' +
         'URL from which to load JSON [' + $scope.widget.widgetURL + '],' +
         ' expression [' + $scope.switchConfig.expression + ']' +

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -27,10 +27,8 @@ define(['angular', 'moment'], function(angular, moment) {
    * the type and sets launch button url for un-typed (basic) widgets.
    */
   .controller('WidgetCardController', [
-    '$scope', '$log', '$localStorage', '$transclude', '$timeout',
-    'widgetService',
-    function($scope, $log, $localStorage, $transclude, $timeout,
-             widgetService) {
+    '$scope', '$log', '$transclude', '$timeout', 'widgetService',
+    function($scope, $log, $transclude, $timeout, widgetService) {
     /**
      * Check for widget types that require extra configuration
      * (including null/undefined case), default to provided
@@ -132,24 +130,6 @@ define(['angular', 'moment'], function(angular, moment) {
       } else {
         $log.warn('WidgetCardController didn\'t get an fname.');
       }
-    };
-
-    /**
-     * Set the launch button url for static content,
-     * exclusive mode, and basic widgets
-     * @return {*}
-     */
-    $scope.renderUrl = function renderUrl() {
-      var widget = $scope.widget;
-      // Check for static content or exclusive mode portlets (rare)
-      if (widget.altMaxUrl == false) {
-        if (widget.staticContent != null) {
-          return 'static/' + widget.fname;
-        } else if (widget.renderOnWeb || $localStorage.webPortletRender) {
-          return 'exclusive/' + widget.fname;
-        }
-      }
-      return widget.url;
     };
 
     // Initialize the widget
@@ -728,8 +708,8 @@ define(['angular', 'moment'], function(angular, moment) {
 
   // SWITCH widget type
   .controller('SwitchWidgetController', [
-    '$scope', '$log', '$parse', '$localStorage', 'widgetService',
-    function($scope, $log, $parse, $localStorage, widgetService) {
+    '$scope', '$log', '$parse', 'widgetService',
+    function($scope, $log, $parse, widgetService) {
       /**
        * Fetch additional widget data
        */
@@ -831,25 +811,6 @@ define(['angular', 'moment'], function(angular, moment) {
         $scope.widget.widgetType = 'basic';
         $scope.widget.widgetConfig = '';
       }
-    };
-
-    /**
-     * Set the launch button url for static content,
-     * exclusive mode, and basic widgets
-     * @return {*}
-     */
-    $scope.renderUrl = function renderUrl() {
-      // TODO: refactor. This is a copy-and-paste from WidgetCardController
-      var widget = $scope.widget;
-      // Check for static content or exclusive mode portlets (rare)
-      if (widget.altMaxUrl == false) {
-        if (widget.staticContent != null) {
-          return 'static/' + widget.fname;
-        } else if (widget.renderOnWeb || $localStorage.webPortletRender) {
-          return 'exclusive/' + widget.fname;
-        }
-      }
-      return widget.url;
     };
 
     initializeSwitchWidget();

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -200,5 +200,17 @@ define(['angular', 'require'], function(angular, require) {
       templateUrl: require.toUrl('./partials/type__weather.html'),
       controller: 'WeatherWidgetController',
     };
+  })
+
+  .directive('basicWidget', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        widget: '=app',
+        config: '=config',
+      },
+      templateUrl: require.toUrl('./partials/type__basic.html'),
+      controller: 'BasicWidgetController',
+    };
   });
 });

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -161,8 +161,19 @@ define(['angular', 'require'], function(angular, require) {
         widget: '=app',
         config: '=config',
       },
-      templateUrl: require.toUrl('./partials/type__switch.html'),
+      templateUrl: require.toUrl('./partials/widget-content.html'),
       controller: 'SwitchWidgetController',
+    };
+  })
+
+  .directive('widgetContent', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        widget: '=app',
+        config: '=config',
+      },
+      templateUrl: require.toUrl('./partials/widget-content.html'),
     };
   })
 

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -154,7 +154,7 @@ define(['angular', 'require'], function(angular, require) {
     };
   })
 
-  .directive('switch', function() {
+  .directive('switchWidget', function() {
     return {
       restrict: 'E',
       scope: {

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -154,6 +154,18 @@ define(['angular', 'require'], function(angular, require) {
     };
   })
 
+  .directive('switch', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        widget: '=app',
+        config: '=config',
+      },
+      templateUrl: require.toUrl('./partials/type__switch.html'),
+      controller: 'SwitchWidgetController',
+    };
+  })
+
   .directive('rssWidget', function() {
     return {
       restrict: 'E',

--- a/components/portal/widgets/partials/type__basic.html
+++ b/components/portal/widgets/partials/type__basic.html
@@ -1,0 +1,17 @@
+<div>
+  <a class="basic-widget" tabindex="-1"
+    ng-href="{{ renderUrl() }}"
+    target="{{ widget.target ? widget.target : '_self' }}"
+    rel="noopener noreferrer">
+    <div class="widget-icon-container"
+      layout="column" layout-align="center center">
+      <widget-icon></widget-icon>
+    </div>
+  </a>
+</div>
+<launch-button data-aria-label="{{ 'Launch ' + widget.title }}"
+  data-href="{{ renderUrl() }}"
+  data-target="{{ widget.target ? widget.target : '_self' }}"
+  data-rel="noopener noreferrer"
+  data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}">
+</launch-button>

--- a/components/portal/widgets/partials/type__basic.html
+++ b/components/portal/widgets/partials/type__basic.html
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <div>
   <a class="basic-widget" tabindex="-1"
     ng-href="{{ renderUrl() }}"

--- a/components/portal/widgets/partials/type__switch.html
+++ b/components/portal/widgets/partials/type__switch.html
@@ -61,21 +61,9 @@
     </div>
   </div>
 
-  <!-- "basic" widget type-->
+  <!-- default to an untyped, basic widget -->
   <div ng-switch-default>
-    <a tabindex="-1" class="basic-widget" ng-href="{{ renderUrl() }}"
-      target="{{ widget.target ? widget.target : '_self' }}"
-      rel="noopener noreferrer">
-      <div class="widget-icon-container" layout="column" layout-align="center center">
-        <widget-icon></widget-icon>
-      </div>
-    </a>
-    <launch-button data-aria-label="{{ 'Launch ' + widget.title }}"
-      data-href="{{ renderUrl() }}"
-      data-target="{{ widget.target ? widget.target : '_self' }}"
-      data-rel="noopener noreferrer"
-      data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}">
-    </launch-button>
+    <basic-widget></basic-widget>
   </div>
 
 </div>

--- a/components/portal/widgets/partials/type__switch.html
+++ b/components/portal/widgets/partials/type__switch.html
@@ -1,0 +1,81 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<div ng-switch="widget.widgetType" class="widget-type-container">
+
+  <div ng-switch-when="time-sensitive-content">
+    <time-sensitive app="widget" config="widget.widgetConfig"></time-sensitive>
+  </div>
+
+  <div ng-switch-when="option-link">
+    <option-link app="widget" config="widget.widgetConfig"></option-link>
+  </div>
+
+  <div ng-switch-when="rss">
+    <rss-widget app="widget" config="widget.widgetConfig"></rss-widget>
+  </div>
+
+  <div ng-switch-when="action-items">
+    <action-items app="widget" config="widget.widgetConfig"></action-items>
+  </div>
+
+  <div ng-switch-when="list-of-links">
+    <list-of-links app="widget" config="widget.widgetConfig"></list-of-links>
+  </div>
+
+  <div ng-switch-when="search-with-links">
+    <search-with-links app="widget" config="widget.widgetConfig"></search-with-links>
+  </div>
+
+  <div ng-switch-when="switch">
+    <loading-gif></loading-gif>
+  </div>
+
+  <div ng-switch-when="weather">
+    <weather-widget app="widget" config="widget.widgetConfig"></weather-widget>
+  </div>
+
+  <div ng-switch-when="custom" class="custom-widget">
+    <div ng-controller="CustomWidgetController as customWidgetCtrl">
+      <div ng-if="loading" layout="row" layout-align="center center">
+        <loading-gif data-object="content" data-empty="isEmpty"></loading-gif>
+      </div>
+      <content-item ng-if="!loading"></content-item>
+    </div>
+  </div>
+
+  <!-- "basic" widget type-->
+  <div ng-switch-default>
+    <a tabindex="-1" class="basic-widget" ng-href="{{ renderUrl() }}"
+      target="{{ widget.target ? widget.target : '_self' }}"
+      rel="noopener noreferrer">
+      <div class="widget-icon-container" layout="column" layout-align="center center">
+        <widget-icon></widget-icon>
+      </div>
+    </a>
+    <launch-button data-aria-label="{{ 'Launch ' + widget.title }}"
+      data-href="{{ renderUrl() }}"
+      data-target="{{ widget.target ? widget.target : '_self' }}"
+      data-rel="noopener noreferrer"
+      data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}">
+    </launch-button>
+  </div>
+
+</div>

--- a/components/portal/widgets/partials/type__switch.html
+++ b/components/portal/widgets/partials/type__switch.html
@@ -63,7 +63,7 @@
 
   <!-- default to an untyped, basic widget -->
   <div ng-switch-default>
-    <basic-widget></basic-widget>
+    <basic-widget app="widget" config="widget.widgetConfig"></basic-widget>
   </div>
 
 </div>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -117,17 +117,7 @@
 
       <!-- "basic" widget type-->
       <div ng-switch-default>
-        <a tabindex="-1" ng-href="{{ renderUrl() }}" target="{{ widget.target ? widget.target : '_self' }}" class="basic-widget" rel="noopener noreferrer">
-          <div class="widget-icon-container" layout="column" layout-align="center center">
-            <widget-icon></widget-icon>
-          </div>
-        </a>
-        <launch-button data-href="{{ renderUrl() }}"
-                       data-target="{{ widget.target ? widget.target : '_self' }}"
-                       data-rel="noopener noreferrer"
-                       data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}"
-                       data-aria-label="{{ 'Launch ' + widget.title }}">
-        </launch-button>
+        <basic-widget app="widget" config="widget.widgetConfig"></basic-widget>
       </div>
 
     </div>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -71,56 +71,8 @@
 
   <!-- BODY -->
   <md-card-content class="widget-content">
-
-    <div ng-switch="widgetType" class="widget-type-container">
-
-      <div ng-switch-when="time-sensitive-content">
-        <time-sensitive app="widget" config="widget.widgetConfig"></time-sensitive>
-      </div>
-
-      <div ng-switch-when="option-link">
-        <option-link app="widget" config="widget.widgetConfig"></option-link>
-      </div>
-
-      <div ng-switch-when="rss">
-        <rss-widget app="widget" config="widget.widgetConfig"></rss-widget>
-      </div>
-
-      <div ng-switch-when="action-items">
-        <action-items app="widget" config="widget.widgetConfig"></action-items>
-      </div>
-
-      <div ng-switch-when="list-of-links">
-        <list-of-links app="widget" config="widget.widgetConfig"></list-of-links>
-      </div>
-
-      <div ng-switch-when="search-with-links">
-        <search-with-links app="widget" config="widget.widgetConfig"></search-with-links>
-      </div>
-
-      <div ng-switch-when="switch">
-        <switch app="widget" config="widget.widgetConfig"></switch>
-      </div>
-
-      <div ng-switch-when="weather">
-        <weather-widget app="widget" config="widget.widgetConfig"></weather-widget>
-      </div>
-
-      <div ng-switch-when="custom" class="custom-widget">
-        <div ng-controller="CustomWidgetController as customWidgetCtrl">
-          <div ng-if="loading" layout="row" layout-align="center center">
-            <loading-gif data-object="content" data-empty="isEmpty"></loading-gif>
-          </div>
-          <content-item ng-if="!loading"></content-item>
-        </div>
-      </div>
-
-      <!-- "basic" widget type-->
-      <div ng-switch-default>
-        <basic-widget app="widget" config="widget.widgetConfig"></basic-widget>
-      </div>
-
-    </div>
+      <widget-content app="widget" config="widget.widgetConfig">
+      </widget-content>
   </md-card-content>
 
 </md-card>

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -98,6 +98,10 @@
         <search-with-links app="widget" config="widget.widgetConfig"></search-with-links>
       </div>
 
+      <div ng-switch-when="switch">
+        <switch app="widget" config="widget.widgetConfig"></switch>
+      </div>
+
       <div ng-switch-when="weather">
         <weather-widget app="widget" config="widget.widgetConfig"></weather-widget>
       </div>

--- a/components/portal/widgets/partials/widget-content.html
+++ b/components/portal/widgets/partials/widget-content.html
@@ -45,7 +45,9 @@
   </div>
 
   <div ng-switch-when="switch">
-    <loading-gif></loading-gif>
+    <loading-gif ng-if="switching" ></loading-gif>
+    <switch ng-if="!switching"
+      app="widget" config="widget.widgetConfig"></switch>
   </div>
 
   <div ng-switch-when="weather">

--- a/components/portal/widgets/partials/widget-content.html
+++ b/components/portal/widgets/partials/widget-content.html
@@ -46,8 +46,8 @@
 
   <div ng-switch-when="switch">
     <loading-gif ng-if="switching" ></loading-gif>
-    <switch ng-if="!switching"
-      app="widget" config="widget.widgetConfig"></switch>
+    <switch-widget ng-if="!switching"
+      app="widget" config="widget.widgetConfig"></switch-widget>
   </div>
 
   <div ng-switch-when="weather">

--- a/components/staticFeeds/enrollment-flag-H.json
+++ b/components/staticFeeds/enrollment-flag-H.json
@@ -1,0 +1,1 @@
+{"report":[{"enrollmentFlag":"H"}]}

--- a/components/staticFeeds/enrollment-flag-O.json
+++ b/components/staticFeeds/enrollment-flag-O.json
@@ -1,0 +1,1 @@
+{"report":[{"enrollmentFlag":"O"}]}

--- a/components/staticFeeds/enrollment-flag-Z.json
+++ b/components/staticFeeds/enrollment-flag-Z.json
@@ -1,0 +1,1 @@
+{"report":[{"enrollmentFlag":"Z"}]}

--- a/components/staticFeeds/sample-widget__switch.json
+++ b/components/staticFeeds/sample-widget__switch.json
@@ -1,0 +1,103 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Switch matching first case",
+      "description": "This widget switches runtime type depending upon a JSON feed.",
+      "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+      "iconUrl": null,
+      "mdIcon": "switch_camera",
+      "fname": "sample-widget__switch",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": "/staticFeeds/enrollment-flag-O.json",
+      "widgetType": "switch",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "expression": "report[0].enrollmentFlag",
+        "cases": [
+          {
+            "matchValue": "O",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the first case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was O",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          }
+        ],
+        "caseotherwise": {
+          "widgetType": "search-with-links",
+          "widgetConfig": {
+            "actionURL": "https://rprg.wisc.edu/",
+            "actionTarget": "_blank",
+            "actionParameter": "s",
+            "launchText": "Should not display",
+            "links": [
+              {
+                "title": "Otherwise case",
+                "href": "https://rprg.wisc.edu/phases/initiate/",
+                "icon": "fa-map-o",
+                "target": "_blank"
+              },
+              {
+                "title": "Should not display",
+                "href": "https://rprg.wisc.edu/category/resource/",
+                "icon": "fa-th-list",
+                "target": "_blank"
+              }
+            ]
+          }
+        },
+        "launchText": "Honors launchText"
+      },
+      "staticContent": null,
+      "pithyStaticContent": null,
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "keywords": [
+      "complex",
+      "composed",
+      "composite",
+      "flexible",
+      "meta"
+    ],
+    "fname": "sample-widget__switch",
+    "lifecycleState": "PUBLISHED",
+    "rating": 4.5,
+    "portletWebAppName": "/AintGotNoPortlet",
+    "maxUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "title": "Example switch widget",
+    "categories": [
+      "Widget types"
+    ],
+    "portletName": "AintGotNoPortlet",
+    "name": "Example switch widget",
+    "id": "2742",
+    "type": "Portlet",
+    "target": "_blank",
+    "description": "This widget switches runtime type depending upon a JSON feed"
+  }
+}

--- a/components/staticFeeds/sample-widget__switch_2.json
+++ b/components/staticFeeds/sample-widget__switch_2.json
@@ -1,0 +1,123 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Matches 2nd case",
+      "description": "In this case the second case matches.",
+      "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+      "iconUrl": null,
+      "mdIcon": "switch_camera",
+      "fname": "sample-widget__switch_2",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": "/staticFeeds/enrollment-flag-H.json",
+      "widgetType": "switch",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "expression": "report[0].enrollmentFlag",
+        "cases": [
+          {
+            "matchValue": "O",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the first case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was O",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          },
+          {
+            "matchValue": "H",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the second case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was H",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ],
+              "launchText": "Second case matched"
+            }
+          }
+        ],
+        "caseotherwise": {
+          "widgetType": "search-with-links",
+          "widgetConfig": {
+            "actionURL": "https://rprg.wisc.edu/",
+            "actionTarget": "_blank",
+            "actionParameter": "s",
+            "launchText": "Should not display",
+            "links": [
+              {
+                "title": "Otherwise case",
+                "href": "https://rprg.wisc.edu/phases/initiate/",
+                "icon": "fa-map-o",
+                "target": "_blank"
+              },
+              {
+                "title": "Should not display",
+                "href": "https://rprg.wisc.edu/category/resource/",
+                "icon": "fa-th-list",
+                "target": "_blank"
+              }
+            ]
+          }
+        }
+      },
+      "staticContent": null,
+      "pithyStaticContent": null,
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "keywords": [
+      "complex",
+      "composed",
+      "composite",
+      "flexible",
+      "meta"
+    ],
+    "fname": "sample-widget__switch_2",
+    "lifecycleState": "PUBLISHED",
+    "rating": 4.5,
+    "portletWebAppName": "/AintGotNoPortlet",
+    "maxUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "title": "Matches 2nd case",
+    "categories": [
+      "Widget types"
+    ],
+    "portletName": "AintGotNoPortlet",
+    "name": "Matches 2nd case",
+    "id": "2742",
+    "type": "Portlet",
+    "target": "_blank",
+    "description": "This widget switches runtime type depending upon a JSON feed"
+  }
+}

--- a/components/staticFeeds/sample-widget__switch_broken.json
+++ b/components/staticFeeds/sample-widget__switch_broken.json
@@ -1,0 +1,99 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Bad configuration",
+      "description": "No case matches and no otherwise case is configured so falls back on being a basic widget.",
+      "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+      "iconUrl": null,
+      "mdIcon": "switch_camera",
+      "fname": "sample-widget__switch_broken",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": "this-path-does-not-exist.json",
+      "widgetType": "switch",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "expression": "report[0].enrollmentFlag",
+        "cases": [
+          {
+            "matchValue": "O",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the first case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was O",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          },
+          {
+            "matchValue": "H",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the second case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was H",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "staticContent": null,
+      "pithyStaticContent": null,
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "keywords": [
+      "complex",
+      "composed",
+      "composite",
+      "flexible",
+      "meta"
+    ],
+    "fname": "sample-widget__switch_broken",
+    "lifecycleState": "PUBLISHED",
+    "rating": 4.5,
+    "portletWebAppName": "/AintGotNoPortlet",
+    "maxUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "title": "Bad configuration",
+    "categories": [
+      "Widget types"
+    ],
+    "portletName": "AintGotNoPortlet",
+    "name": "Bad configuration",
+    "id": "2742",
+    "type": "Portlet",
+    "target": "_blank",
+    "description": "This widget switches runtime type depending upon a JSON feed"
+  }
+}

--- a/components/staticFeeds/sample-widget__switch_otherwise.json
+++ b/components/staticFeeds/sample-widget__switch_otherwise.json
@@ -1,0 +1,122 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Matches neither case",
+      "description": "In this switch neither case matches so it falls back on an otherwise case.",
+      "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+      "iconUrl": null,
+      "mdIcon": "switch_camera",
+      "fname": "sample-widget__switch_otherwise",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": "/staticFeeds/enrollment-flag-Z.json",
+      "widgetType": "switch",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "expression": "report[0].enrollmentFlag",
+        "cases": [
+          {
+            "matchValue": "O",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the first case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was O",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          },
+          {
+            "matchValue": "H",
+            "widgetType": "list-of-links",
+            "widgetConfig": {
+              "links": [
+                {
+                  "title": "Matched the second case",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                },
+                {
+                  "title": "Dynamic value was H",
+                  "href": "",
+                  "icon": "fa-at",
+                  "target": "_blank"
+                }
+              ]
+            }
+          }
+        ],
+        "caseotherwise": {
+          "widgetType": "search-with-links",
+          "widgetConfig": {
+            "actionURL": "https://rprg.wisc.edu/",
+            "actionTarget": "_blank",
+            "actionParameter": "s",
+            "launchText": "Otherwise case",
+            "links": [
+              {
+                "title": "Otherwise case",
+                "href": "https://rprg.wisc.edu/phases/initiate/",
+                "icon": "fa-map-o",
+                "target": "_blank"
+              },
+              {
+                "title": "Neither case matched",
+                "href": "https://rprg.wisc.edu/category/resource/",
+                "icon": "fa-th-list",
+                "target": "_blank"
+              }
+            ]
+          }
+        }
+      },
+      "staticContent": null,
+      "pithyStaticContent": null,
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "keywords": [
+      "complex",
+      "composed",
+      "composite",
+      "flexible",
+      "meta"
+    ],
+    "fname": "sample-widget__switch_otherwise",
+    "lifecycleState": "PUBLISHED",
+    "rating": 4.5,
+    "portletWebAppName": "/AintGotNoPortlet",
+    "maxUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
+    "title": "Matches neither case",
+    "categories": [
+      "Widget types"
+    ],
+    "portletName": "AintGotNoPortlet",
+    "name": "Matches neither case",
+    "id": "2742",
+    "type": "Portlet",
+    "target": "_blank",
+    "description": "In this switch neither case matches so it falls back on an otherwise case."
+  }
+}


### PR DESCRIPTION
Adds a new `switch` widget type, a meta widget that switches to become another widget type depending upon a dynamic value.

+ The `widgetURL` is the source for the dynamic JSON to evaluate.
+ Evaluates an AngularJS `expression` on that JSON to extract a value.
+ Matches that value against one or more `cases` configured in `widgetConfig`.
+ The matching case, or a default `caseotherwise` case, may specify a new `launchText`, widget type, `widgetConfig`, or even a new URL from which to source JSON to drive the newly selected widget type.

See [documentation for the new widget, added in this changeset](https://github.com/uPortal-Project/uportal-app-framework/blob/eccf6b0ea0a9a4613f20ac3fea0d1a7e40c94417/docs/make-a-widget.md#switch-widget-type).

Adds example widget publications in `localhost` to demonstrate this new widget type.

![localhost-example-switch-widgets](https://user-images.githubusercontent.com/952283/45164496-2bb23c00-b1b8-11e8-9e5f-e9c3361845ce.png)

Tech debt incurred:

+ None of this is covered with unit tests. We have a test coverage problem in this project.
+ ~Duplicates a method from `WidgetCardController` into the new `SwitchWidgetController` to support the way templating for `basic` type widgets determines the URL of the links in that widget.~ Not incurred by this changeset, but observation for future refactoring: Arguably this should be refactored to resolve that URL higher up in the architecture, rather than the controller being responsible to figure it out while rendering the widget. As in, shouldn't something higher up (`WidgetService`?) just go ahead and set `widget.url` to the right value and then the controller / partials / whatevers just rely on it?
+ ~Duplicates a chunk of the `widget-card` partial to re-implement the switching among widget types for content. Arguably this should be refactored to eliminate this duplication.~

Anticipated remaining refactoring in this PR:

- [x] Introduce `<basic-widget>` directive and accompanying controller and partial. Move `renderURL()` function to that controller, and thereby refactor away the duplication of that method introduced by this PR.
- [x] Refactor the switch widget partial to be a more general `widget-content` partial. (It's probably already that, literally just needs renamed, once `<basic-widget>` is a thing.) Reference it, probably via a directive, from `widget-card`, and thereby refactor away the duplication of that `ng-switch` introduced by this PR. 

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
