### PR TITLE
feat(widgets): default to `basic` when type unrecognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
++ Default to handling unrecognized widget types as if they were `basic` widgets (#823)
 + Leverate `npm ci` to speed continuous integration builds (#812)
 
 ### Fixed

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -111,7 +111,8 @@
         </div>
       </div>
 
-      <div ng-switch-when="basic">
+      <!-- "basic" widget type-->
+      <div ng-switch-default>
         <a tabindex="-1" ng-href="{{ renderUrl() }}" target="{{ widget.target ? widget.target : '_self' }}" class="basic-widget" rel="noopener noreferrer">
           <div class="widget-icon-container" layout="column" layout-align="center center">
             <widget-icon></widget-icon>


### PR DESCRIPTION
When the framework does not recognize a widget type, fall back to handling it as if it were a `basic` widget.

Before:

![widget-with-unknown-type-renders-broken](https://user-images.githubusercontent.com/952283/44877859-e5feec00-ac6a-11e8-8537-dac54dbeb0de.png)

(Widget with unrecognized type renders broken. Can't even launch it.)


After:

![widget-with-unknown-type-renders-basic](https://user-images.githubusercontent.com/952283/44877870-edbe9080-ac6a-11e8-9448-36e052364d82.png)

(Widget with unrecognized type renders as if it were a `basic` widget. At least I can launch it.)



----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
