### PR TITLE
feat(switch): rename `caseotherwise` to `defaultCase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 + New `switch` widget type ( `<switch-widget>` directive), for composing
   composite widgets by dynamically switching over other types and configurations
-  of widgets. (#820)
+  of widgets. (#820, #826)
 + New `<widget-content>` directive, factored out from the inline `ng-switch` in
   `<widget-card>`. Not a breaking change: `widget-card` behaves the same as
   before, its implementation now delegates to `<widget-content>` for the

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -748,13 +748,13 @@ define(['angular', 'moment'], function(angular, moment) {
 
           var caseToActivate = $scope.switchConfig.cases.find(matchesValue);
 
-          // if none of the cases match, select the otherwise case if configured
+          // if none of the cases match, select the default case if configured
           if (!caseToActivate && $scope.switchConfig &&
-            $scope.switchConfig.caseotherwise) {
+            $scope.switchConfig.defaultCase) {
             $log.debug($scope.widget.fname +
-              ' switching to otherwise case after no case matched value ' +
+              ' switching to default case after no case matched value ' +
               dynamicValueToMatch);
-            caseToActivate = $scope.switchConfig.caseotherwise;
+            caseToActivate = $scope.switchConfig.defaultCase;
           }
 
           // a case was selected for activation, so let's activate it
@@ -787,7 +787,7 @@ define(['angular', 'moment'], function(angular, moment) {
               }
           } else {
             $log.debug($scope.widget.fname +
-              ' did not switch to any case (not even an otherwise case) ' +
+              ' did not switch to any case (not even a default case) ' +
               'for activation, so falling back to being a basic widget.');
 
             $scope.widget.widgetType = 'basic';

--- a/components/staticFeeds/sample-widget__switch.json
+++ b/components/staticFeeds/sample-widget__switch.json
@@ -38,7 +38,7 @@
             }
           }
         ],
-        "caseotherwise": {
+        "defaultCase": {
           "widgetType": "search-with-links",
           "widgetConfig": {
             "actionURL": "https://rprg.wisc.edu/",
@@ -47,7 +47,7 @@
             "launchText": "Should not display",
             "links": [
               {
-                "title": "Otherwise case",
+                "title": "Default case",
                 "href": "https://rprg.wisc.edu/phases/initiate/",
                 "icon": "fa-map-o",
                 "target": "_blank"

--- a/components/staticFeeds/sample-widget__switch_2.json
+++ b/components/staticFeeds/sample-widget__switch_2.json
@@ -59,7 +59,7 @@
             }
           }
         ],
-        "caseotherwise": {
+        "defaultCase": {
           "widgetType": "search-with-links",
           "widgetConfig": {
             "actionURL": "https://rprg.wisc.edu/",
@@ -68,7 +68,7 @@
             "launchText": "Should not display",
             "links": [
               {
-                "title": "Otherwise case",
+                "title": "Default case",
                 "href": "https://rprg.wisc.edu/phases/initiate/",
                 "icon": "fa-map-o",
                 "target": "_blank"

--- a/components/staticFeeds/sample-widget__switch_broken.json
+++ b/components/staticFeeds/sample-widget__switch_broken.json
@@ -4,7 +4,7 @@
     "layoutObject": {
       "nodeId": "-1",
       "title": "Bad configuration",
-      "description": "No case matches and no otherwise case is configured so falls back on being a basic widget.",
+      "description": "No case matches and no default case is configured so falls back on being a basic widget.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
       "iconUrl": null,
       "mdIcon": "switch_camera",

--- a/components/staticFeeds/sample-widget__switch_otherwise.json
+++ b/components/staticFeeds/sample-widget__switch_otherwise.json
@@ -4,7 +4,7 @@
     "layoutObject": {
       "nodeId": "-1",
       "title": "Matches neither case",
-      "description": "In this switch neither case matches so it falls back on an otherwise case.",
+      "description": "In this switch neither case matches so it falls back on a default case.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",
       "iconUrl": null,
       "mdIcon": "switch_camera",
@@ -58,16 +58,16 @@
             }
           }
         ],
-        "caseotherwise": {
+        "defaultCase": {
           "widgetType": "search-with-links",
           "widgetConfig": {
             "actionURL": "https://rprg.wisc.edu/",
             "actionTarget": "_blank",
             "actionParameter": "s",
-            "launchText": "Otherwise case",
+            "launchText": "Default case",
             "links": [
               {
-                "title": "Otherwise case",
+                "title": "Default case",
                 "href": "https://rprg.wisc.edu/phases/initiate/",
                 "icon": "fa-map-o",
                 "target": "_blank"
@@ -117,6 +117,6 @@
     "id": "2742",
     "type": "Portlet",
     "target": "_blank",
-    "description": "In this switch neither case matches so it falls back on an otherwise case."
+    "description": "In this switch neither case matches so it falls back on an default case."
   }
 }

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -570,7 +570,7 @@ benefits.
             }
           }
         ],
-        "caseotherwise": {
+        "defaultCase": {
           "widgetType": "list-of-links",
           "widgetConfig": {
             "links": [
@@ -625,14 +625,14 @@ The keys in `widgetConfig` for a `switch` widget are
   case.
 + `cases`: cases, an array of objects where in each object the key `matchValue`
   keys to the value that would activate that case
-+ `caseotherwise`: `switch` will activate this case if the expression did not
++ `defaultCase`: `switch` will activate this case if the expression did not
   match any of the `matchValue`s of the cases in the `cases[]` array. Optional.
   If not set, defaults to a `basic` widget type with no additional
   `widgetConfig`.
 + {other keys}: The `launchText` key generally honored in `widgetConfig` is
   honored here.
 
-The `caseotherwise` object is
+The `defaultCase` object is
 
 + `widgetType`: the type the widget should become. Any value that would have
   been valid for the `widgetType` `portlet-preference` is valid here. Optional.


### PR DESCRIPTION
Adopt`defaultCase` as a better name than `caseotherwise` as the none-of-the-cases-matched case in the new `switch` type widget.

[Naming things is hard](https://martinfowler.com/bliki/TwoHardThings.html), and [important](https://twitter.com/i/web/status/1032267640033538048).

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
