### PR TITLE
fix(listoflinks): collapse trivial list-of-links to basic type widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 + Added `aria-label` describing mascot image (#808)
++ More reliably collapses trivial `list-of-links` widgets to `basic` widgets
+  (#827)
 
 ### Removed
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -49,6 +49,9 @@
         <widget fname="sample-widget__list-of-no-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
+        <widget fname="sample-widget__list-of-one-redundant-link"></widget>
+      </div>
+      <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__search-with-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
@@ -102,6 +105,9 @@
         </div>
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__list-of-no-links"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__list-of-one-redundant-link"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__search-with-links"></compact-widget>

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -40,18 +40,6 @@
         <widget fname="sample-widget__rss"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
-        <widget fname="sample-widget__list-of-links"></widget>
-      </div>
-      <div flex-xs="100" class="widget-container">
-        <widget fname="sample-widget__list-of-8-links"></widget>
-      </div>
-      <div flex-xs="100" class="widget-container">
-        <widget fname="sample-widget__list-of-no-links"></widget>
-      </div>
-      <div flex-xs="100" class="widget-container">
-        <widget fname="sample-widget__list-of-one-redundant-link"></widget>
-      </div>
-      <div flex-xs="100" class="widget-container">
         <widget fname="sample-widget__search-with-links"></widget>
       </div>
       <div flex-xs="100" class="widget-container">
@@ -64,6 +52,30 @@
         <widget fname="sample-widget__maintenance-custom"></widget>
       </div>
     </div>
+
+    <h3 style="margin-left:26px">
+      Example list-of-links widgets in expanded mode</h3>
+
+      <div style="margin-left:26px">list-of-links widgets change display
+        depending upon how many links. Zero links or a single link that would
+        be redundant with the launch button collapse to a basic widget. Fewer
+        than four links display as circle buttons. More links display as a
+        list.</div>
+      <div layout="row" layout-align="center start"
+        style="flex-wrap:wrap;padding:18px;">
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__list-of-links"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__list-of-8-links"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__list-of-no-links"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__list-of-one-redundant-link"></widget>
+        </div>
+      </div>
 
     <h3 style="margin-left:26px">Example switch widgets in expanded mode</h3>
     <div style="margin-left:26px">Switch widgets dynamically change runtime type depending upon the

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -54,16 +54,8 @@ define(['angular', 'moment'], function(angular, moment) {
                 $log.warn('List of links widget ' + widget.fname + ' failed.');
                 $log.error(error);
               });
-            return 'list-of-links';
           }
-          // If the list of links only has one link and it's the
-          // same as the launch button url, display a basic widget
-          if (widget.widgetConfig.links.length === 1 && widget.altMaxUrl &&
-              widget.widgetConfig.links[0].href === widget.url) {
-            return 'basic';
-          } else {
-            return 'list-of-links';
-          }
+          return 'list-of-links';
         case 'generic':
           // DEPRECATED: Backwards compatibility. Use 'custom' instead.
           return 'custom';

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -19,18 +19,9 @@
 
 -->
 <!-- ZERO LINKS: emulate a basic widget -->
-<div ng-show="config.links.length == 0">
-  <a tabindex="-1"
-    ng-href="{{ widget.url }}"
-    target="{{ widget.target ? widget.target : '_self' }}"
-    rel="noopener noreferrer"
-    class="basic-widget">
-    <div class="widget-icon-container"
-      layout="column" layout-align="center center">
-      <widget-icon></widget-icon>
-    </div>
-  </a>
-</div>
+<basic-widget
+  ng-show="config.links.length == 0"
+  app="widget" config="widget.widgetConfig"></basic-widget>
 
 <!-- ONE REDUNDANT LINK: collapse to basic widget -->
 
@@ -86,9 +77,10 @@
 
 </div>
 
-<!-- LAUNCH BUTTON -->
+<!-- LAUNCH BUTTON
+  suppress in cases where collapsed to basic-widget, which rendered its own launch button -->
 <launch-button
-  ng-show="config.links.length != 1 || config.links[0].href != widget.url"
+  ng-show="config.links.length > 1 || (config.links.length !=1 || config.links[0].href != widget.url)"
                data-href="{{widget.url}}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -32,10 +32,20 @@
   </a>
 </div>
 
-<div class="widget-body list-of-links" ng-show="config.links.length > 0">
+<!-- ONE REDUNDANT LINK: collapse to basic widget -->
+
+<basic-widget
+  ng-show="config.links.length == 1 && config.links[0].href === widget.url"
+  app="widget" config="widget.widgetConfig"></basic-widget>
+
+<!-- list-of-links widget (not collapsing to basic widget)-->
+<div class="widget-body list-of-links"
+  ng-show="config.links.length > 0 && config.links[0].href != widget.url">
 
   <!-- FOUR LINKS OR LESS -->
-  <div ng-show="config.links.length > 0 && config.links.length <= 4" class="list-of-links__{{config.links.length}}">
+  <div ng-show="config.links.length > 0 && config.links.length <= 4
+    && config.links[0].href != widget.url"
+    class="list-of-links__{{config.links.length}}">
     <circle-button ng-if="item.icon.indexOf('fa-') > -1"
                    ng-repeat="item in config.links"
                    data-href="{{item.href}}"
@@ -77,7 +87,9 @@
 </div>
 
 <!-- LAUNCH BUTTON -->
-<launch-button data-href="{{widget.url}}"
+<launch-button
+  ng-show="config.links.length != 1 || config.links[0].href != widget.url"
+               data-href="{{widget.url}}"
                data-target="{{ widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
                data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -24,7 +24,6 @@
   app="widget" config="widget.widgetConfig"></basic-widget>
 
 <!-- ONE REDUNDANT LINK: collapse to basic widget -->
-
 <basic-widget
   ng-show="config.links.length == 1 && config.links[0].href === widget.url"
   app="widget" config="widget.widgetConfig"></basic-widget>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -31,7 +31,8 @@
 
 <!-- list-of-links widget (not collapsing to basic widget)-->
 <div class="widget-body list-of-links"
-  ng-show="config.links.length > 0 && config.links[0].href != widget.url">
+  ng-show="config.links.length > 0
+    && (config.links.length != 1 || config.links[0].href != widget.url)">
 
   <!-- FOUR LINKS OR LESS -->
   <div ng-show="config.links.length > 0 && config.links.length <= 4

--- a/components/staticFeeds/list-of-one-redundant-link-via-url.json
+++ b/components/staticFeeds/list-of-one-redundant-link-via-url.json
@@ -5,7 +5,7 @@
       {
         "icon": "fa-book",
         "href": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
-        "title": "JSON defining this widget",
+        "title": "Should not display",
         "target": "_blank"
       }
     ]

--- a/components/staticFeeds/list-of-one-redundant-link-via-url.json
+++ b/components/staticFeeds/list-of-one-redundant-link-via-url.json
@@ -1,0 +1,13 @@
+{
+  "result": "ok",
+  "content": {
+    "links": [
+      {
+        "icon": "fa-book",
+        "href": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
+        "title": "JSON defining this widget",
+        "target": "_blank"
+      }
+    ]
+  }
+}

--- a/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
+++ b/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
@@ -1,0 +1,59 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "list-of-links degrades to basic",
+      "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it degrades to a basic widget.",
+      "url": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
+      "iconUrl": null,
+      "faIcon": "fa-book",
+      "fname": "sample-widget__list-of-one-redundant-link",
+      "lifecycleState": "PUBLISHED",
+      "target": null,
+      "widgetURL": "/staticFeeds/list-of-one-redundant-link-via-url.json",
+      "widgetType": "list-of-links",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "getLinksURL": "true",
+        "launchText": "View widget JSON"
+      },
+      "staticContent": "<div><p>Static content goes here.</p></div>",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "categories": [
+      "Widget types",
+      "list-of-links"
+    ],
+    "portletName": "cms",
+    "title": "list-of-links degrades to basic",
+    "keywords": [
+      "list",
+      "links",
+      "ordered",
+      "icons",
+      "few"
+    ],
+    "fname": "sample-widget__list-of-one-redundant-link",
+    "rating": 0.0,
+    "lifecycleState": "PUBLISHED",
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
+    "portletWebAppName": "/SimpleContentPortlet",
+    "maxUrl": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 0,
+    "faIcon": "fa-briefcase",
+    "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it degrades to a basic widget.",
+    "name": "list-of-links degrades to basic",
+    "id": "77",
+    "type": "Portlet",
+    "target": null
+  }
+}

--- a/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
+++ b/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
@@ -3,8 +3,8 @@
     "canAdd": true,
     "layoutObject": {
       "nodeId": "-1",
-      "title": "list-of-links degrades to basic",
-      "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it degrades to a basic widget.",
+      "title": "list-of-links collapses to basic",
+      "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it collapses to a basic widget.",
       "url": "staticFeeds/sample-widget__list-of-one-redundant-link.json",
       "iconUrl": null,
       "faIcon": "fa-book",
@@ -27,7 +27,7 @@
       "list-of-links"
     ],
     "portletName": "cms",
-    "title": "list-of-links degrades to basic",
+    "title": "list-of-links collapses to basic",
     "keywords": [
       "list",
       "links",
@@ -50,8 +50,8 @@
     "marketplaceScreenshots": [],
     "userRated": 0,
     "faIcon": "fa-briefcase",
-    "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it degrades to a basic widget.",
-    "name": "list-of-links degrades to basic",
+    "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it collapses to a basic widget.",
+    "name": "list-of-links collapses to basic",
     "id": "77",
     "type": "Portlet",
     "target": null

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -219,7 +219,10 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
   [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory)
   to represent the link. This provides a more usable click surface, a simpler
   and cleaner user experience, and achieves better consistency with other
-  just-a-link widgets in the portal.
+  just-a-link widgets in the portal. The `list-of-links` widget will
+  automatically collapse trivial just-one-link widgets to become `basic` widgets
+  when it detects the single link and the launch button would link to the same
+  place.
 * `list-of-links` presents different quantities of links differently. 1 to 4
   links present as `circle-button`s. 5 to 6 links present as a more
   traditional-style list. Zero links presents as a basic widget.

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -219,7 +219,7 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
   [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory)
   to represent the link. This provides a more usable click surface, a simpler
   and cleaner user experience, and achieves better consistency with other
-  just-a-link widgets in MyUW.
+  just-a-link widgets in the portal.
 * `list-of-links` presents different quantities of links differently. 1 to 4
   links present as `circle-button`s. 5 to 6 links present as a more
   traditional-style list. Zero links presents as a basic widget.


### PR DESCRIPTION
Status quo `list-of-links` widget had a feature where it would try to detect when the widget would be trivial (displaying only a single link redundant with the link the launch button would link) and collapse to a `basic` type widget in this case.

However, in at least some cases the widget wasn't doing this, as demonstrated by a `localhost` example added in this changeset.

Added example before fix:

![did-not-collapse](https://user-images.githubusercontent.com/952283/45303219-e86b0c80-b4da-11e8-97f5-1bd62d2dd832.png)

Looks like there'd been some code at the controller layer to try to detect and handle this case, and that it didn't always fire. This changeset moves responsibility for handling this case into the `list-of-links` partial so that this handling will apply regardless of how the framework gets to that partial.

After:

![collapsed](https://user-images.githubusercontent.com/952283/45303232-f02ab100-b4da-11e8-9cb5-311851eb997d.png)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
