### PR TITLE
feat(examples): add examples of time-sensitive-content widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Documentation
 
-
++ Added localhost examples of `time-sensitive-content` widget type (#831)
 
 ## [10.2.0][] - 2018-09-12
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -96,6 +96,29 @@
     </div>
 
     <h3 style="margin-left:26px">
+      Example `time-sensitive-content` widgets in expanded mode</h3>
+      <div style="margin-left:26px">`time-sensitive-content` widgets render 
+        different content depending upon the date.</div>
+      <div layout="row" layout-align="center start"
+        style="flex-wrap:wrap;padding:18px;">
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__time-future"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__time-soon"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__time-current"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__time-past"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__time-expired"></widget>
+        </div>
+      </div>
+
+    <h3 style="margin-left:26px">
       Example custom widgets in expanded mode</h3>
       <div style="margin-left:26px">custom widgets render arbitrary AngularJS 
         templates optionally applied to dynamic JSON. `generic` is a deprecated 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -182,6 +182,21 @@
           <compact-widget fname="sample-widget__switch_broken"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__time-future"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__time-soon"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__time-current"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__time-past"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <compact-widget fname="sample-widget__time-expired"></compact-widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__custom"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">

--- a/components/staticFeeds/sample-widget__time-current.json
+++ b/components/staticFeeds/sample-widget__time-current.json
@@ -1,0 +1,76 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "After the action start date",
+      "description": "time-sensitive-content widgets count down during the action period.",
+      "url": "https://rprg.wisc.edu/",
+      "iconUrl": null,
+      "mdIcon": "stop",
+      "fname": "sample-widget__time-current",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": null,
+      "widgetType": "time-sensitive-content",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "callsToAction": [
+          {
+            "activeDateRange": {
+              "templateLiveDate": "2017-12-01",
+              "takeActionStartDate": "2018-01-01",
+              "takeActionEndDate": "2050-01-01",
+              "templateRetireDate": "2060-03-30"
+            },
+            "actionName": "Andrew projected retirement date",
+            "daysLeftMessage": "until plausible retirement",
+            "lastDayMessage": "might retire today",
+            "actionButton": {
+              "url": 
+                "https://www.example.edu/take-some-action",
+              "label": "Retire"
+            },
+            "learnMoreUrl": "https://www.ohr.wisc.edu/benefits/retirement/",
+            "feedbackUrl": "https://www.example.edu/feedback-on-retirement"
+          }
+        ]
+      },
+      "staticContent": "\n            \n                Access the \n                <a href=\"https://rprg.wisc.edu/\">Research Project Resource Guide</a>.\n            \n        ",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "title": "Counting down",
+    "categories": [
+      "bad-jokes",
+      "time-sensitive-content",
+      "widget"
+    ],
+    "portletName": "advanced-cms",
+    "keywords": [
+      "future",
+      "time"
+    ],
+    "fname": "sample-widget__time-current",
+    "lifecycleState": "PUBLISHED",
+    "rating": 5.0,
+    "relatedPortlets": [],
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://rprg.wisc.edu/",
+    "maxUrl": "https://rprg.wisc.edu/",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletWebAppName": "/SimpleContentPortlet",
+    "mdIcon": "stop",
+    "description": "time-sensitive-content widgets count down during the action period.",
+    "name": "After the action start date",
+    "id": "5296",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}

--- a/components/staticFeeds/sample-widget__time-expired.json
+++ b/components/staticFeeds/sample-widget__time-expired.json
@@ -1,0 +1,75 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "After the template retires",
+      "description": "time-sensitive-content widget templates can retire entirely, returning the widget to basic-widget-like state.",
+      "url": "https://rprg.wisc.edu/",
+      "iconUrl": null,
+      "mdIcon": "done",
+      "fname": "sample-widget__time-expired",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": null,
+      "widgetType": "time-sensitive-content",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "callsToAction": [
+          {
+            "activeDateRange": {
+              "templateLiveDate": "2017-12-01",
+              "takeActionStartDate": "2017-12-31",
+              "takeActionEndDate": "2018-01-01",
+              "templateRetireDate": "2018-02-30"
+            },
+            "actionName": "Opportunity for action",
+            "daysLeftMessage": "until the action is no longer available",
+            "lastDayMessage": "ends today",
+            "actionButton": {
+              "url": 
+                "https://www.example.edu/take-some-action",
+              "label": "Take action"
+            },
+            "learnMoreUrl": "https://www.example.edu/learn-about-action",
+            "feedbackUrl": "https://www.example.edu/feedback-on-missed-opportunity"
+          }
+        ]
+      },
+      "staticContent": "\n            \n                Access the \n                <a href=\"https://rprg.wisc.edu/\">Research Project Resource Guide</a>.\n            \n        ",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "title": "After the template retires",
+    "categories": [
+      "time-sensitive-content",
+      "widget"
+    ],
+    "portletName": "advanced-cms",
+    "keywords": [
+      "future",
+      "time"
+    ],
+    "fname": "sample-widget__time-expired",
+    "lifecycleState": "PUBLISHED",
+    "rating": 5.0,
+    "relatedPortlets": [],
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://rprg.wisc.edu/",
+    "maxUrl": "https://rprg.wisc.edu/",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletWebAppName": "/SimpleContentPortlet",
+    "mdIcon": "done",
+    "description": "time-sensitive-content widget templates can retire entirely, returning the widget to basic-widget-like state.",
+    "name": "After the template retires",
+    "id": "5296",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}

--- a/components/staticFeeds/sample-widget__time-future.json
+++ b/components/staticFeeds/sample-widget__time-future.json
@@ -1,0 +1,75 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Before the template starts",
+      "description": "time-sensitive-content widgets sleep as basic widgets until a templateLiveDate arrives.",
+      "url": "https://rprg.wisc.edu/",
+      "iconUrl": null,
+      "mdIcon": "snooze",
+      "fname": "sample-widget__time-future",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": null,
+      "widgetType": "time-sensitive-content",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "callsToAction": [
+          {
+            "activeDateRange": {
+              "templateLiveDate": "2100-01-01",
+              "takeActionStartDate": "2100-02-01",
+              "takeActionEndDate": "2100-03-01",
+              "templateRetireDate": "2100-04-01"
+            },
+            "actionName": "The Action Period",
+            "daysLeftMessage": "to take action",
+            "lastDayMessage": "ends today",
+            "actionButton": {
+              "url": 
+                "https://www.example.edu/take-some-action",
+              "label": "Take action"
+            },
+            "learnMoreUrl": "",
+            "feedbackUrl": ""
+          }
+        ]
+      },
+      "staticContent": "\n            \n                Access the \n                <a href=\"https://rprg.wisc.edu/\">Research Project Resource Guide</a>.\n            \n        ",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "title": "Foreshadowing",
+    "categories": [
+      "time-sensitive-content",
+      "widget"
+    ],
+    "portletName": "advanced-cms",
+    "keywords": [
+      "future",
+      "time"
+    ],
+    "fname": "sample-widget__time-future",
+    "lifecycleState": "PUBLISHED",
+    "rating": 5.0,
+    "relatedPortlets": [],
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://rprg.wisc.edu/",
+    "maxUrl": "https://rprg.wisc.edu/",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletWebAppName": "/SimpleContentPortlet",
+    "mdIcon": "snooze",
+    "description": "time-sensitive-content widgets sleep as basic widgets until a templateLiveDate arrives.",
+    "name": "Before the template starts",
+    "id": "5296",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}

--- a/components/staticFeeds/sample-widget__time-past.json
+++ b/components/staticFeeds/sample-widget__time-past.json
@@ -1,0 +1,75 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "After the action end date",
+      "description": "time-sensitive-content widgets can solicit feedback after the action period.",
+      "url": "https://rprg.wisc.edu/",
+      "iconUrl": null,
+      "mdIcon": "timelapse",
+      "fname": "sample-widget__time-past",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": null,
+      "widgetType": "time-sensitive-content",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "callsToAction": [
+          {
+            "activeDateRange": {
+              "templateLiveDate": "2017-12-01",
+              "takeActionStartDate": "2017-12-31",
+              "takeActionEndDate": "2018-01-01",
+              "templateRetireDate": "2030-03-30"
+            },
+            "actionName": "Opportunity for action",
+            "daysLeftMessage": "until the iron is no longer hot",
+            "lastDayMessage": "ends today",
+            "actionButton": {
+              "url": 
+                "https://www.example.edu/take-some-action",
+              "label": "Strike while iron is hot"
+            },
+            "learnMoreUrl": "https://en.wikipedia.org/wiki/Blacksmith",
+            "feedbackUrl": "https://www.example.edu/feedback-on-hammering"
+          }
+        ]
+      },
+      "staticContent": "\n            \n                Access the \n                <a href=\"https://rprg.wisc.edu/\">Research Project Resource Guide</a>.\n            \n        ",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "title": "After the action period",
+    "categories": [
+      "time-sensitive-content",
+      "widget"
+    ],
+    "portletName": "advanced-cms",
+    "keywords": [
+      "future",
+      "time"
+    ],
+    "fname": "sample-widget__time-past",
+    "lifecycleState": "PUBLISHED",
+    "rating": 5.0,
+    "relatedPortlets": [],
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://rprg.wisc.edu/",
+    "maxUrl": "https://rprg.wisc.edu/",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletWebAppName": "/SimpleContentPortlet",
+    "mdIcon": "timelapse",
+    "description": "time-sensitive-content widgets can solicit feedback after the action period.",
+    "name": "After the action end date",
+    "id": "5296",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}

--- a/components/staticFeeds/sample-widget__time-soon.json
+++ b/components/staticFeeds/sample-widget__time-soon.json
@@ -1,0 +1,75 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "Once the template goes live",
+      "description": "time-sensitive-content widgets foreshadow the action period.",
+      "url": "https://rprg.wisc.edu/",
+      "iconUrl": null,
+      "mdIcon": "timelapse",
+      "fname": "sample-widget__time-soon",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": null,
+      "widgetType": "time-sensitive-content",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "callsToAction": [
+          {
+            "activeDateRange": {
+              "templateLiveDate": "2017-12-01",
+              "takeActionStartDate": "2020-01-01",
+              "takeActionEndDate": "2029-12-31",
+              "templateRetireDate": "2030-03-30"
+            },
+            "actionName": "The 2020s",
+            "daysLeftMessage": "until the decade ends",
+            "lastDayMessage": "end today",
+            "actionButton": {
+              "url": 
+                "https://www.example.edu/take-some-action",
+              "label": "Seize the day"
+            },
+            "learnMoreUrl": "https://en.wikipedia.org/wiki/2020s",
+            "feedbackUrl": "https://www.example.edu/feedback-on-time-passing"
+          }
+        ]
+      },
+      "staticContent": "\n            \n                Access the \n                <a href=\"https://rprg.wisc.edu/\">Research Project Resource Guide</a>.\n            \n        ",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "title": "Foreshadowing",
+    "categories": [
+      "time-sensitive-content",
+      "widget"
+    ],
+    "portletName": "advanced-cms",
+    "keywords": [
+      "future",
+      "time"
+    ],
+    "fname": "sample-widget__time-soon",
+    "lifecycleState": "PUBLISHED",
+    "rating": 5.0,
+    "relatedPortlets": [],
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://rprg.wisc.edu/",
+    "maxUrl": "https://rprg.wisc.edu/",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 2,
+    "portletWebAppName": "/SimpleContentPortlet",
+    "mdIcon": "timelapse",
+    "description": "time-sensitive-content widgets foreshadow the action period.",
+    "name": "Once the template goes live",
+    "id": "5296",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}


### PR DESCRIPTION
Adds `localhost` examples demonstrating the `time-sensitive-content` widget across most of its lifecycle.

<img width="1555" alt="Screenshot of the new time-sensitive-content widget examples" src="https://user-images.githubusercontent.com/952283/45505066-37ba7280-b751-11e8-932f-9cbad0115463.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
