### PR TITLE
style(examples): use blank lines to chunk compact widget examples

### DIFF
--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -156,6 +156,7 @@
           <compact-widget fname="sample-widget__maintenance-custom">
           </compact-widget>
         </div>
+
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__list-of-links"></compact-widget>
         </div>
@@ -168,6 +169,7 @@
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__list-of-one-redundant-link"></compact-widget>
         </div>
+
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__switch"></compact-widget>
         </div>
@@ -181,6 +183,7 @@
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__switch_broken"></compact-widget>
         </div>
+
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__time-future"></compact-widget>
         </div>
@@ -196,6 +199,7 @@
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__time-expired"></compact-widget>
         </div>
+
         <div flex-xs="100" class="widget-container">
           <compact-widget fname="sample-widget__custom"></compact-widget>
         </div>


### PR DESCRIPTION
Trivial, whitespace change to chunk the compact mode widget examples by types ala the sections of expanded widgets

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
