### PR TITLE
fix: use logoutURL for inactive timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-+ Added session inactivity checker, and updated logout dialog (#830)
++ Added session inactivity checker, and updated logout dialog (#830, #837)
 
 ### Changed
 

--- a/components/portal/timeout/controllers.js
+++ b/components/portal/timeout/controllers.js
@@ -103,7 +103,7 @@ define(['angular'], function(angular) {
      * Redirect to end the session;
      */
     function redirect() {
-      $window.location.replace(MISC_URLS.loginURL);
+      $window.location.replace(MISC_URLS.logoutURL);
     }
 
     /**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ this is constructed.
 + **inactivityTimeout**: the length in minutes a login session can remain
 inactive before the server expires it. A dialog will show during the last
 minute of a session, prompting user action. If no action is taken, the user
-will be redirected to `MISC_URLS.loginURL` when the session has expired.
+will be redirected to `MISC_URLS.logoutURL` when the session has expired.
 
 ### SERVICE_LOC
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ _as of 2.2.2_
 + **shibbolethSessionURL**: Default is **null**. When set to a proper string
 (like **'/Shibboleth.sso/Session.json'**) it then adds a timeout alert
 notifying users the session is no longer valid. The action of the pop-up is to
-forward them on to the **MISC_URLS.loginURL**. _as of 2.6.2_
+forward them on to the **MISC_URLS.logoutURL**.
 + **campusIdAttribute**: Default is **null**. Provide a session attribute for
 campus ID (i.e. UW-Madison's **wiscEduStudentID** attribute) so that users can
 see their ID in the username menu. _This is currently unimplemented._


### PR DESCRIPTION
Because the uPortal session hasn't actually died after an inactive timeout occurs, going directly to loginURL causes you to be automatically re-logged in. What we actually want is for the user to be explicitly logged out due to inactivity.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
