### PR TITLE
feat(action-items): add more error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-
++ `action-items` widgets now handle more kinds of errors more fluently (#839)
 
 ### Removed
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -416,11 +416,11 @@ define(['angular', 'moment'], function(angular, moment) {
           $log.warn('Problem getting action item data from: ' + item.feedUrl);
           $scope.hasServiceError = true;
 
-              // Add an error to the error array
-              $scope.actionItemErrors.push({
-                textPlural: item.textPlural,
-                actionUrl: item.actionUrl,
-              });
+          // Add an error to the error array
+          $scope.actionItemErrors.push({
+            textPlural: item.textPlural,
+            actionUrl: item.actionUrl,
+          });
 
           $scope.loading = false;
         });

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -445,13 +445,15 @@ define(['angular', 'moment'], function(angular, moment) {
           $log.warn('An action item was missing one or '
             + 'more required configuration options');
 
-            if ($scope.config.actionItems[i].textPlural) {
-              // Add an error to the error array
-              $scope.actionItemErrors.push({
-                textPlural: $scope.config.actionItems[i].textPlural,
-                actionUrl: $scope.config.actionItems[i].actionUrl,
-              });
-            }
+          if (!$scope.config.actionItems[i].textPlural) {
+            $scope.config.actionItems[i].textPlural = 'misconfigured things';
+          }
+
+          // Add an error to the error array
+          $scope.actionItemErrors.push({
+            textPlural: $scope.config.actionItems[i].textPlural,
+            actionUrl: $scope.config.actionItems[i].actionUrl,
+          });
         }
 
         // If this is the last time through the loop, turn off loading spinner

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -400,6 +400,13 @@ define(['angular', 'moment'], function(angular, moment) {
                 quantity: data.quantity,
               });
             }
+          } else {
+            // no data
+            // Add an error to the error array
+            $scope.actionItemErrors.push({
+              textPlural: item.textPlural,
+              actionUrl: item.actionUrl,
+            });
           }
 
           return data;

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -437,6 +437,14 @@ define(['angular', 'moment'], function(angular, moment) {
           // Log a missing-config error
           $log.warn('An action item was missing one or '
             + 'more required configuration options');
+
+            if ($scope.config.actionItems[i].textPlural) {
+              // Add an error to the error array
+              $scope.actionItemErrors.push({
+                textPlural: $scope.config.actionItems[i].textPlural,
+                actionUrl: $scope.config.actionItems[i].actionUrl,
+              });
+            }
         }
 
         // If this is the last time through the loop, turn off loading spinner

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -385,6 +385,12 @@ define(['angular', 'moment'], function(angular, moment) {
               }
               // Show error
               $scope.hasQuantityError = true;
+
+              // Add an error to the error array
+              $scope.actionItemErrors.push({
+                textPlural: item.textPlural,
+                actionUrl: item.actionUrl,
+              });
             } else {
               // Add an action item to scope array
               $scope.actionItems.push({
@@ -402,6 +408,13 @@ define(['angular', 'moment'], function(angular, moment) {
           // Log a service failure error
           $log.warn('Problem getting action item data from: ' + item.feedUrl);
           $scope.hasServiceError = true;
+
+              // Add an error to the error array
+              $scope.actionItemErrors.push({
+                textPlural: item.textPlural,
+                actionUrl: item.actionUrl,
+              });
+
           $scope.loading = false;
         });
     };
@@ -443,6 +456,7 @@ define(['angular', 'moment'], function(angular, moment) {
     var initializeActionItems = function() {
       // Initialize bindable members
       $scope.actionItems = [];
+      $scope.actionItemErrors = [];
       $scope.loading = true;
       $scope.hasServiceError = false;
       $scope.hasQuantityError = false;

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -46,8 +46,7 @@
               <span ng-if="actionItemErrors.length > 1 && $last">and </span>
               <span ng-click="goToAction(itemError.actionUrl)">
                 {{itemError.textPlural}}</span><span
-                ng-if="actionItemErrors.length > 2 && !$last">, </span><span
-                ng-if="$last">.</span>
+                ng-if="actionItemErrors.length > 2 && !$last">, </span>
             </span>
           </span>
         </md-list-item>

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -41,7 +41,6 @@
         <md-list-item  ng-if="actionItemErrors && actionItemErrors.length">
           <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
           <span>
-            Something went wrong.
             <span>
               Unable to count
               <span ng-repeat="itemError in actionItemErrors">

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -20,45 +20,46 @@
 -->
 <div class="widget-body action-items">
   <!-- No action items to display -->
-  <div layout="row" layout-align="center center" ng-show="actionItems.length == 0">
+  <div layout="row" layout-align="center center">
     <!-- Loading case -->
     <loading-gif data-object="actionItems" ng-show="loading"></loading-gif>
 
-    <!-- Error case (endpoint failure) -->
-    <div class="error" layout="row" layout-align="start center" ng-show="hasServiceError">
-      <div><md-icon class="md-warn">warning</md-icon></div>
-      <span>There was an issue loading the information. Click <a href="{{ widget.url }}" target="{{ widget.target ? widget.target : '_self' }}">{{ launchText }}</a> for more info.</span>
+    <div>
+      <md-list class="widget-list md-2-line">
+        <md-list-item aria-label="click to take action"
+          ng-repeat="item in actionItems | limitTo:itemsLimit"
+          ng-click="goToAction(item.actionUrl)" >
+          <div class="action-item__quantity">
+            <span>{{ item.quantity }}</span>
+          </div>
+          <div class="md-list-item-text">
+            <p ng-if="item.quantity == 1">{{ item.textSingular }}</p>
+            <p ng-if="item.quantity != 1">{{ item.textPlural }}</p>
+          </div>
+        </md-list-item>
+        <!-- Error case -->
+        <md-list-item  ng-if="actionItemErrors && actionItemErrors.length">
+          <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
+          <span>
+            Something went wrong.
+            <span>
+              Unable to count
+              <span ng-repeat="itemError in actionItemErrors">
+                <span ng-if="actionItemErrors.length > 1 && $last">and </span>
+                <span ng-click="goToAction(itemError.actionUrl)">
+                  {{itemError.textPlural}}</span><span
+                  ng-if="actionItemErrors.length > 2 && !$last">, </span><span
+                  ng-if="$last">.</span>
+              </span>
+            </span>
+          </span>
+        </md-list-item>
+      </md-list>
+      <!-- Over limit case -->
+      <p ng-show="actionItems.length > itemsLimit" class="action-item__showing">Showing {{ errorQuantity ? itemsLimit + 1 : itemsLimit }} of {{ actionItems.length }}</p>
     </div>
 
-    <!-- Error case (non-number quantity for all items) -->
-    <div class="error" layout="row" layout-align="start center" ng-show="hasQuantityError">
-      <div><md-icon class="md-warn">warning</md-icon></div>
-      <span>One or more items failed to retrieve quantity data. Click <a href="{{ widget.url }}" target="{{ widget.target ? widget.target : '_self' }}">{{ launchText }}</a> for more info.</span>
-    </div>
   </div>
-
-  <!-- Has action items to display -->
-  <div ng-show="actionItems.length > 0">
-    <md-list class="widget-list md-2-line">
-      <md-list-item ng-repeat="item in actionItems | limitTo:itemsLimit" ng-click="goToAction(item.actionUrl)" aria-label="click to take action">
-        <div class="action-item__quantity">
-          <span>{{ item.quantity }}</span>
-        </div>
-        <div class="md-list-item-text">
-          <p ng-if="item.quantity == 1">{{ item.textSingular }}</p>
-          <p ng-if="item.quantity != 1">{{ item.textPlural }}</p>
-        </div>
-      </md-list-item>
-      <!-- Error case (non-number quantity item) -->
-      <md-list-item ng-show="hasQuantityError">
-        <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
-        <p>At least one item failed to retrieve quantity data</p>
-      </md-list-item>
-    </md-list>
-    <!-- Over limit case -->
-    <p ng-show="actionItems.length > itemsLimit" class="action-item__showing">Showing {{ errorQuantity ? itemsLimit + 1 : itemsLimit }} of {{ actionItems.length }}</p>
-  </div>
-
 </div>
 
 <!-- LAUNCH BUTTON -->

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -41,7 +41,7 @@
         <md-list-item  ng-if="actionItemErrors && actionItemErrors.length">
           <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
           <span>
-            Unable to count
+            Could not count
             <span ng-repeat="itemError in actionItemErrors">
               <span ng-if="actionItemErrors.length > 1 && $last">and </span>
               <span ng-click="goToAction(itemError.actionUrl)">

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -41,15 +41,13 @@
         <md-list-item  ng-if="actionItemErrors && actionItemErrors.length">
           <md-icon class="md-warn action-item__error-quantity">warning</md-icon>
           <span>
-            <span>
-              Unable to count
-              <span ng-repeat="itemError in actionItemErrors">
-                <span ng-if="actionItemErrors.length > 1 && $last">and </span>
-                <span ng-click="goToAction(itemError.actionUrl)">
-                  {{itemError.textPlural}}</span><span
-                  ng-if="actionItemErrors.length > 2 && !$last">, </span><span
-                  ng-if="$last">.</span>
-              </span>
+            Unable to count
+            <span ng-repeat="itemError in actionItemErrors">
+              <span ng-if="actionItemErrors.length > 1 && $last">and </span>
+              <span ng-click="goToAction(itemError.actionUrl)">
+                {{itemError.textPlural}}</span><span
+                ng-if="actionItemErrors.length > 2 && !$last">, </span><span
+                ng-if="$last">.</span>
             </span>
           </span>
         </md-list-item>

--- a/components/staticFeeds/sample-widget__action-items_one.json
+++ b/components/staticFeeds/sample-widget__action-items_one.json
@@ -18,8 +18,8 @@
         "launchText": "See all",
         "actionItems": [
           {
-            "textSingular": "approval awaits your attention.",
-            "textPlural": "approvals await your attention.",
+            "textSingular": "approval awaiting your attention",
+            "textPlural": "approvals awaiting your attention",
             "feedUrl": "staticFeeds/example-json-callbacks/quantities/quantity_42.json",
             "actionUrl": "http://www.google.com"
           }

--- a/components/staticFeeds/sample-widget__action-items_partially-broken.json
+++ b/components/staticFeeds/sample-widget__action-items_partially-broken.json
@@ -18,60 +18,47 @@
         "launchText": "See all",
         "actionItems": [
           {
-            "textSingular": "unconfigured feedUrl",
-            "textPlural": "unconfigured feedUrls",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "task in inbox",
-            "textPlural": "tasks in inbox",
-            "feedUrl": 
-              "staticFeeds/example-json-callbacks/quantities/quantity_0.json",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "task in someday/maybe",
-            "textPlural": "tasks in someday/maybe",
-            "feedUrl": 
-              "staticFeeds/example-json-callbacks/quantities/quantity_17.json",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "missing JSON source",
-            "textPlural": "missing JSON sources",
-            "feedUrl": "does/not/exist/alas.json",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "malformed response",
-            "textPlural": "malformed responses",
-            "feedUrl": "staticFeeds/example-json-callbacks/ill-formed.json",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "nonsensical response",
-            "textPlural": "nonsensical responses",
-            "feedUrl": 
+            "textSingular": "overdue task",
+            "textPlural": "overdue tasks",
+            "feedUrl":
               "staticFeeds/example-json-callbacks/quantities/quantity_nonsense.json",
             "actionUrl": "http://www.google.com"
           },
           {
-            "textSingular": "empty string",
-            "textPlural": "empty strings",
-            "feedUrl": 
-              "staticFeeds/example-json-callbacks/quantities/quantity_empty-string.json",
-            "actionUrl": "http://www.google.com"
-          },
-          {
-            "textSingular": "unfulfilled schema",
-            "textPlural": "unfulfilled schemas",
-            "feedUrl": "list-of-links-via-url.json",
+            "textSingular": "task due today",
+            "textPlural": "tasks due today",
+            "feedUrl": "staticFeeds/example-json-callbacks/ill-formed.json",
             "actionUrl": "http://www.google.com"
           },
           {
             "textSingular": "next action",
             "textPlural": "next actions",
             "feedUrl": "/example-json-callbacks/quantities/quantity_42.json",
+            "actionUrl": "http://www.google.com"
+          },
+          {
+            "textSingular": "project due for review",
+            "textPlural": "projects due for review",
+            "feedUrl": "does/not/exist/alas.json",
+            "actionUrl": "http://www.google.com"
+          },
+          {
+            "textSingular": "task waiting on others",
+            "textPlural": "tasks waiting on others",
+            "actionUrl": "http://www.google.com"
+          },
+          {
+            "textSingular": "task in inbox",
+            "textPlural": "tasks in inbox",
+            "feedUrl":
+              "staticFeeds/example-json-callbacks/quantities/quantity_0.json",
+            "actionUrl": "http://www.google.com"
+          },
+          {
+            "textSingular": "task in someday/maybe",
+            "textPlural": "tasks in someday/maybe",
+            "feedUrl":
+              "staticFeeds/example-json-callbacks/quantities/quantity_17.json",
             "actionUrl": "http://www.google.com"
           }
         ]

--- a/components/staticFeeds/sample-widget__action-items_totally-broken.json
+++ b/components/staticFeeds/sample-widget__action-items_totally-broken.json
@@ -37,14 +37,14 @@
           {
             "textSingular": "nonsensical response",
             "textPlural": "nonsensical responses",
-            "feedUrl": 
+            "feedUrl":
               "staticFeeds/example-json-callbacks/quantities/quantity_nonsense.json",
             "actionUrl": "http://www.google.com"
           },
           {
             "textSingular": "empty string",
             "textPlural": "empty strings",
-            "feedUrl": 
+            "feedUrl":
               "staticFeeds/example-json-callbacks/quantities/quantity_empty-string.json",
             "actionUrl": "http://www.google.com"
           },

--- a/components/staticFeeds/sample-widget__action-items_totally-broken.json
+++ b/components/staticFeeds/sample-widget__action-items_totally-broken.json
@@ -53,6 +53,12 @@
             "textPlural": "unfulfilled schemas",
             "feedUrl": "list-of-links-via-url.json",
             "actionUrl": "http://www.google.com"
+          },
+          {
+            "textSingular": "missing textPlural",
+            "feedUrl":
+              "staticFeeds/example-json-callbacks/quantities/quantity_0.json",
+            "actionUrl": "http://www.google.com"
           }
         ]
       },

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -344,7 +344,11 @@ The [rssToJson][] microservice is a fine way to convert desired RSS feeds into t
 
 #### When to use `action-items`
 
-* You want to display a list of quantity-based items, with quantities that are expected to change. For example, a manager who has to approve time off could see "5 leave requests".
+Use `action-items` to tell the user how many of specific kinds of things need
+their action.
+
+For example, a manager who approves time off could see "5 leave requests" in an
+"Approve time and absences" widget.
 
 #### Additional `action-items` entity file configuration
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -374,22 +374,35 @@ For example, a manager who approves time off could see "5 leave requests" in an
 </portlet-preference>
 ```
 
-* **actionItems**: A simple array of items. Each item should have values for each of the four attributes.
-* **textSingular**: Text to show when there is only 1 item of this type requiring attention.
-* **textPlural**: Text to show when there are multiple items of this type
-  requiring attention. The widget will also use this label to describe the
-  problem if there's an error getting the quantity, as in
-  "Unable to count {textPlural}." This reads better when {textPlural} is a noun
-  phrase, as in "approvals awaiting your attention" rather than
-  "approvals await your attention".
-* **feedUrl**: The URL to fetch the *JSON representation* of the quantity of items needing attention.
-* **actionUrl**: The URL where action can be taken for this specific item. If no such URL exists, use the same URL as you use for the "See all" launch button.
+`widgetConfig` for this widget type contains a single key **actionItems** keying
+to an array of objects. Each object in the array should have values for each of
+four keys.
+
+* **textSingular**: Label shown when the quantity is 1
+* **textPlural**: Label shown when the quantity is other than 1. The widget will
+  also use this label to describe the problem if there's an error getting the
+  quantity, as in "Unable to count {textPlural}." This reads better when
+  {textPlural} is a noun phrase, as in "approvals awaiting your attention"
+  rather than "approvals await your attention".
+* **feedUrl**: The URL to fetch the *JSON representation* of the quantity of
+  items needing attention.
+* **actionUrl**: The URL where the user can take action for this specific item.
+  If no such URL exists, use the same URL as you use for the "See all" launch
+  button.
 
 #### Guidance about `action-items`
 
-If there are multiple action item types to display, the widget will display the first 3 in the list. If there are more than 3, it will display a note that says "Showing 3 of \[x]".
+If there are multiple action item types to display, the widget will display the
+first 3 in the list, or the first two if the widget needs to display an error
+message. If any of the action item types fail (independently), the widget shows
+an error message telling the user what it couldn't count.
 
-The endpoint used for **feedUrl** should return a simple JSON object containing a "quantity" key with an integer for a value. For example:
+If there are more action item types configured than the widget has room to
+display, it will acknowledge it is not showing everything with
+"Showing {x} of {y}".
+
+The **feedUrl** should return a simple JSON object containing a "quantity" key
+with an integer for a value. For example:
 
 ```json
   {

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -385,7 +385,7 @@ The [rssToJson][] microservice is a fine way to convert desired RSS feeds into t
 
 If there are multiple action item types to display, the widget will display the first 3 in the list. If there are more than 3, it will display a note that says "Showing 3 of \[x]".
 
-The endpoint used for **feedUrl** should return a simple JSON object containing a "quantity" key with a number for a value. For example:
+The endpoint used for **feedUrl** should return a simple JSON object containing a "quantity" key with an integer for a value. For example:
 
 ```json
   {

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -344,7 +344,7 @@ The [rssToJson][] microservice is a fine way to convert desired RSS feeds into t
 
 #### When to use `action-items`
 
-* You want to display a list of quantity-based items, with quantities that are expected to change. For example, a manager who has to approve time off could see "5 leave requests need your approval".
+* You want to display a list of quantity-based items, with quantities that are expected to change. For example, a manager who has to approve time off could see "5 leave requests".
 
 #### Additional `action-items` entity file configuration
 
@@ -359,10 +359,10 @@ The [rssToJson][] microservice is a fine way to convert desired RSS feeds into t
       <![CDATA[{
         "actionItems": [
           {
-            "textSingular": "item needs your attention.",
-            "textPlural": "items need your attention.",
-            "feedUrl": "example/path/to/individual-item-feed",
-            "actionUrl": "example/path/to/take/action"
+            "textSingular": "absence request to approve",
+            "textPlural": "absence requests to approve",
+            "feedUrl": "example/path/to/absence-request-quantity-feed",
+            "actionUrl": "example/path/to/approve/absences"
           }
         ]
       }]]>
@@ -372,7 +372,12 @@ The [rssToJson][] microservice is a fine way to convert desired RSS feeds into t
 
 * **actionItems**: A simple array of items. Each item should have values for each of the four attributes.
 * **textSingular**: Text to show when there is only 1 item of this type requiring attention.
-* **textPlural**: Text to show when there are multiple items of this type requiring attention.
+* **textPlural**: Text to show when there are multiple items of this type
+  requiring attention. The widget will also use this label to describe the
+  problem if there's an error getting the quantity, as in
+  "Unable to count {textPlural}." This reads better when {textPlural} is a noun
+  phrase, as in "approvals awaiting your attention" rather than
+  "approvals await your attention".
 * **feedUrl**: The URL to fetch the *JSON representation* of the quantity of items needing attention.
 * **actionUrl**: The URL where action can be taken for this specific item. If no such URL exists, use the same URL as you use for the "See all" launch button.
 


### PR DESCRIPTION
Improving error handling in `action-items` widget type, trying to un-block the "HRS Approvals" widget going to production in MyUW (currently blocked by insufficiently clear failure experiences that might detract from smooth launch of incremental self-service approvals functions).

Allows action item types within an `action-items` widget to independently fail and acknowledges the failed item types by name.

After:

<img width="1590" alt="tightened-action-items-error-handling" src="https://user-images.githubusercontent.com/952283/45919156-f57ee880-be56-11e8-92f5-6474e5a80a9f.png">

Before:

<img width="1553" alt="status_quo_action-items_error_handling" src="https://user-images.githubusercontent.com/952283/45824616-06dcbf00-bcb6-11e8-8b6f-2803a944817e.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
