### PR TITLE
docs: fix trivial typo "us it" --> "use it" (inline source code comment)

### DIFF
--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -170,7 +170,7 @@ define(['angular'], function(angular) {
                     message.title = messageTitle;
                   }
 
-                  // if dataMessageLearnMoreUrl is specified, us it
+                  // if dataMessageLearnMoreUrl is specified, use it
                   if (objectToFind &&
                       message.data.dataMessageMoreInfoUrl &&
                       message.moreInfoButton && angular.isArray(


### PR DESCRIPTION
Fixes a trivial typo in an inline comment in the source code.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
