### PR TITLE
docs(changelog): correct and clean up CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,14 +373,14 @@ version or later to avoid showing users a broken mascot announcement experience.
 
 ### Breaking Changes
 
-+   Moves the data object in messages out of the audience object and into a
++ Moves the data object in messages out of the audience object and into a
   separate object. This will affect installations that have configured a
   messages.json file. (#649)
-+   Removes a route formerly used to catch a localStorage error (#643)
++ Removes a route formerly used to catch a localStorage error (#643)
 
-+   To upgrade:
-    - If your app's main.js file uses the `'/sorry-safari'` route, remove it
-    - Also remove the corresponding url-pattern from your app's web.xml file
++ To upgrade:
+  + If your app's main.js file uses the `'/sorry-safari'` route, remove it
+  + Also remove the corresponding url-pattern from your app's web.xml file
 
 When upgrading a shared `messages.json` to use this new structure, all apps
 sourcing that shared `messages.json` will need to be upgraded to this version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,6 @@ and this project adheres to
 + Removed link to Features page ("What's New") from default app configuration
   (#770)
 
-
 ### Fixed in 9.2.1
 
 + Fixed potential upgrade path difficulty by making changes to "/about" and
@@ -181,7 +180,6 @@ and this project adheres to
   above other content (#771)
 + Added basic `<body>` styles (override Bootstrap values) to ensure Roboto is
   always preferred (#771)
-
 
 ## [9.2.0][] - 2018-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,42 +138,42 @@ and this project adheres to
 ## [10.0.0][] - 2018-07-13
 
 ### Removed
-* Removes `$rootScope.GuestMode` (#777)
++ Removes `$rootScope.GuestMode` (#777)
 
 ### Added
-* new filter `canAdd`, useful for filtering portlets on whether user can or
++ new filter `canAdd`, useful for filtering portlets on whether user can or
   cannot add them to layout (#791)
 
 ### Changed
-* Changes list of links limit to 6 items. (#773)
-* Fixed list of links widget buttons clipping on some screen sizes (#781)
-* Moved widget info (description) and remove button into contextual menu to
++ Changes list of links limit to 6 items. (#773)
++ Fixed list of links widget buttons clipping on some screen sizes (#781)
++ Moved widget info (description) and remove button into contextual menu to
   reduce burden on keyboard users (#786)
-* Upgrades Angular to version 1.7.2 (#788)
++ Upgrades Angular to version 1.7.2 (#788)
 
 ### Fixed
-* Dates and titles in RSS widget no longer overlap each other (#780)
-* Removes unused `id` on the widget-removal div, thereby removing a source of
++ Dates and titles in RSS widget no longer overlap each other (#780)
++ Removes unused `id` on the widget-removal div, thereby removing a source of
   HTML element `id` uniqueness constraint violations in the markup. (#787)
 
 ### Documentation
-* Note in changelog message handling changes needing upgrade coordination (#733)
++ Note in changelog message handling changes needing upgrade coordination (#733)
 
 ## [9.2.1][] - 2018-06-08
 
 ### Changed
-* Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app
++ Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app
   name (i.e. "STAR"), the two names now appear inline (#766)
-* Removed link to Features page ("What's New") from default app configuration
++ Removed link to Features page ("What's New") from default app configuration
   (#770)
 
 
 ### Fixed
-* Fixed potential upgrade path difficulty by making changes to "/about" and
++ Fixed potential upgrade path difficulty by making changes to "/about" and
   "/session-info" routes backward compatible (#765)
-* Increased z-index of all dialogs to highest value (101) to ensure they appear
++ Increased z-index of all dialogs to highest value (101) to ensure they appear
   above other content (#771)
-* Added basic `<body>` styles (override Bootstrap values) to ensure Roboto is
++ Added basic `<body>` styles (override Bootstrap values) to ensure Roboto is
   always preferred (#771)
 
 
@@ -181,59 +181,59 @@ and this project adheres to
 
 ### Added
 
-* New "session info" page containing the former content of the "About" page
++ New "session info" page containing the former content of the "About" page
   (uportal-app-framework version info, app info JSON) (#755)
-  * To use: Add the `'portal/help/routes'` module in your main.js file (#765)
-* App config option `aboutPageURL` to get text and links for "About" page (#755)
-* Made Google's Roboto web font available (#761)
+  + To use: Add the `'portal/help/routes'` module in your main.js file (#765)
++ App config option `aboutPageURL` to get text and links for "About" page (#755)
++ Made Google's Roboto web font available (#761)
 
 ### Changed
-* "About" page now sources meaningful content from `aboutPageURL` (#755)
-* Use Roboto font family (#761)
-* z-index values adjusted from highest (101) to lowest (51) stated values to
++ "About" page now sources meaningful content from `aboutPageURL` (#755)
++ Use Roboto font family (#761)
++ z-index values adjusted from highest (101) to lowest (51) stated values to
   play nicer with Angular Material (#760)
-* To better support open source commitment and downstream apps, replaced
++ To better support open source commitment and downstream apps, replaced
   hard-coded MyUW/UW-Madison specific language in meta tags (now sourced from
   the same JSON file as the app's About page information) (#763)
-* SVG widget icons use the md-icon directive to scale properly (#764)
++ SVG widget icons use the md-icon directive to scale properly (#764)
 
 ### Fixed
 
-* When priority notification title is truncated, provide full title as tooltip
++ When priority notification title is truncated, provide full title as tooltip
   (#754)
-* Fix route to newly-added version info page (#758)
-* Widgets with overlays can be removed (#760)
-* Notifications' action buttons now open in new tab (#762)
++ Fix route to newly-added version info page (#758)
++ Widgets with overlays can be removed (#760)
++ Notifications' action buttons now open in new tab (#762)
 
 ### Removed
 
-* No longer used LoginOnLoad option removed (#753)
++ No longer used LoginOnLoad option removed (#753)
 
 ## [9.1.0][] - 2018-04-17
 
 ### Added
 
-* `showAllMessages` beta setting. When true disables all client-side message
++ `showAllMessages` beta setting. When true disables all client-side message
   filtering. Useful for demos and testing. (#742)
 
 ### Changed
 
-* `list-of-links` now offers tooltip with full title when it truncates any link
++ `list-of-links` now offers tooltip with full title when it truncates any link
   title, not just those presented via `circle-button`s (#736)
-* RSS widgets now offer tooltip with full title when truncating item titles
++ RSS widgets now offer tooltip with full title when truncating item titles
   (#737)
-* Data urls only called when necessary (#747)
++ Data urls only called when necessary (#747)
 
 ### Fixed
 
-* `list-of-links` widgets are now `basic` widgets in the zero links edge case
++ `list-of-links` widgets are now `basic` widgets in the zero links edge case
   (#735)
-* `list-of-links` now `aria-label`s links, ensuring a non-truncated version of
++ `list-of-links` now `aria-label`s links, ensuring a non-truncated version of
   the link label is available to browsers (#736)
 
 ### Removed
 
-* Support for `APP_OPTIONS.optionsTemplateURL` configuration is removed in this
++ Support for `APP_OPTIONS.optionsTemplateURL` configuration is removed in this
   release. It had previously been documented as "deprecated" but the
   backwards-compatibility support didn't work out (#744), so in practice support
   for this feature was already removed as a breaking change for the `9.x`
@@ -253,9 +253,9 @@ clean artifact.
 
 ### Changed
 
-* Minor CHANGELOG change
++ Minor CHANGELOG change
   (#731)
-* Fix positioning of frame-page title when using on-page side navigation (#738)
++ Fix positioning of frame-page title when using on-page side navigation (#738)
 
 ## [9.0.1][] - 2018-03-29
 
@@ -269,53 +269,53 @@ would need to be upgraded to this version or later to avoid showing messages to
 audiences for whom they may not have been intended.
 
 ### Added
-* Adds resetters to user-settings page (#724)
-* `circle-button` now offers tooltip with full title when title is truncated
++ Adds resetters to user-settings page (#724)
++ `circle-button` now offers tooltip with full title when title is truncated
   (#727)
 
 ### Changed
 
-* Out of the box example `list-of-links` widget now more self-documenting
++ Out of the box example `list-of-links` widget now more self-documenting
   (#727, #729)
 
 ### Fixed
 
-* `circle-button` no longer truncates `aria-label` representation of title
++ `circle-button` no longer truncates `aria-label` representation of title
   (#727)
-* Message filtering now more precise (#730)
++ Message filtering now more precise (#730)
 
 ### Build engineering
 
 
 ### Documentation
 
-* DEPRECATED: Font Awesome icons for `list-of-links` links. Use Material Icons
++ DEPRECATED: Font Awesome icons for `list-of-links` links. Use Material Icons
   instead. (#727)
-* Modest improvements to `list-of-links` widget type documentation (#727)
-* Adds glossary (#725)
++ Modest improvements to `list-of-links` widget type documentation (#727)
++ Adds glossary (#725)
 
 ## [9.0.0][] - 2018-03-21
 
 ### Breaking changes
 
-* Removed jQuery UI sortable dependency (#721)
-* Removed `<app-header>` directive. This affects any framework apps using that
++ Removed jQuery UI sortable dependency (#721)
++ Removed `<app-header>` directive. This affects any framework apps using that
   directive outside of `<frame-page>`. `<frame-page>` usages should be
   unaffected. (#684)
-* With the removal of the `<app-header>`, the `APP_OPTIONS.optionsTemplateURL`
++ With the removal of the `<app-header>`, the `APP_OPTIONS.optionsTemplateURL`
   config has been removed, superseded by a new `APP_OPTIONS.appMenuTemplateURL`.
   Templates may require minor layout/appearance adjustments for use in the new
   way. (#684)
 
 To upgrade:
 
-* Add jQueryUI Sortable to frame app, or refer to
++ Add jQueryUI Sortable to frame app, or refer to
   [an example of angular-drag-and-drop-lists][uportal-home #795]
-* If using the "app-title" attribute on frame-page directive, that title will be
++ If using the "app-title" attribute on frame-page directive, that title will be
   used as the document title
-* Pages formerly using `app-header` can use the `page-title` attribute on
++ Pages formerly using `app-header` can use the `page-title` attribute on
   `frame-page` to achieve a similar within-page `h1` heading as before.
-* Port forward `APP_OPTIONS.optionsTemplateURL` usages to
++ Port forward `APP_OPTIONS.optionsTemplateURL` usages to
   `APP_OPTIONS.appMenuTemplateURL` usages. This content will now appear in the
   side navigation and may likely need a bit of tweaking if using a rigid
   CSS layout.
@@ -327,52 +327,52 @@ version or later to avoid showing users a broken mascot announcement experience.
 
 ### Added
 
-* `mainService` now offers `computeWindowTitle(...)` (#679)
-* `<frame-page>` directive now offers `page-title` attribute to add a `<h1>`
++ `mainService` now offers `computeWindowTitle(...)` (#679)
++ `<frame-page>` directive now offers `page-title` attribute to add a `<h1>`
   tag with the app icon and title to the page (#684)
-* When side navigation is open, keyboard focus will remain inside the menu and
++ When side navigation is open, keyboard focus will remain inside the menu and
   cycle through menu options until it's closed (#707)
-* Logs the dynamic list-of-links response in some dynamic list-of-links error
++ Logs the dynamic list-of-links response in some dynamic list-of-links error
   cases (#715)
-* Core Infrastructure Initiative badge (#711)
++ Core Infrastructure Initiative badge (#711)
 
 ### Changed
 
-* `<frame-page>` sets document title per existing `app-title` attribute (#682)
-* The `show-add-to-home` attribute on the `<frame-page>` directive now displays
++ `<frame-page>` sets document title per existing `app-title` attribute (#682)
++ The `show-add-to-home` attribute on the `<frame-page>` directive now displays
   a dismissible-for-session toast message prompting users to add the app to
   their home page, instead of a button. (#684)
-* `vm.showMessagesFeatures` variable moved out of default and into more
++ `vm.showMessagesFeatures` variable moved out of default and into more
   logically appropriate spot (#694)
-* Improved appearance of add-to-home toast message (#706)
++ Improved appearance of add-to-home toast message (#706)
 
 ### Fixed
 
-* External links in mascot announcements now work again. (#697)
-* "Skip to main content" link now skips more repeated navigation to reach
++ External links in mascot announcements now work again. (#697)
++ "Skip to main content" link now skips more repeated navigation to reach
   closer to the main content. (#698) (#705)
-* Label widget cover dismiss button as "OK" rather than "Continue" (#675)
-* Fixed widget in-app message example (#714)
++ Label widget cover dismiss button as "OK" rather than "Continue" (#675)
++ Fixed widget in-app message example (#714)
 
 ### Build engineering
 
-* Update package lockfile with updated dependencies (#704)
-* Update stylelint to version 9.1.3 (#718)
++ Update package lockfile with updated dependencies (#704)
++ Update stylelint to version 9.1.3 (#718)
 
 ### Documentation
 
-* About dynamically sourcing `list-of-links` widget content (#717)
++ About dynamically sourcing `list-of-links` widget content (#717)
 
 ## [8.0.0][] - 2018-01-08
 
 ### Breaking Changes
 
-*   Moves the data object in messages out of the audience object and into a
++   Moves the data object in messages out of the audience object and into a
   separate object. This will affect installations that have configured a
   messages.json file. (#649)
-*   Removes a route formerly used to catch a localStorage error (#643)
++   Removes a route formerly used to catch a localStorage error (#643)
 
-*   To upgrade:
++   To upgrade:
     - If your app's main.js file uses the `'/sorry-safari'` route, remove it
     - Also remove the corresponding url-pattern from your app's web.xml file
 
@@ -392,35 +392,35 @@ or expired messages.
 
 ### Added
 
-* track clicks on sidenav footer links (#642)
-* add documentation clarifying major upgrades (#647)
-* add the ability to set message title via an external data source (#649)
-* add the ability to set a message more info button url via an external data
++ track clicks on sidenav footer links (#642)
++ add documentation clarifying major upgrades (#647)
++ add the ability to set message title via an external data source (#649)
++ add the ability to set a message more info button url via an external data
   source (#649)
 
 ### Changed
 
-* update documentation to read more and state intent more clearly (#632)
-* update to latest version (2.0) of karma (#652)
++ update documentation to read more and state intent more clearly (#632)
++ update to latest version (2.0) of karma (#652)
 
 ### Fixed
 
-* synch priority header with bell (#638)
-* filter messages where today is outside of start and end dates (#639)
-* allow priority notification buttons to display full button text (#640)
-* catch localStorage error with IE (#643)
-* implemented filter messages by date (#650)
++ synch priority header with bell (#638)
++ filter messages where today is outside of start and end dates (#639)
++ allow priority notification buttons to display full button text (#640)
++ catch localStorage error with IE (#643)
++ implemented filter messages by date (#650)
 
 ### Build engineering
 
-* add documentation stating intent to use Conventional commits and tips on how
++ add documentation stating intent to use Conventional commits and tips on how
   to comply (#634)
-* leverage commitlint travis helper (#621)
-* update to latest version (6.0.0) of lint-staged (#631)
-* move some git commit hooks to be optionally installed (#635)
-* suppress `eslint` on `docs/` when linting staged changes (#636)
-* require npm 5.6.0 or higher (#644)
-* resolved appveyor require.js flakiness (#645)
++ leverage commitlint travis helper (#621)
++ update to latest version (6.0.0) of lint-staged (#631)
++ move some git commit hooks to be optionally installed (#635)
++ suppress `eslint` on `docs/` when linting staged changes (#636)
++ require npm 5.6.0 or higher (#644)
++ resolved appveyor require.js flakiness (#645)
 
 ## [7.0.0][] - 2017-11-30
 
@@ -443,18 +443,18 @@ flex-based layout (#588).
 
 This may affect an application if:
 
-* It has a lot of elements with a defined `min-width` property
-* It is already using flex positioning but is not using `flex-wrap` on
++ It has a lot of elements with a defined `min-width` property
++ It is already using flex positioning but is not using `flex-wrap` on
   containers with a lot of content
-* It has many elements with `position: absolute` (may experience a minor
++ It has many elements with `position: absolute` (may experience a minor
 
 Examples of the kinds of downstream changes required:
 
-* uPortal-home [change to use `<frame-page>` in some views][uportal-home #739]
++ uPortal-home [change to use `<frame-page>` in some views][uportal-home #739]
   and [in the rest of the views][uportal-home #742]
-* uPortal-home had to further adjust [to accommodate flex-based
++ uPortal-home had to further adjust [to accommodate flex-based
   layout][uportal-home #747]
-* uPortal-home [updated the app directory entry details page with plain
++ uPortal-home [updated the app directory entry details page with plain
   CSS][uportal-home #750] to cope with this change
 
 Also, this release adds support for dynamic notification text sourced from a
@@ -465,34 +465,34 @@ notification content.
 
 ### Features
 
-* Add on-page side navigation feature (#588) + To use: Set
++ Add on-page side navigation feature (#588) + To use: Set
   `APP_OPTIONS.enablePushContentMenu` to true in your override.js file
-* Add more Google Analytics around notifications (#598). Events for + rendering
++ Add more Google Analytics around notifications (#598). Events for + rendering
   priority (banner across the top) notification + dismissing priority
   notification + rendering notification by opening the bell menu + clicks on
   mobile side-nav notification bell, with and without priority
   indicator + dismissing notification from the bell menu + dismissing or
   restoring notification from notifications page
-* Support dynamic notification text sourced from JSON web service (#601)
++ Support dynamic notification text sourced from JSON web service (#601)
 
 ### Fixed
 
-* Improves top bar accessibility (#594)
-* Fix the `search-with-links` widget type (#585)
-* Fix footer link style to avoid off-by-one-pixel misalignment (#586)
-* Fix separator character between footer links (#587, #590)
-* Clarify safety of `/settings` tooling to reset in-browser state. (#600)
-* Fix notification rendering robustness against duplicate ids (#602, #603)
++ Improves top bar accessibility (#594)
++ Fix the `search-with-links` widget type (#585)
++ Fix footer link style to avoid off-by-one-pixel misalignment (#586)
++ Fix separator character between footer links (#587, #590)
++ Clarify safety of `/settings` tooling to reset in-browser state. (#600)
++ Fix notification rendering robustness against duplicate ids (#602, #603)
 
 ### Refactor
 
-* Use `moment.js` in `time-sensitive-content` widget type (#593)
++ Use `moment.js` in `time-sensitive-content` widget type (#593)
 
 ### Build engineering
 
-* Now runs `commitlint` on `travis-ci`, removing `precommit` hook that
++ Now runs `commitlint` on `travis-ci`, removing `precommit` hook that
   previously verified commit messages locally. (#581)
-* Now sets Java 8 rather than 7 as source and target version (#591)
++ Now sets Java 8 rather than 7 as source and target version (#591)
 
 Note that this project only incidentally uses Java and Maven. In the future
 this front-end product may not use Java at all. (Server-side services uPortal
@@ -500,40 +500,40 @@ app framework relies upon might still use Java, of course.)
 
 ### Code style
 
-* Fix a bunch of JSDoc warnings (#598)
++ Fix a bunch of JSDoc warnings (#598)
 
 ## [6.1.0][] - 2017-10-18
 
 ### Added
 
-* Add filter to determine rel attribute on anchors (#569)
-* Add configurable side navigation (#561) - See
++ Add filter to determine rel attribute on anchors (#569)
++ Add configurable side navigation (#561) - See
   [uportal-app-framework documentation][sidenav-documentation] of this new
   feature
 
 ### Changed
 
-* Refactor theme names (#568)
-* Update to version 4.2.0 of config-angular (#578)
-* Pull UI Sortable from CDN (#579)
++ Refactor theme names (#568)
++ Update to version 4.2.0 of config-angular (#578)
++ Pull UI Sortable from CDN (#579)
 
 ### Fixed
 
-* Fix mismatch in portal theme key (#570)
-* Hides notification bell when on notification page (#572)
-* Update release documentation (#557)
-* Fix app hangs when promise returns undefined (#575)
-* Fix bug where notification bell still showed on notification page (#576)
-* Add error message when notifications fail (#577)
-* Fix spacing error if no configurable side navigation is used (#583)
-* Allow unbroken experience when opting-out of portal-wide notifications (#611)
-* Fix accessibility bug where screen reader/keyboard navigation couldn't access
++ Fix mismatch in portal theme key (#570)
++ Hides notification bell when on notification page (#572)
++ Update release documentation (#557)
++ Fix app hangs when promise returns undefined (#575)
++ Fix bug where notification bell still showed on notification page (#576)
++ Add error message when notifications fail (#577)
++ Fix spacing error if no configurable side navigation is used (#583)
++ Allow unbroken experience when opting-out of portal-wide notifications (#611)
++ Fix accessibility bug where screen reader/keyboard navigation couldn't access
   notifications/announcements (#613)
-* Clarify that side navigation subheader is not a link (#617)
++ Clarify that side navigation subheader is not a link (#617)
 
 ## [6.0.3][] - 2017-09-29
 
-* fix(messages): return nothing on filter fail (#554)
++ fix(messages): return nothing on filter fail (#554)
 
 ## [6.0.2][] - 2017-09-29
 
@@ -542,45 +542,45 @@ relying upon fixed notifications in a shared messages source, all participating
 apps must first be upgraded to this release or later to avoid improperly bound
 URLs in priority notifications as presented in not-yet-upgraded apps.
 
-* Properly bind URLs in priority notifications (#553)
-* Eliminate gap between top bar on mobile (#552)
-* Add Google Analytics events to notifications (#550)
-* renaming angularjs-portal to uportal-home (#549)
-* correct references uportal app framework (#548)
++ Properly bind URLs in priority notifications (#553)
++ Eliminate gap between top bar on mobile (#552)
++ Add Google Analytics events to notifications (#550)
++ renaming angularjs-portal to uportal-home (#549)
++ correct references uportal app framework (#548)
 
 ## [6.0.1][] - 2017-09-25
 
-* Cleaning up project name relics (#538, #539, #540, #541, #542)
-* Fix typo in time-sensitive widget (#537)
++ Cleaning up project name relics (#538, #539, #540, #541, #542)
++ Fix typo in time-sensitive widget (#537)
 
 ## [6.0.0][] - 2017-09-22
 
-* Renaming project to uportal-app-framework
++ Renaming project to uportal-app-framework
 
 ## [5.2.1][] - 2017-09-21
 
-* Add time-sensitive-content widget type (#524)
++ Add time-sensitive-content widget type (#524)
 
 ## [5.2.0][] - 2017-09-20
 
 ### Messages Enhancements
 
-* Notifications may be non-dismissible (#521)
-* Add widget from mascot announcement (#526)
++ Notifications may be non-dismissible (#521)
++ Add widget from mascot announcement (#526)
 
 ### Widget Enhancements
 
-* Option-link widget evaluates target (#519)
++ Option-link widget evaluates target (#519)
 
 ### Configuration Change
 
-* Default menu options to be null (#514)
++ Default menu options to be null (#514)
 
 ### Maintenance
 
-* Shore up licencing (#515) (#523) (#527)
-* Add a changelog (#513)
-* Release using Conventional Commits (#516)
++ Shore up licencing (#515) (#523) (#527)
++ Add a changelog (#513)
++ Release using Conventional Commits (#516)
 
 ## [5.1.0][] - 2017-09-01
 
@@ -592,17 +592,17 @@ announcements in not-yet-upgraded applications.
 
 ### Messages Enhancements
 
-* Adds actionbutton and more info button to features page and priority
++ Adds actionbutton and more info button to features page and priority
   notifications (#504)
-* Adds 'addToHome' functionality directly from mascot announcement (#506)
++ Adds 'addToHome' functionality directly from mascot announcement (#506)
   (#512)
-* Fixes bug with notification urls not being resolved correctly (#507)
++ Fixes bug with notification urls not being resolved correctly (#507)
 
 ### Code Maintenance and Enhancements
 
-* Updates karma to latest version (#511)
-* Adopts Conventional Commits (#487)
-* Adds additional project status badges (#510)
++ Updates karma to latest version (#511)
++ Adopts Conventional Commits (#487)
++ Adds additional project status badges (#510)
 
 ## [5.0.0][] - 2017-08-24
 
@@ -630,99 +630,99 @@ return to a faster paced release cycle in the future.
 
 #### Messages!
 
-* [Simplify disparate forms of in-app messaging](https://github.com/uPortal-Project/uportal-app-framework/pull/484)
++ [Simplify disparate forms of in-app messaging](https://github.com/uPortal-Project/uportal-app-framework/pull/484)
 
 ### Minor Enhancements
 
 #### Widget Types
 
-* [Action Items widget type](https://github.com/uPortal-Project/uportal-app-framework/pull/465)
-* [Add URL capability to list of links type](https://github.com/uPortal-Project/uportal-app-framework/pull/473)
++ [Action Items widget type](https://github.com/uPortal-Project/uportal-app-framework/pull/465)
++ [Add URL capability to list of links type](https://github.com/uPortal-Project/uportal-app-framework/pull/473)
 
 #### UI Enhancements
 
-* [Add tooltips to header buttons a la Google apps](https://github.com/uPortal-Project/uportal-app-framework/pull/445)
-* [Improve usability for screen readers](https://github.com/uPortal-Project/uportal-app-framework/pull/448)
-* [Frame works withu portal master](https://github.com/uPortal-Project/uportal-app-framework/pull/451)
-* [Improve mascot announcements](https://github.com/uPortal-Project/uportal-app-framework/pull/456)
-* [Notifications](https://github.com/uPortal-Project/uportal-app-framework/pull/458)
-* [Improve appearance of features page](https://github.com/uPortal-Project/uportal-app-framework/pull/459)
-* [Show number of notifications/announcements in see all link](https://github.com/uPortal-Project/uportal-app-framework/pull/460)
-* [Opt out av](https://github.com/uPortal-Project/uportal-app-framework/pull/469)
-* [Display campus ID in username menu](https://github.com/uPortal-Project/uportal-app-framework/pull/470)
-* [Refactor app-header options](https://github.com/uPortal-Project/uportal-app-framework/pull/490)
-* [Speed up notifications bell (and other improvements)](https://github.com/uPortal-Project/uportal-app-framework/pull/502)
++ [Add tooltips to header buttons a la Google apps](https://github.com/uPortal-Project/uportal-app-framework/pull/445)
++ [Improve usability for screen readers](https://github.com/uPortal-Project/uportal-app-framework/pull/448)
++ [Frame works withu portal master](https://github.com/uPortal-Project/uportal-app-framework/pull/451)
++ [Improve mascot announcements](https://github.com/uPortal-Project/uportal-app-framework/pull/456)
++ [Notifications](https://github.com/uPortal-Project/uportal-app-framework/pull/458)
++ [Improve appearance of features page](https://github.com/uPortal-Project/uportal-app-framework/pull/459)
++ [Show number of notifications/announcements in see all link](https://github.com/uPortal-Project/uportal-app-framework/pull/460)
++ [Opt out av](https://github.com/uPortal-Project/uportal-app-framework/pull/469)
++ [Display campus ID in username menu](https://github.com/uPortal-Project/uportal-app-framework/pull/470)
++ [Refactor app-header options](https://github.com/uPortal-Project/uportal-app-framework/pull/490)
++ [Speed up notifications bell (and other improvements)](https://github.com/uPortal-Project/uportal-app-framework/pull/502)
 
 #### Configuration Changes
 
-* [pulling string into configuration](https://github.com/uPortal-Project/uportal-app-framework/pull/443)
-* [Enables notifications to work in static frame](https://github.com/uPortal-Project/uportal-app-framework/pull/453)
-* [Sets uPortal default theme as default](https://github.com/uPortal-Project/uportal-app-framework/pull/466)
-* [Uses aries proxy](https://github.com/uPortal-Project/uportal-app-framework/pull/475)
-* [MUMUP-2699 Adds ability for portal skin switching](https://github.com/uPortal-Project/uportal-app-framework/pull/483)
-* [MUMUP-2990 Use portal session rather than Shibboleth](https://github.com/uPortal-Project/uportal-app-framework/pull/491)
++ [pulling string into configuration](https://github.com/uPortal-Project/uportal-app-framework/pull/443)
++ [Enables notifications to work in static frame](https://github.com/uPortal-Project/uportal-app-framework/pull/453)
++ [Sets uPortal default theme as default](https://github.com/uPortal-Project/uportal-app-framework/pull/466)
++ [Uses aries proxy](https://github.com/uPortal-Project/uportal-app-framework/pull/475)
++ [MUMUP-2699 Adds ability for portal skin switching](https://github.com/uPortal-Project/uportal-app-framework/pull/483)
++ [MUMUP-2990 Use portal session rather than Shibboleth](https://github.com/uPortal-Project/uportal-app-framework/pull/491)
 
 ### Patch Enhancements
 
 #### Content Changes
 
-* [making the widget init function accessible via scope](https://github.com/uPortal-Project/uportal-app-framework/pull/444)
-* [Use sentence case in tooltips.](https://github.com/uPortal-Project/uportal-app-framework/pull/446)
-* [Animate priority notifications [nice-to-have]](https://github.com/uPortal-Project/uportal-app-framework/pull/499)
++ [making the widget init function accessible via scope](https://github.com/uPortal-Project/uportal-app-framework/pull/444)
++ [Use sentence case in tooltips.](https://github.com/uPortal-Project/uportal-app-framework/pull/446)
++ [Animate priority notifications [nice-to-have]](https://github.com/uPortal-Project/uportal-app-framework/pull/499)
 
 #### Documentation Improvements
 
-* [Documentation Syntax Highlighting](https://github.com/uPortal-Project/uportal-app-framework/pull/431)
-* [Adds skinning exercise to docs folder](https://github.com/uPortal-Project/uportal-app-framework/pull/447)
-* [Fixes skinning.md lint errors](https://github.com/uPortal-Project/uportal-app-framework/pull/449)
-* [Expands the quickstart link text from the main README](https://github.com/uPortal-Project/uportal-app-framework/pull/452)
-* [Adds a notification user exercise](https://github.com/uPortal-Project/uportal-app-framework/pull/454)
-* [Adds a feature exercise](https://github.com/uPortal-Project/uportal-app-framework/pull/455)
-* [Acknowledge Apereo Welcoming Policy](https://github.com/uPortal-Project/uportal-app-framework/pull/461)
-* [Add Christian Murphy as committer](https://github.com/uPortal-Project/uportal-app-framework/pull/464)
-* [Move widget documentation from uportal-home](https://github.com/uPortal-Project/uportal-app-framework/pull/471)
-* [MUMUP-2932 Adds missing png files to docs](https://github.com/uPortal-Project/uportal-app-framework/pull/476)
-* [Remove Manifest group reference](https://github.com/uPortal-Project/uportal-app-framework/pull/477)
-* [Guide towards sentence case](https://github.com/uPortal-Project/uportal-app-framework/pull/478)
-* [docs(github): Add SUPPORT.md to guide questions to the mailing list](https://github.com/uPortal-Project/uportal-app-framework/pull/479)
-* [Acknowledge bundled dependencies and add NOTICE file](https://github.com/uPortal-Project/uportal-app-framework/pull/489)
++ [Documentation Syntax Highlighting](https://github.com/uPortal-Project/uportal-app-framework/pull/431)
++ [Adds skinning exercise to docs folder](https://github.com/uPortal-Project/uportal-app-framework/pull/447)
++ [Fixes skinning.md lint errors](https://github.com/uPortal-Project/uportal-app-framework/pull/449)
++ [Expands the quickstart link text from the main README](https://github.com/uPortal-Project/uportal-app-framework/pull/452)
++ [Adds a notification user exercise](https://github.com/uPortal-Project/uportal-app-framework/pull/454)
++ [Adds a feature exercise](https://github.com/uPortal-Project/uportal-app-framework/pull/455)
++ [Acknowledge Apereo Welcoming Policy](https://github.com/uPortal-Project/uportal-app-framework/pull/461)
++ [Add Christian Murphy as committer](https://github.com/uPortal-Project/uportal-app-framework/pull/464)
++ [Move widget documentation from uportal-home](https://github.com/uPortal-Project/uportal-app-framework/pull/471)
++ [MUMUP-2932 Adds missing png files to docs](https://github.com/uPortal-Project/uportal-app-framework/pull/476)
++ [Remove Manifest group reference](https://github.com/uPortal-Project/uportal-app-framework/pull/477)
++ [Guide towards sentence case](https://github.com/uPortal-Project/uportal-app-framework/pull/478)
++ [docs(github): Add SUPPORT.md to guide questions to the mailing list](https://github.com/uPortal-Project/uportal-app-framework/pull/479)
++ [Acknowledge bundled dependencies and add NOTICE file](https://github.com/uPortal-Project/uportal-app-framework/pull/489)
 
 #### Bug Fixes
 
-* [Fix md-menu forcing scroll when priority notifications visible](https://github.com/uPortal-Project/uportal-app-framework/pull/428)
-* [Portal feature service flatten nested promises](https://github.com/uPortal-Project/uportal-app-framework/pull/438)
-* [fixing errors and not returning reasons](https://github.com/uPortal-Project/uportal-app-framework/pull/442)
-* [Announcement bug fix](https://github.com/uPortal-Project/uportal-app-framework/pull/450)
-* [Reverts groups url back to previous default state](https://github.com/uPortal-Project/uportal-app-framework/pull/457)
-* [error checking weather data response](https://github.com/uPortal-Project/uportal-app-framework/pull/468)
-* [using css for action-items, md-colors didn't work well with themes](https://github.com/uPortal-Project/uportal-app-framework/pull/472)
-* [Lower z-index of maintenance mode overlay](https://github.com/uPortal-Project/uportal-app-framework/pull/482)
-* [Fix sticky priority notifications](https://github.com/uPortal-Project/uportal-app-framework/pull/496)
-* [Fix dismiss/restore message state not persisting](https://github.com/uPortal-Project/uportal-app-framework/pull/497)
-* [upping the expiration on the mock session to be 8 hours](https://github.com/uPortal-Project/uportal-app-framework/pull/501)
++ [Fix md-menu forcing scroll when priority notifications visible](https://github.com/uPortal-Project/uportal-app-framework/pull/428)
++ [Portal feature service flatten nested promises](https://github.com/uPortal-Project/uportal-app-framework/pull/438)
++ [fixing errors and not returning reasons](https://github.com/uPortal-Project/uportal-app-framework/pull/442)
++ [Announcement bug fix](https://github.com/uPortal-Project/uportal-app-framework/pull/450)
++ [Reverts groups url back to previous default state](https://github.com/uPortal-Project/uportal-app-framework/pull/457)
++ [error checking weather data response](https://github.com/uPortal-Project/uportal-app-framework/pull/468)
++ [using css for action-items, md-colors didn't work well with themes](https://github.com/uPortal-Project/uportal-app-framework/pull/472)
++ [Lower z-index of maintenance mode overlay](https://github.com/uPortal-Project/uportal-app-framework/pull/482)
++ [Fix sticky priority notifications](https://github.com/uPortal-Project/uportal-app-framework/pull/496)
++ [Fix dismiss/restore message state not persisting](https://github.com/uPortal-Project/uportal-app-framework/pull/497)
++ [upping the expiration on the mock session to be 8 hours](https://github.com/uPortal-Project/uportal-app-framework/pull/501)
 
 #### Dependency Management
 
-* [Remove less-1.6.2.js from source](https://github.com/uPortal-Project/uportal-app-framework/pull/439)
-* [Update dependencies to enable Greenkeeper](https://github.com/uPortal-Project/uportal-app-framework/pull/474)
-* [fix: Use only 4.1.x version of superstatic not 4.x](https://github.com/uPortal-Project/uportal-app-framework/pull/493)
-* [Update superstatic to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/498)
-* [Update remark-validate-links to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/500)
++ [Remove less-1.6.2.js from source](https://github.com/uPortal-Project/uportal-app-framework/pull/439)
++ [Update dependencies to enable Greenkeeper](https://github.com/uPortal-Project/uportal-app-framework/pull/474)
++ [fix: Use only 4.1.x version of superstatic not 4.x](https://github.com/uPortal-Project/uportal-app-framework/pull/493)
++ [Update superstatic to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/498)
++ [Update remark-validate-links to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/500)
 
 #### Continuous Integration
 
-* [Fixing trivial ESLint checks](https://github.com/uPortal-Project/uportal-app-framework/pull/429)
-* [ESLint Refactor Integration](https://github.com/uPortal-Project/uportal-app-framework/pull/430)
-* [Eslint promise rule fixes](https://github.com/uPortal-Project/uportal-app-framework/pull/432)
-* [fixing eslint angular/typecheck rules](https://github.com/uPortal-Project/uportal-app-framework/pull/434)
-* [ESLint fix angular/no-private-call](https://github.com/uPortal-Project/uportal-app-framework/pull/435)
-* [ESLint angular/module rules](https://github.com/uPortal-Project/uportal-app-framework/pull/436)
-* [fixing eslint max-len](https://github.com/uPortal-Project/uportal-app-framework/pull/440)
-* [Test on headless Chrome](https://github.com/uPortal-Project/uportal-app-framework/pull/462)
-* [Add macOS environment to Travis CI](https://github.com/uPortal-Project/uportal-app-framework/pull/463)
-* [fix(ci): Update Travis CI script so greenkeeper works with the lockfile](https://github.com/uPortal-Project/uportal-app-framework/pull/480)
-* [style(less): Add Stylelint](https://github.com/uPortal-Project/uportal-app-framework/pull/485)
-* [style(md): Add Remarklint](https://github.com/uPortal-Project/uportal-app-framework/pull/486)
++ [Fixing trivial ESLint checks](https://github.com/uPortal-Project/uportal-app-framework/pull/429)
++ [ESLint Refactor Integration](https://github.com/uPortal-Project/uportal-app-framework/pull/430)
++ [Eslint promise rule fixes](https://github.com/uPortal-Project/uportal-app-framework/pull/432)
++ [fixing eslint angular/typecheck rules](https://github.com/uPortal-Project/uportal-app-framework/pull/434)
++ [ESLint fix angular/no-private-call](https://github.com/uPortal-Project/uportal-app-framework/pull/435)
++ [ESLint angular/module rules](https://github.com/uPortal-Project/uportal-app-framework/pull/436)
++ [fixing eslint max-len](https://github.com/uPortal-Project/uportal-app-framework/pull/440)
++ [Test on headless Chrome](https://github.com/uPortal-Project/uportal-app-framework/pull/462)
++ [Add macOS environment to Travis CI](https://github.com/uPortal-Project/uportal-app-framework/pull/463)
++ [fix(ci): Update Travis CI script so greenkeeper works with the lockfile](https://github.com/uPortal-Project/uportal-app-framework/pull/480)
++ [style(less): Add Stylelint](https://github.com/uPortal-Project/uportal-app-framework/pull/485)
++ [style(md): Add Remarklint](https://github.com/uPortal-Project/uportal-app-framework/pull/486)
 
 ## [4.1.0][] - 2017-05-04
 
@@ -795,10 +795,10 @@ notifications, progresses [Apereo](https://www.apereo.org/)
 
 ### How to Upgrade from version 3.X
 
-* Change dependency to version 4.0.0
-* For upgrading application consuming notifications programmatically: the
++ Change dependency to version 4.0.0
++ For upgrading application consuming notifications programmatically: the
   [notification service api changed from `getNotificationsByGroups` to `getFilteredNotifications`](https://github.com/uPortal-Project/uportal-app-framework/pull/386/files#diff-9a244329b1c0f99008f0fb506d3b9c64L159). This will not be a concern for most (if not all) applications.
-* If the app had previously named services and directives with the word "widget"
++ If the app had previously named services and directives with the word "widget"
   in the name, naming conflicts may arise due to the new Widget directives and
   services being added. [See the code for more details](https://github.com/uPortal-Project/uportal-app-framework/pull/385/files).
   This will not be a concern for most applications.
@@ -854,28 +854,28 @@ Adjusts link colors for themes #377
 Patch release. Simply bump the app's dependency declaration from `uw-frame`
 `3.0.2` to `3.0.3` to adopt this release.
 
-* Fixes Google Analytics usage ( #353 )
-* Documents source code whitespace conventions ( #356 )
-* Improves [documentation about releasing `uw-frame` itself](http://uportal-project.github.io/uportal-app-framework/v3.0.3/#/md/releasing)
++ Fixes Google Analytics usage ( #353 )
++ Documents source code whitespace conventions ( #356 )
++ Improves [documentation about releasing `uw-frame` itself](http://uportal-project.github.io/uportal-app-framework/v3.0.3/#/md/releasing)
   ( #355 )
 
 See also
 
-* [the 3.0.3 milestone](https://github.com/uPortal-Project/uportal-app-framework/milestone/9?closed=1).
-* [release announcement](https://groups.google.com/forum/#!topic/myuw-developers/evV8Ie3AhfQ).
++ [the 3.0.3 milestone](https://github.com/uPortal-Project/uportal-app-framework/milestone/9?closed=1).
++ [release announcement](https://groups.google.com/forum/#!topic/myuw-developers/evV8Ie3AhfQ).
 
 ## [3.0.2][] - 2016-12-14
 
 Patch release. Trivial upgrade from `v3.0.1` (or even `v3.0.0`).
 
-* Username menu items are no longer redundantly duplicatively labeled ( #351 )
-* Circle buttons now maintain their circular shape even when their label text
++ Username menu items are no longer redundantly duplicatively labeled ( #351 )
++ Circle buttons now maintain their circular shape even when their label text
   wraps ( #352 )
 
 Supporting links:
 
-* [Documentation for this version specifically](http://uportal-project.github.io/uportal-app-framework/v3.0.2/).
-* [Release announcement on myuw-developers group](https://groups.google.com/d/topic/myuw-developers/tKOWjo8r96c/discussion)
++ [Documentation for this version specifically](http://uportal-project.github.io/uportal-app-framework/v3.0.2/).
++ [Release announcement on myuw-developers group](https://groups.google.com/d/topic/myuw-developers/tKOWjo8r96c/discussion)
 
 ## 3.0.1 - 2016-11-28 \[YANKED]
 
@@ -885,7 +885,7 @@ Unreleased due to issues pushing to Maven Central.
 
 ### Major Version Upgrade
 
-* Upgrade angular-ui-bootstrap and angular libraries (#350) from 0.13.4 to 2.2.0
++ Upgrade angular-ui-bootstrap and angular libraries (#350) from 0.13.4 to 2.2.0
 
 The `angular-ui-bootstrap` upgrade moves up 2 major versions and does
 break compatibility with some older components. If the app used any
@@ -894,20 +894,20 @@ break compatibility with some older components. If the app used any
 
 ### Build changes
 
-* Add postcss/autoprefixer to uw-frame build (#345)
-* Remove dependency on Grunt (#335)
-* Break docs submodule dependency (#337)
-* Tweaked build.js (#348)
++ Add postcss/autoprefixer to uw-frame build (#345)
++ Remove dependency on Grunt (#335)
++ Break docs submodule dependency (#337)
++ Tweaked build.js (#348)
 
 ### Material
 
-* Upgrade uw-frame to Angular Material 1.1 (#339)
++ Upgrade uw-frame to Angular Material 1.1 (#339)
 
 ### Miscellaneous fixes
 
-* Fix for Safari private browsing bug (#347)
-* Added ability to have a name for the default theme (#336)
-* Fixed format for announcement end date (#332)
++ Fix for Safari private browsing bug (#347)
++ Added ability to have a name for the default theme (#336)
++ Fixed format for announcement end date (#332)
 
 [unreleased]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.3.0...HEAD
 [10.3.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.2.0...v10.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 + Added session inactivity checker, and updated logout dialog (#830)
-+ CSS variables for each theme to enable `myuw-app-bar` cooperation with angular material theming (#836)
++ CSS variables for each theme to enable `myuw-app-bar` cooperation with angular
+  material theming (#836)
 + Added patched Web Components polyfill for AngularJS compatibility (#847)
 
 ### Changed
 
-+ Replaced Angular Material toolbar directive with `myuw-app-bar` v1.5.3 from myuw-web-components library (#836)
-  + CSS hierarchy has changed a bit to reflect the absence of the Angular Material toolbar. Custom CSS that targets elements within `md-toolbar` may be affected
++ Replaced Angular Material toolbar directive with `myuw-app-bar` v1.5.3 from
+  myuw-web-components library (#836)
+  + CSS hierarchy has changed a bit to reflect the absence of the Angular
+  Material toolbar. Custom CSS that targets elements within `md-toolbar` may be
+  affected
 + Regular side navigation now looks the same on mobile and desktop (#836)
 
 
@@ -32,7 +36,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   expired. (#846)
 + Use sentence-case rather within `time-sensitive-content` widget type (#832)
 + Improved spacing/appearance of push-content side navigation for desktop (#836)
-+ Mobile search "Close" button now uses arrow icon, so not to be confused with "clear" functionality (#836)
++ Mobile search "Close" button now uses arrow icon, so not to be confused with
+  "clear" functionality (#836)
 + `action-items` widgets now handle more kinds of errors more fluently (#839)
 
 ### Removed
@@ -82,7 +87,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-+ Default to handling unrecognized widget types as if they were `basic` widgets (#823)
++ Default to handling unrecognized widget types as if they were `basic` widgets
+  (#823)
 + Leverage `npm ci` to speed continuous integration builds (#812)
 
 ### Fixed
@@ -102,13 +108,16 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-+ Update modules included in `package.json` and update `package-lock.json` to match (#804)
-+ Error states for action items widget link to launch button for better UX (#807)
++ Update modules included in `package.json` and update `package-lock.json` to
+  match (#804)
++ Error states for action items widget link to launch button for better UX
+  (#807)
 
 ### Fixed
 
 + Fixed compact mode widget removal (#805)
-+ Action items widget type now fails gracefully when service returns non-number data (#807)
++ Action items widget type now fails gracefully when service returns non-number
+  data (#807)
 
 
 ## [10.1.0][] - 2018-07-26
@@ -124,13 +133,16 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 + Widget actions are always visible, no longer only on hover (#794)
-+ Increased padding on sides of expanded widget titles to accommodate menu button (#794)
++ Increased padding on sides of expanded widget titles to accommodate menu
+  button (#794)
 
 ### Fixed
 
-+ Fixed display bug in compact widgets. Compact widgets now correctly use the per-widget contextual menu. (#794)
++ Fixed display bug in compact widgets. Compact widgets now correctly use the
+  per-widget contextual menu. (#794)
 + Make widget removal button focusable by keyboard when present (#797)
-+ Enable keyboard activation of widget removal button, when present (#800) & (#805)
++ Enable keyboard activation of widget removal button, when present (#800) &
+  (#805)
 
 
 ## [10.0.0][] - 2018-07-13
@@ -781,7 +793,9 @@ This release has some code cleanup and some bug fixes. Upgrade from [v4.0.0](htt
 
 ## [4.0.0][] - 2017-04-05
 
-This release adds a widget directive to the app-framework, adds personalized notifications, progresses [Apereo](https://www.apereo.org/) [Incubation](https://www.apereo.org/incubation), and fixes a help url bug.
+This release adds a widget directive to the app-framework, adds personalized
+notifications, progresses [Apereo](https://www.apereo.org/)
+[Incubation](https://www.apereo.org/incubation), and fixes a help url bug.
 
 [Guides Contributors to Apereo CLA compliance](https://github.com/uPortal-Project/uportal-app-framework/pull/381)
 [Changes help url for uw-system schools](https://github.com/uPortal-Project/uportal-app-framework/pull/382)
@@ -793,7 +807,8 @@ This release adds a widget directive to the app-framework, adds personalized not
 ### How to Upgrade from version 3.X
 
 * Change dependency to version 4.0.0
-* For upgrading application consuming notifications programmatically: the [notification service api changed from `getNotificationsByGroups` to `getFilteredNotifications`](https://github.com/uPortal-Project/uportal-app-framework/pull/386/files#diff-9a244329b1c0f99008f0fb506d3b9c64L159). This will not be a concern for most (if not all) applications.
+* For upgrading application consuming notifications programmatically: the
+  [notification service api changed from `getNotificationsByGroups` to `getFilteredNotifications`](https://github.com/uPortal-Project/uportal-app-framework/pull/386/files#diff-9a244329b1c0f99008f0fb506d3b9c64L159). This will not be a concern for most (if not all) applications.
 * If the app had previously named services and directives with the word "widget"
   in the name, naming conflicts may arise due to the new Widget directives and
   services being added. [See the code for more details](https://github.com/uPortal-Project/uportal-app-framework/pull/385/files).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ and this project adheres to
 ### Added
 
 + CSS variables for each theme to enable `myuw-app-bar` cooperation with angular
-  material theming (#836)
+  material theming (#838)
 + Added patched Web Components polyfill for AngularJS compatibility (#847)
 
 ### Changed
 
 + Replaced Angular Material toolbar directive with `myuw-app-bar` v1.5.3 from
-  myuw-web-components library (#836)
+  myuw-web-components library (#838)
   + CSS hierarchy has changed a bit to reflect the absence of the Angular
   Material toolbar. Custom CSS that targets elements within `md-toolbar` may be
   affected
-+ Regular side navigation now looks the same on mobile and desktop (#836)
++ Regular side navigation now looks the same on mobile and desktop (#838)
 
 ### Fixed
 
@@ -33,9 +33,9 @@ and this project adheres to
   live. Omitting `expireDate` means there is no date after which the message is
   expired. (#846)
 + Use sentence-case within `time-sensitive-content` widget type (#832)
-+ Improved spacing/appearance of push-content side navigation for desktop (#836)
++ Improved spacing/appearance of push-content side navigation for desktop (#838)
 + Mobile search "Close" button now uses arrow icon, so not to be confused with
-  "clear" functionality (#836)
+  "clear" functionality (#838)
 + `action-items` widgets now handle more kinds of errors more fluently (#839)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to
   Omitting `goLiveDate` means there is no date before which the message is not
   live. Omitting `expireDate` means there is no date after which the message is
   expired. (#846)
-+ Use sentence-case within `time-sensitive-content` widget type (#832)
 + Improved spacing/appearance of push-content side navigation for desktop (#838)
 + Mobile search "Close" button now uses arrow icon, so not to be confused with
   "clear" functionality (#838)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic
-Versioning](http://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,7 @@ would need to be upgraded to this version or later to avoid showing messages to
 audiences for whom they may not have been intended.
 
 ### Added in 9.0.1
+
 + Adds resetters to user-settings page (#724)
 + `circle-button` now offers tooltip with full title when title is truncated
   (#727)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,6 @@ and this project adheres to
 
 + Removes unused photo opt-out on settings page (#811)
 
-
 ## [10.1.1][] - 2018-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to
 
 ### Added
 
-+ Added session inactivity checker, and updated logout dialog (#830)
 + CSS variables for each theme to enable `myuw-app-bar` cooperation with angular
   material theming (#836)
 + Added patched Web Components polyfill for AngularJS compatibility (#847)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to
   affected
 + Regular side navigation now looks the same on mobile and desktop (#836)
 
-
 ### Fixed
 
 + `audienceFilter.groups` is now optional in messages. Omitting it is the same
@@ -42,15 +41,9 @@ and this project adheres to
 
 ### Removed
 
-
-
 ### Deprecated
 
-
-
 ### Documentation
-
-
 
 ## [10.3.0][] - 2018-09-19
 
@@ -119,9 +112,7 @@ and this project adheres to
 + Action items widget type now fails gracefully when service returns non-number
   data (#807)
 
-
 ## [10.1.0][] - 2018-07-26
-
 
 ### Added
 
@@ -143,7 +134,6 @@ and this project adheres to
 + Make widget removal button focusable by keyboard when present (#797)
 + Enable keyboard activation of widget removal button, when present (#800) &
   (#805)
-
 
 ## [10.0.0][] - 2018-07-13
 
@@ -220,7 +210,6 @@ and this project adheres to
 * No longer used LoginOnLoad option removed (#753)
 
 ## [9.1.0][] - 2018-04-17
-
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,13 +138,16 @@ and this project adheres to
 ## [10.0.0][] - 2018-07-13
 
 ### Removed
+
 + Removes `$rootScope.GuestMode` (#777)
 
 ### Added
+
 + new filter `canAdd`, useful for filtering portlets on whether user can or
   cannot add them to layout (#791)
 
 ### Changed
+
 + Changes list of links limit to 6 items. (#773)
 + Fixed list of links widget buttons clipping on some screen sizes (#781)
 + Moved widget info (description) and remove button into contextual menu to
@@ -152,16 +155,19 @@ and this project adheres to
 + Upgrades Angular to version 1.7.2 (#788)
 
 ### Fixed
+
 + Dates and titles in RSS widget no longer overlap each other (#780)
 + Removes unused `id` on the widget-removal div, thereby removing a source of
   HTML element `id` uniqueness constraint violations in the markup. (#787)
 
 ### Documentation
+
 + Note in changelog message handling changes needing upgrade coordination (#733)
 
 ## [9.2.1][] - 2018-06-08
 
 ### Changed
+
 + Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app
   name (i.e. "STAR"), the two names now appear inline (#766)
 + Removed link to Features page ("What's New") from default app configuration
@@ -169,6 +175,7 @@ and this project adheres to
 
 
 ### Fixed
+
 + Fixed potential upgrade path difficulty by making changes to "/about" and
   "/session-info" routes backward compatible (#765)
 + Increased z-index of all dialogs to highest value (101) to ensure they appear
@@ -188,6 +195,7 @@ and this project adheres to
 + Made Google's Roboto web font available (#761)
 
 ### Changed
+
 + "About" page now sources meaningful content from `aboutPageURL` (#755)
 + Use Roboto font family (#761)
 + z-index values adjusted from highest (101) to lowest (51) stated values to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,24 +47,24 @@ and this project adheres to
 
 ## [10.3.0][] - 2018-09-19
 
-### Added
+### Added in 10.3.0
 
 + Added session inactivity checker, and updated logout dialog (#830, #837)
 
-### Fixed
+### Fixed in 10.3.0
 
 + `action-items` widget now detects and handles as an error when a quantity
   callback returns an empty String. (#836)
 + Use sentence-case rather within `time-sensitive-content` widget type (#832)
 
-### Documentation
+### Documentation in 10.3.0
 
 + Added localhost examples of `action-items` widget type (#835)
 + Added localhost examples of `time-sensitive-content` widget type (#831)
 
 ## [10.2.0][] - 2018-09-12
 
-### Added
+### Added in 10.2.0
 
 + New `switch` widget type ( `<switch-widget>` directive), for composing
   composite widgets by dynamically switching over other types and configurations
@@ -78,13 +78,13 @@ and this project adheres to
   before, its implementation now delegates to `<basic-widget>` in the basic
   widget case. (#820)
 
-### Changed
+### Changed in 10.2.0
 
 + Default to handling unrecognized widget types as if they were `basic` widgets
   (#823)
 + Leverage `npm ci` to speed continuous integration builds (#812)
 
-### Fixed
+### Fixed in 10.2.0
 
 + Added `aria-label` describing mascot image (#808)
 + More reliably collapses trivial `list-of-links` widgets to `basic` widgets
@@ -92,20 +92,20 @@ and this project adheres to
 + Restored support for deprecated `generic` as alias for `custom` widget type.
   (#828)
 
-### Removed
+### Removed in 10.2.0
 
 + Removes unused photo opt-out on settings page (#811)
 
 ## [10.1.1][] - 2018-08-01
 
-### Changed
+### Changed in 10.1.1
 
 + Update modules included in `package.json` and update `package-lock.json` to
   match (#804)
 + Error states for action items widget link to launch button for better UX
   (#807)
 
-### Fixed
+### Fixed in 10.1.1
 
 + Fixed compact mode widget removal (#805)
 + Action items widget type now fails gracefully when service returns non-number
@@ -113,20 +113,20 @@ and this project adheres to
 
 ## [10.1.0][] - 2018-07-26
 
-### Added
+### Added in 10.1.0
 
 + Out of the box example page now includes compact mode widget examples, rather
   than just expanded mode widget examples. (#791)
 + New `widgetConfig.maintenanceMessage` for customizing the message a widget
   shows when in `MAINTENANCE` lifecycle state (#798)
 
-### Changed
+### Changed in 10.1.0
 
 + Widget actions are always visible, no longer only on hover (#794)
 + Increased padding on sides of expanded widget titles to accommodate menu
   button (#794)
 
-### Fixed
+### Fixed in 10.1.0
 
 + Fixed display bug in compact widgets. Compact widgets now correctly use the
   per-widget contextual menu. (#794)
@@ -136,16 +136,16 @@ and this project adheres to
 
 ## [10.0.0][] - 2018-07-13
 
-### Removed
+### Removed in 10.0.0
 
 + Removes `$rootScope.GuestMode` (#777)
 
-### Added
+### Added in 10.0.0
 
 + new filter `canAdd`, useful for filtering portlets on whether user can or
   cannot add them to layout (#791)
 
-### Changed
+### Changed in 10.0.0
 
 + Changes list of links limit to 6 items. (#773)
 + Fixed list of links widget buttons clipping on some screen sizes (#781)
@@ -153,19 +153,19 @@ and this project adheres to
   reduce burden on keyboard users (#786)
 + Upgrades Angular to version 1.7.2 (#788)
 
-### Fixed
+### Fixed in 10.0.0
 
 + Dates and titles in RSS widget no longer overlap each other (#780)
 + Removes unused `id` on the widget-removal div, thereby removing a source of
   HTML element `id` uniqueness constraint violations in the markup. (#787)
 
-### Documentation
+### Documentation in 10.0.0
 
 + Note in changelog message handling changes needing upgrade coordination (#733)
 
 ## [9.2.1][] - 2018-06-08
 
-### Changed
+### Changed in 9.2.1
 
 + Per UX guidance: When an app provides a theme name (i.e. "MyUW") and an app
   name (i.e. "STAR"), the two names now appear inline (#766)
@@ -173,7 +173,7 @@ and this project adheres to
   (#770)
 
 
-### Fixed
+### Fixed in 9.2.1
 
 + Fixed potential upgrade path difficulty by making changes to "/about" and
   "/session-info" routes backward compatible (#765)
@@ -185,7 +185,7 @@ and this project adheres to
 
 ## [9.2.0][] - 2018-05-22
 
-### Added
+### Added in 9.2.0
 
 + New "session info" page containing the former content of the "About" page
   (uportal-app-framework version info, app info JSON) (#755)
@@ -193,7 +193,7 @@ and this project adheres to
 + App config option `aboutPageURL` to get text and links for "About" page (#755)
 + Made Google's Roboto web font available (#761)
 
-### Changed
+### Changed in 9.2.0
 
 + "About" page now sources meaningful content from `aboutPageURL` (#755)
 + Use Roboto font family (#761)
@@ -204,7 +204,7 @@ and this project adheres to
   the same JSON file as the app's About page information) (#763)
 + SVG widget icons use the md-icon directive to scale properly (#764)
 
-### Fixed
+### Fixed in 9.2.0
 
 + When priority notification title is truncated, provide full title as tooltip
   (#754)
@@ -212,18 +212,18 @@ and this project adheres to
 + Widgets with overlays can be removed (#760)
 + Notifications' action buttons now open in new tab (#762)
 
-### Removed
+### Removed in 9.2.0
 
 + No longer used LoginOnLoad option removed (#753)
 
 ## [9.1.0][] - 2018-04-17
 
-### Added
+### Added in 9.1.0
 
 + `showAllMessages` beta setting. When true disables all client-side message
   filtering. Useful for demos and testing. (#742)
 
-### Changed
+### Changed in 9.1.0
 
 + `list-of-links` now offers tooltip with full title when it truncates any link
   title, not just those presented via `circle-button`s (#736)
@@ -231,14 +231,14 @@ and this project adheres to
   (#737)
 + Data urls only called when necessary (#747)
 
-### Fixed
+### Fixed in 9.1.0
 
 + `list-of-links` widgets are now `basic` widgets in the zero links edge case
   (#735)
 + `list-of-links` now `aria-label`s links, ensuring a non-truncated version of
   the link label is available to browsers (#736)
 
-### Removed
+### Removed in 9.1.0
 
 + Support for `APP_OPTIONS.optionsTemplateURL` configuration is removed in this
   release. It had previously been documented as "deprecated" but the
@@ -246,7 +246,7 @@ and this project adheres to
   for this feature was already removed as a breaking change for the `9.x`
   version series. (#745)
 
-### Deprecated
+### Deprecated in 9.1.0
 
 The `disableGroupFilteringForMessages` beta setting is deprecated. While it
 still works in this release, the new `showAllMessages` beta setting is intended
@@ -258,7 +258,7 @@ future release. (#742)
 This release is to mop up some weirdness which happened with 9.0.1 and get a
 clean artifact.
 
-### Changed
+### Changed in 9.0.2
 
 + Minor CHANGELOG change
   (#731)
@@ -275,17 +275,17 @@ multiple uPortal App Framework applications, all participating applications
 would need to be upgraded to this version or later to avoid showing messages to
 audiences for whom they may not have been intended.
 
-### Added
+### Added in 9.0.1
 + Adds resetters to user-settings page (#724)
 + `circle-button` now offers tooltip with full title when title is truncated
   (#727)
 
-### Changed
+### Changed in 9.0.1
 
 + Out of the box example `list-of-links` widget now more self-documenting
   (#727, #729)
 
-### Fixed
+### Fixed in 9.0.1
 
 + `circle-button` no longer truncates `aria-label` representation of title
   (#727)
@@ -294,7 +294,7 @@ audiences for whom they may not have been intended.
 ### Build engineering
 
 
-### Documentation
+### Documentation in 9.0.1
 
 + DEPRECATED: Font Awesome icons for `list-of-links` links. Use Material Icons
   instead. (#727)
@@ -332,7 +332,7 @@ Before relying upon a shared `messages.json` using the fixed mascot announcement
 feature, all apps sourcing those messages will need to be upgraded to this
 version or later to avoid showing users a broken mascot announcement experience.
 
-### Added
+### Added in 9.0.0
 
 + `mainService` now offers `computeWindowTitle(...)` (#679)
 + `<frame-page>` directive now offers `page-title` attribute to add a `<h1>`
@@ -343,7 +343,7 @@ version or later to avoid showing users a broken mascot announcement experience.
   cases (#715)
 + Core Infrastructure Initiative badge (#711)
 
-### Changed
+### Changed in 9.0.0
 
 + `<frame-page>` sets document title per existing `app-title` attribute (#682)
 + The `show-add-to-home` attribute on the `<frame-page>` directive now displays
@@ -353,7 +353,7 @@ version or later to avoid showing users a broken mascot announcement experience.
   logically appropriate spot (#694)
 + Improved appearance of add-to-home toast message (#706)
 
-### Fixed
+### Fixed in 9.0.0
 
 + External links in mascot announcements now work again. (#697)
 + "Skip to main content" link now skips more repeated navigation to reach
@@ -361,12 +361,12 @@ version or later to avoid showing users a broken mascot announcement experience.
 + Label widget cover dismiss button as "OK" rather than "Continue" (#675)
 + Fixed widget in-app message example (#714)
 
-### Build engineering
+### Build engineering in 9.0.0
 
 + Update package lockfile with updated dependencies (#704)
 + Update stylelint to version 9.1.3 (#718)
 
-### Documentation
+### Documentation in 9.0.0
 
 + About dynamically sourcing `list-of-links` widget content (#717)
 
@@ -397,7 +397,7 @@ feature all apps participating in a shared `messages.json` will need upgraded
 to this release or later to avoid the not-yet-upgraded apps displaying premature
 or expired messages.
 
-### Added
+### Added in 8.0.0
 
 + track clicks on sidenav footer links (#642)
 + add documentation clarifying major upgrades (#647)
@@ -405,12 +405,12 @@ or expired messages.
 + add the ability to set a message more info button url via an external data
   source (#649)
 
-### Changed
+### Changed in 8.0.0
 
 + update documentation to read more and state intent more clearly (#632)
 + update to latest version (2.0) of karma (#652)
 
-### Fixed
+### Fixed in 8.0.0
 
 + synch priority header with bell (#638)
 + filter messages where today is outside of start and end dates (#639)
@@ -418,7 +418,7 @@ or expired messages.
 + catch localStorage error with IE (#643)
 + implemented filter messages by date (#650)
 
-### Build engineering
+### Build engineering in 8.0.0
 
 + add documentation stating intent to use Conventional commits and tips on how
   to comply (#634)
@@ -470,7 +470,7 @@ JSON web service (#601). Before relying upon this feature in a shared
 framework version or later, otherwise they will not reflect the new dynamic
 notification content.
 
-### Features
+### Features in 7.0.0
 
 + Add on-page side navigation feature (#588) + To use: Set
   `APP_OPTIONS.enablePushContentMenu` to true in your override.js file
@@ -482,7 +482,7 @@ notification content.
   restoring notification from notifications page
 + Support dynamic notification text sourced from JSON web service (#601)
 
-### Fixed
+### Fixed in 7.0.0
 
 + Improves top bar accessibility (#594)
 + Fix the `search-with-links` widget type (#585)
@@ -491,11 +491,11 @@ notification content.
 + Clarify safety of `/settings` tooling to reset in-browser state. (#600)
 + Fix notification rendering robustness against duplicate ids (#602, #603)
 
-### Refactor
+### Refactor in 7.0.0
 
 + Use `moment.js` in `time-sensitive-content` widget type (#593)
 
-### Build engineering
+### Build engineering in 7.0.0
 
 + Now runs `commitlint` on `travis-ci`, removing `precommit` hook that
   previously verified commit messages locally. (#581)
@@ -505,26 +505,26 @@ Note that this project only incidentally uses Java and Maven. In the future
 this front-end product may not use Java at all. (Server-side services uPortal
 app framework relies upon might still use Java, of course.)
 
-### Code style
+### Code style in 7.0.0
 
 + Fix a bunch of JSDoc warnings (#598)
 
 ## [6.1.0][] - 2017-10-18
 
-### Added
+### Added in 6.1.0
 
 + Add filter to determine rel attribute on anchors (#569)
 + Add configurable side navigation (#561) - See
   [uportal-app-framework documentation][sidenav-documentation] of this new
   feature
 
-### Changed
+### Changed in 6.1.0
 
 + Refactor theme names (#568)
 + Update to version 4.2.0 of config-angular (#578)
 + Pull UI Sortable from CDN (#579)
 
-### Fixed
+### Fixed in 6.1.0
 
 + Fix mismatch in portal theme key (#570)
 + Hides notification bell when on notification page (#572)
@@ -570,20 +570,20 @@ URLs in priority notifications as presented in not-yet-upgraded apps.
 
 ## [5.2.0][] - 2017-09-20
 
-### Messages Enhancements
+### Messages Enhancements in 5.2.0
 
 + Notifications may be non-dismissible (#521)
 + Add widget from mascot announcement (#526)
 
-### Widget Enhancements
+### Widget Enhancements in 5.2.0
 
 + Option-link widget evaluates target (#519)
 
-### Configuration Change
+### Configuration Change in 5.2.0
 
 + Default menu options to be null (#514)
 
-### Maintenance
+### Maintenance in 5.2.0
 
 + Shore up licencing (#515) (#523) (#527)
 + Add a changelog (#513)
@@ -597,7 +597,7 @@ feature in a shared messages source, all participating applications must first
 be upgraded to this framework version or later to avoid displaying broken
 announcements in not-yet-upgraded applications.
 
-### Messages Enhancements
+### Messages Enhancements in 5.1.0
 
 + Adds actionbutton and more info button to features page and priority
   notifications (#504)
@@ -605,7 +605,7 @@ announcements in not-yet-upgraded applications.
   (#512)
 + Fixes bug with notification urls not being resolved correctly (#507)
 
-### Code Maintenance and Enhancements
+### Code Maintenance and Enhancements in 5.1.0
 
 + Updates karma to latest version (#511)
 + Adopts Conventional Commits (#487)
@@ -633,13 +633,13 @@ Management service to our repository.
 While we're proud of what we've accomplished in this major release, we hope to
 return to a faster paced release cycle in the future.
 
-### Major Enhancements
+### Major Enhancements in 5.0.0
 
 #### Messages!
 
 + [Simplify disparate forms of in-app messaging](https://github.com/uPortal-Project/uportal-app-framework/pull/484)
 
-### Minor Enhancements
+### Minor Enhancements in 5.0.0
 
 #### Widget Types
 
@@ -669,7 +669,7 @@ return to a faster paced release cycle in the future.
 + [MUMUP-2699 Adds ability for portal skin switching](https://github.com/uPortal-Project/uportal-app-framework/pull/483)
 + [MUMUP-2990 Use portal session rather than Shibboleth](https://github.com/uPortal-Project/uportal-app-framework/pull/491)
 
-### Patch Enhancements
+### Patch Enhancements in 5.0.0
 
 #### Content Changes
 
@@ -677,7 +677,7 @@ return to a faster paced release cycle in the future.
 + [Use sentence case in tooltips.](https://github.com/uPortal-Project/uportal-app-framework/pull/446)
 + [Animate priority notifications [nice-to-have]](https://github.com/uPortal-Project/uportal-app-framework/pull/499)
 
-#### Documentation Improvements
+#### Documentation Improvements in 5.0.0
 
 + [Documentation Syntax Highlighting](https://github.com/uPortal-Project/uportal-app-framework/pull/431)
 + [Adds skinning exercise to docs folder](https://github.com/uPortal-Project/uportal-app-framework/pull/447)
@@ -694,7 +694,7 @@ return to a faster paced release cycle in the future.
 + [docs(github): Add SUPPORT.md to guide questions to the mailing list](https://github.com/uPortal-Project/uportal-app-framework/pull/479)
 + [Acknowledge bundled dependencies and add NOTICE file](https://github.com/uPortal-Project/uportal-app-framework/pull/489)
 
-#### Bug Fixes
+#### Bug Fixes in 5.0.0
 
 + [Fix md-menu forcing scroll when priority notifications visible](https://github.com/uPortal-Project/uportal-app-framework/pull/428)
 + [Portal feature service flatten nested promises](https://github.com/uPortal-Project/uportal-app-framework/pull/438)
@@ -708,7 +708,7 @@ return to a faster paced release cycle in the future.
 + [Fix dismiss/restore message state not persisting](https://github.com/uPortal-Project/uportal-app-framework/pull/497)
 + [upping the expiration on the mock session to be 8 hours](https://github.com/uPortal-Project/uportal-app-framework/pull/501)
 
-#### Dependency Management
+#### Dependency Management in 5.0.0
 
 + [Remove less-1.6.2.js from source](https://github.com/uPortal-Project/uportal-app-framework/pull/439)
 + [Update dependencies to enable Greenkeeper](https://github.com/uPortal-Project/uportal-app-framework/pull/474)
@@ -716,7 +716,7 @@ return to a faster paced release cycle in the future.
 + [Update superstatic to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/498)
 + [Update remark-validate-links to the latest version](https://github.com/uPortal-Project/uportal-app-framework/pull/500)
 
-#### Continuous Integration
+#### Continuous Integration in 5.0.0
 
 + [Fixing trivial ESLint checks](https://github.com/uPortal-Project/uportal-app-framework/pull/429)
 + [ESLint Refactor Integration](https://github.com/uPortal-Project/uportal-app-framework/pull/430)
@@ -733,19 +733,19 @@ return to a faster paced release cycle in the future.
 
 ## [4.1.0][] - 2017-05-04
 
-### Code Cleanup
+### Code Cleanup in 4.1.0
 
 [Removes unused sorting function](https://github.com/uPortal-Project/uportal-app-framework/pull/399)
 [Adds local Jekyll files to gitignore](https://github.com/uPortal-Project/uportal-app-framework/pull/405)
 [Replaces hard coded fa-icons with material icon equivalents](https://github.com/uPortal-Project/uportal-app-framework/pull/426)
 
-### CI Enhancements
+### CI Enhancements in 4.1.0
 
 [Tests against multiple jdks, improve build time](https://github.com/uPortal-Project/uportal-app-framework/pull/400)
 [Tests against Windows OS](https://github.com/uPortal-Project/uportal-app-framework/pull/408)
 [Fixes bug where local build wasn't working](https://github.com/uPortal-Project/uportal-app-framework/pull/421)
 
-### Widget Enhancements
+### Widget Enhancements in 4.1.0
 
 [Fixes RSS widget display bug](https://github.com/uPortal-Project/uportal-app-framework/pull/403)
 [Fixes RSS widget display bug](https://github.com/uPortal-Project/uportal-app-framework/pull/406)
@@ -755,13 +755,13 @@ return to a faster paced release cycle in the future.
 [Adds display error message when users try to render an unauthorized widget](https://github.com/uPortal-Project/uportal-app-framework/pull/419)
 [Fixes display bug with error message for unauthorized widget](https://github.com/uPortal-Project/uportal-app-framework/pull/420)
 
-### Apereo Incubation
+### Apereo Incubation in 4.1.0
 
 [Formally bootstraps initial committers](https://github.com/uPortal-Project/uportal-app-framework/pull/404)
 [Acknowledges contributors](https://github.com/uPortal-Project/uportal-app-framework/pull/412)
 [Formalizes release procedures](https://github.com/uPortal-Project/uportal-app-framework/pull/416)
 
-### Header Enhancements
+### Header Enhancements in 4.1.0
 
 [Replaces UW-Madison crest with higher resolution crest](https://github.com/uPortal-Project/uportal-app-framework/pull/413)
 [Replaces name with an avatar](https://github.com/uPortal-Project/uportal-app-framework/pull/414)
@@ -899,18 +899,18 @@ break compatibility with some older components. If the app used any
 `angular-ui-bootstrap` components, it will need to begin prefixing them with
 `uib-`. See `angular-ui-bootstrap` [Migration Guide for Prefixes](https://github.com/angular-ui/bootstrap/wiki/Migration-guide-for-prefixes).
 
-### Build changes
+### Build changes in 3.0.0
 
 + Add postcss/autoprefixer to uw-frame build (#345)
 + Remove dependency on Grunt (#335)
 + Break docs submodule dependency (#337)
 + Tweaked build.js (#348)
 
-### Material
+### Material in 3.0.0
 
 + Upgrade uw-frame to Angular Material 1.1 (#339)
 
-### Miscellaneous fixes
+### Miscellaneous fixes in 3.0.0
 
 + Fix for Safari private browsing bug (#347)
 + Added ability to have a name for the default theme (#336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to
   Omitting `goLiveDate` means there is no date before which the message is not
   live. Omitting `expireDate` means there is no date after which the message is
   expired. (#846)
-+ Use sentence-case rather within `time-sensitive-content` widget type (#832)
++ Use sentence-case within `time-sensitive-content` widget type (#832)
 + Improved spacing/appearance of push-content side navigation for desktop (#836)
 + Mobile search "Close" button now uses arrow icon, so not to be confused with
   "clear" functionality (#836)
@@ -55,7 +55,7 @@ and this project adheres to
 
 + `action-items` widget now detects and handles as an error when a quantity
   callback returns an empty String. (#836)
-+ Use sentence-case rather within `time-sensitive-content` widget type (#832)
++ Use sentence-case within `time-sensitive-content` widget type (#832)
 
 ### Documentation in 10.3.0
 


### PR DESCRIPTION
+ Fix incorrect references to #836 that were meant to be references to #838
+ Remove incorrect duplicate references to #830 and #832 that would describe these as new in the next release, whereas they were included in already-released 10.3.0.

In general, appease the Markdown linter. In specific,

+ Avoid duplicate heading labels, thereby avoiding ambiguous generated hyperlinks to headings.
+ Wrap at 80 characters.
+ Normalize blank lines.
+ Normalize bullets and bullet list indentation.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
