### PR TITLE
docs(deprecation): formally deprecate Weather widget type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ BREAKING CHANGES
   times out, the framework will attempt to re-bootstrap a session via portal
   login on next interaction.
 
+Deprecation:
+
++ The Weather widget type is deprecated.
+  It may be removed in a future major release.
+
 Other changes
 
 + In miscService.redirectUser, redirect through login when the status code

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -429,7 +429,7 @@
     }
   }
 
-  // WEATHER WIDGET
+  // WEATHER WIDGET - DEPRECATED
   weather-widget,
   weather {
     .forecast .day {

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -843,7 +843,7 @@ define(['angular', 'moment'], function(angular, moment) {
     initializeSwitchWidget();
   }])
 
-  // WEATHER widget type
+  // WEATHER widget type - DEPRECATED
   .controller('WeatherWidgetController', [
     '$scope', '$log', '$q', 'widgetService', 'keyValueService',
     function($scope, $log, $q, widgetService, keyValueService) {
@@ -1037,6 +1037,7 @@ define(['angular', 'moment'], function(angular, moment) {
     $scope.loading = false;
     if ($scope.widget.widgetURL) {
       $scope.loading = true;
+      $log.warn('Weather widget type is deprecated.');
       $scope.weatherData = [];
       $scope.currentUnits = 'F';
       $scope.nextUnits = 'C';

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -203,6 +203,9 @@ define(['angular', 'require'], function(angular, require) {
     };
   })
 
+  /**
+   * DEPRECATED
+   */
   .directive('weatherWidget', function() {
     return {
       restrict: 'E',

--- a/components/portal/widgets/partials/type__weather.html
+++ b/components/portal/widgets/partials/type__weather.html
@@ -18,6 +18,9 @@
     under the License.
 
 -->
+
+<!-- DEPRECATED -->
+
 <div class="weather-dropdown">
   <a class=" weather-not-clicked" href="" ng-click="cycleUnits()">Change units to &deg{{nextUnits}}</a>
 </div>


### PR DESCRIPTION
In some appropriate future release, I'd like `uportal-app-framework` to remove the Weather widget type. We're not using it in MyUW, so I'm not aware of any active adopter in a position to notice when this widget type breaks and maintain it going forward. It'll be cleaner to intentionally remove it than to neglect it.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
