### PR TITLE
feat(timesensitive): suppress feedback link during action period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   Material toolbar. Custom CSS that targets elements within `md-toolbar` may be
   affected
 + Regular side navigation now looks the same on mobile and desktop (#838)
++ `time-sensitive-content` widget type now only shows its feedback link after
+  the action period has expired. (#852)
 
 ### Fixed
 

--- a/components/portal/widgets/partials/type__time-sensitive.html
+++ b/components/portal/widgets/partials/type__time-sensitive.html
@@ -48,7 +48,9 @@
   <!-- Give feedback link -->
   <div class="tsc__extra-buttons" layout="row" layout-align="center center">
     <a ng-if="callToAction.learnMoreUrl" ng-href="{{ callToAction.learnMoreUrl }}" target="_blank" rel="noreferrer noopener">Learn more</a>
-    <a ng-if="templateStatus == 'ended' && callToAction.feedbackUrl" ng-href="{{ callToAction.feedbackUrl }}" target="_blank" rel="noreferrer noopener">Give feedback</a>
+    <a ng-if="templateStatus == 'ended' && callToAction.feedbackUrl"
+      ng-href="{{ callToAction.feedbackUrl }}"
+      target="_blank" rel="noreferrer noopener">Give feedback</a>
   </div>
 </div>
 

--- a/components/portal/widgets/partials/type__time-sensitive.html
+++ b/components/portal/widgets/partials/type__time-sensitive.html
@@ -48,7 +48,7 @@
   <!-- Give feedback link -->
   <div class="tsc__extra-buttons" layout="row" layout-align="center center">
     <a ng-if="callToAction.learnMoreUrl" ng-href="{{ callToAction.learnMoreUrl }}" target="_blank" rel="noreferrer noopener">Learn more</a>
-    <a ng-if="callToAction.feedbackUrl" ng-href="{{ callToAction.feedbackUrl }}" target="_blank" rel="noreferrer noopener">Give feedback</a>
+    <a ng-if="templateStatus == 'ended' && callToAction.feedbackUrl" ng-href="{{ callToAction.feedbackUrl }}" target="_blank" rel="noreferrer noopener">Give feedback</a>
   </div>
 </div>
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -490,7 +490,8 @@ with an integer for a value. For example:
   * **url**: The url where a user can take action
   * **label**: The text the button should display
 * **learnMoreUrl**: *(optional)* Provide a url if you want the widget to display a link for users to get more information.
-* **feedbackUrl**: *(optional)* If set, widget shows a "Give feedback" link after `takeActionEndDate` but before `templateRetireDate`.
+* **feedbackUrl**: *(optional)* If set, widget shows a "Give feedback" link
+  after `takeActionEndDate` but before `templateRetireDate`.
 
 #### Guidance about `time-sensitive-content`
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -490,7 +490,7 @@ with an integer for a value. For example:
   * **url**: The url where a user can take action
   * **label**: The text the button should display
 * **learnMoreUrl**: *(optional)* Provide a url if you want the widget to display a link for users to get more information.
-* **feedbackUrl**: *(optional)* Provide a url if you want the widget to display a link where users can give feedback about the taking action. Shows only after `takeActionEndDate`.
+* **feedbackUrl**: *(optional)* If set, widget shows a "Give feedback" link after `takeActionEndDate` but before `templateRetireDate`.
 
 #### Guidance about `time-sensitive-content`
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -490,7 +490,7 @@ with an integer for a value. For example:
   * **url**: The url where a user can take action
   * **label**: The text the button should display
 * **learnMoreUrl**: *(optional)* Provide a url if you want the widget to display a link for users to get more information.
-* **feedbackUrl**: *(optional)* Provide a url if you want the widget to display a link where users can give feedback about the taking action.
+* **feedbackUrl**: *(optional)* Provide a url if you want the widget to display a link where users can give feedback about the taking action. Shows only after `takeActionEndDate`.
 
 #### Guidance about `time-sensitive-content`
 


### PR DESCRIPTION
Show the feedback link in the `time-sensitive-content` widget only after the action period has expired.

The idea is that while the primary action is available, feedback is more distraction than it's worth. User can still more generally provide feedback through e.g. the footer feedback link. It's only after the action period is over that feedback is the primary action available to the user about the time sensitive activity that a `time-sensitive-content` widget is about.

Before:

<img width="1050" alt="time-sensitive-content-status-quo" src="https://user-images.githubusercontent.com/952283/46951423-8ce9ec80-d04d-11e8-87fb-85fc43078c21.png">

After:

<img width="1067" alt="time-sensitive-content-less-feedback" src="https://user-images.githubusercontent.com/952283/46951435-9410fa80-d04d-11e8-9510-864e369d2ad6.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

------

Tracked internally to MyUW as [MUMUP-3406](https://jira.doit.wisc.edu/jira/browse/MUMUP-3406).