### PR TITLE
fix(list-of-links): multiple links when first redundant with launch bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 ### Fixed
 
++ `list-of-links` no longer erroneously renders blank when it contains 2-4 links
+  the first of which redundant with its launch bar. (#855)
 + `audienceFilter.groups` is now optional in messages. Omitting it is the same
   as setting it to `null` or to an empty array `[]`, namely that no one should
   be denied the message based on group memberships. (#846)

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -72,6 +72,10 @@
         <div flex-xs="100" class="widget-container">
           <widget fname="sample-widget__list-of-one-redundant-link"></widget>
         </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__list-of-4-links-first-redundant">
+          </widget>
+        </div>
       </div>
 
     <h3 style="margin-left:26px">Example switch widgets in expanded mode</h3>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -34,8 +34,10 @@
     && (config.links.length != 1 || config.links[0].href != widget.url)">
 
   <!-- FOUR LINKS OR LESS -->
+  <!-- Use circle buttons iff 2, 3, 4 links or 1 link that did not collapse
+       to basic. -->
   <div ng-show="config.links.length > 0 && config.links.length <= 4
-    && config.links[0].href != widget.url"
+    && (config.links.length != 1 || config.links[0].href != widget.url)"
     class="list-of-links__{{config.links.length}}">
     <circle-button ng-if="item.icon.indexOf('fa-') > -1"
                    ng-repeat="item in config.links"

--- a/components/staticFeeds/list-of-four-links-first-redundant-via-url.json
+++ b/components/staticFeeds/list-of-four-links-first-redundant-via-url.json
@@ -1,0 +1,31 @@
+{
+  "result": "ok",
+  "content": {
+    "links": [
+      {
+        "icon": "fa-book",
+        "href": "http://www.exammple.edu/altMaxLink",
+        "title": "Same as launch bar",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "http://www.exammple.edu/novel-link-1",
+        "title": "Novel link",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "http://www.exammple.edu/novel-link-2",
+        "title": "Also novel",
+        "target": "_blank"
+      },
+      {
+        "icon": "fa-book",
+        "href": "http://www.exammple.edu/novel-link-3",
+        "title": "Different still",
+        "target": "_blank"
+      }
+    ]
+  }
+}

--- a/components/staticFeeds/sample-widget__list-of-4-links-first-redundant.json
+++ b/components/staticFeeds/sample-widget__list-of-4-links-first-redundant.json
@@ -1,0 +1,59 @@
+{
+  "entry": {
+    "canAdd": true,
+    "layoutObject": {
+      "nodeId": "-1",
+      "title": "only collapse when single link",
+      "description": "When list-of-links is configured with multiple links, it does not collapse to a basic widget even when the first link is redundant.",
+      "url": "http://www.exammple.edu/altMaxLink",
+      "iconUrl": null,
+      "faIcon": "fa-book",
+      "fname": "sample-widget__list-of-4-links-first-redundant",
+      "lifecycleState": "PUBLISHED",
+      "target": null,
+      "widgetURL": "/staticFeeds/list-of-four-links-first-redundant-via-url.json",
+      "widgetType": "list-of-links",
+      "widgetTemplate": null,
+      "widgetConfig": {
+        "getLinksURL": "true",
+        "launchText": "Matches first link"
+      },
+      "staticContent": "<div><p>Static content goes here.</p></div>",
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "categories": [
+      "Widget types",
+      "list-of-links"
+    ],
+    "portletName": "cms",
+    "title": "list-of-links collapses to basic",
+    "keywords": [
+      "list",
+      "links",
+      "ordered",
+      "icons",
+      "few"
+    ],
+    "fname": "sample-widget__list-of-4-links-first-redundant",
+    "rating": 0.0,
+    "lifecycleState": "PUBLISHED",
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "http://www.exammple.edu/altMaxLink",
+    "portletWebAppName": "/SimpleContentPortlet",
+    "maxUrl": "http://www.exammple.edu/altMaxLink",
+    "shortUrl": null,
+    "marketplaceScreenshots": [],
+    "userRated": 0,
+    "faIcon": "fa-briefcase",
+    "description": "When list-of-links is configured with multiple links, it does not collapse to a basic widget even when the first link is redundant.",
+    "name": "only collapse when single link",
+    "id": "88",
+    "type": "Portlet",
+    "target": null
+  }
+}


### PR DESCRIPTION
`list-of-links` has a feature where when it's configured with a single link redundant with the widget launch bar, it collapses to a basic widget as the  preferred way to present a single hyperlink. That feature was bugged (my bad) so that it would suppress 2-4 link list-of-links widgets when the first link matched the launch bar. This fixes the bug, adding to localhost content a demo of the fixed case.

Before:

<img width="1375" alt="list-of-links-blank" src="https://user-images.githubusercontent.com/952283/47153891-712d5300-d2a6-11e8-8d31-f8c0658fa28a.png">

After:

<img width="1244" alt="list-of-links-as-intended" src="https://user-images.githubusercontent.com/952283/47154262-7048f100-d2a7-11e8-85e8-95c70e12c34a.png">


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked within MyUW as [MUMUP-3411](https://jira.doit.wisc.edu/jira/browse/MUMUP-3411).
