### PR TITLE
docs(timesensitive): clarify takeActionEndDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to
 
 ### Documentation
 
++ Clarified `takeActionEndDate` in `time-sensitive-content` widget documentation
+  (#861)
+
 ## [10.3.0][] - 2018-09-19
 
 ### Added in 10.3.0

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -486,8 +486,8 @@ with an integer for a value. For example:
     and before `templateRetireDate`, the widget communicates when the action
     stopped being available (e.g "Ended September 20th, 2018"). See "Guidance"
     below for suggested formats and options. Works like SAML `NotOnOrAfter`. If
-    only a date (and not a time) are provided, interprets this as 12:00am, that
-    is as soon as that date starts. So if for example the last day to execute an
+    only a date (and not a time) are provided, interprets this as 00:00, i.e.
+    as soon as that date starts. So if for example the last day to execute an
     Annual Benefits Enrollment opportunity is October 26th, `takeActionEndDate`
     should be set to October 27th.
   * **templateRetireDate**: *(optional)* The date when the widget should switch back to displaying basic content. See "Guidance" heading below for suggested formats and options.
@@ -507,14 +507,14 @@ with an integer for a value. For example:
 
 Configured dates **MUST** match one of the following formats:
 
-+ `'YYYY-MM-DD'` (ex. '2017-09-18'): This format specifies 12:00am on a
++ `'YYYY-MM-DD'` (ex. '2017-09-18'): This format specifies 00:00 on a
   year-specific one-time-only date.
 + `'MM-DD'` (ex. '09-18'): This format specifies a recurring date every year,
-  again with 12:00am implied. Useful for creating recurring annual cycles in
+  again with 00:00 implied. Useful for creating recurring annual cycles in
   `time-sensitive-content` widgets.
 + `'...THH:MM'` (ex. 09-18T10:00): Append the time in hours and minutes to
   either the once-only or the recurring date format to specify a time other than
-  12:00am.
+  00:00
 
 ##### How to configure the active date range in `time-sensitive-content`
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -481,7 +481,15 @@ with an integer for a value. For example:
 * **activeDateRange**: An object used to determine when to switch to the time-sensitive content, with the following attributes:
   * **templateLiveDate**: The date when the widget should switch from basic content to time-sensitive content. See "Guidance" heading below for suggested formats and options.
   * **takeActionStartDate**: *(optional)* The date when action can be taken. Provide a value if you want the widget to communicate when taking action will be possible (e.g. "Begins September 11th, 2018"). See "Guidance" heading below for suggested formats and options.
-  * **takeActionEndDate**: *(optional)* The date when the action can no longer be taken. Required if `takeActionStartDate` is present. Provide a value if you want the widget to communicate when the action stopped being available (e.d "Ended September 20th, 2018"). See "Guidance" heading below for suggested formats and options.
+  * **takeActionEndDate**: *(optional)* The moment when the action can no longer
+    be taken. Required if `takeActionStartDate` is present. After this moment
+    and before `templateRetireDate`, the widget communicates when the action
+    stopped being available (e.g "Ended September 20th, 2018"). See "Guidance"
+    below for suggested formats and options. Works like SAML `NotOnOrAfter`. If
+    only a date (and not a time) are provided, interprets this as 12:00am, that
+    is as soon as that date starts. So if for example the last day to execute an
+    Annual Benefits Enrollment opportunity is October 26th, `takeActionEndDate`
+    should be set to October 27th.
   * **templateRetireDate**: *(optional)* The date when the widget should switch back to displaying basic content. See "Guidance" heading below for suggested formats and options.
 * **actionName**: The name of the action users can take (e.g. "Annual benefits enrollment").
 * **daysLeftMessage**: *(optional)* The language to display during the countdown of remaining days. The widget will always display "# days left". Provide a value if you want to add text after the default text (e.g. A `daysLeftMessage` with the value "to change benefits" would result in the message: "# days left to change benefits").
@@ -497,10 +505,16 @@ with an integer for a value. For example:
 
 ##### Date formatting  in `time-sensitive-content`
 
-Provided dates **MUST** match one of the following formats:
-+ `'YYYY-MM-DD'` (ex. '2017-09-18'): Use this format if the call to action doesn't happen on the same date every year and if the time of day is unknown or unimportant
-+ `'MM-DD'` (ex. '09-18'): Use this format if the date for this action is the same every year
-+ `'...THH:MM'` (ex. 09-18T10:00): Append the time in hours and minutes if you want to set a specific time of day
+Configured dates **MUST** match one of the following formats:
+
++ `'YYYY-MM-DD'` (ex. '2017-09-18'): This format specifies 12:00am on a
+  year-specific one-time-only date.
++ `'MM-DD'` (ex. '09-18'): This format specifies a recurring date every year,
+  again with 12:00am implied. Useful for creating recurring annual cycles in
+  `time-sensitive-content` widgets.
++ `'...THH:MM'` (ex. 09-18T10:00): Append the time in hours and minutes to
+  either the once-only or the recurring date format to specify a time other than
+  12:00am.
 
 ##### How to configure the active date range in `time-sensitive-content`
 


### PR DESCRIPTION
I got confused about how to configure `takeActionEndDate` such that [MyUW Benefit Information widget prematurely told employees today was last day to enroll](http://outages.wisconsin.edu/outage/9441e5d983aa1bd08e4d7447e7b974e89e6e151f98), whereas tomorrow is actual last day to enroll. Updating documentation with clarity that might have supported my correctly configuring the widget.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked as [MUMUP-3420](https://jira.doit.wisc.edu/jira/browse/MUMUP-3420) locally to MyUW.