### PR TITLE
fix: use less disruptive actions for inactivity timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 + Regular side navigation now looks the same on mobile and desktop (#838)
 + `time-sensitive-content` widget type now only shows its feedback link after
   the action period has expired. (#852)
++ Inactive timeout dialog now provides less disruptive actions on timeout (#864)
 
 ### Fixed
 

--- a/components/portal/timeout/controllers.js
+++ b/components/portal/timeout/controllers.js
@@ -156,16 +156,16 @@ define(['angular'], function(angular) {
           };
           $scope.continueLabel = function() {
             return (isContinue)?'OK':'Reload';
-          }
+          };
           $scope.dialogText = function() {
             var result = 'Your session will expire soon due to inactivity. ' +
               'Please press OK to continue, otherwise you will be logged out.';
             if (!isContinue) {
               result = 'Your session has expired.' +
-                ' Please reload the page to continue.'
+                ' Please reload the page to continue.';
             }
             return result;
-          }
+          };
         },
       }).catch($log.error);
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ this is constructed.
 + **inactivityTimeout**: the length in minutes a login session can remain
 inactive before the server expires it. A dialog will show during the last
 minute of a session, prompting user action. If no action is taken, the user
-will be redirected to `MISC_URLS.logoutURL` when the session has expired.
+will be prompted to reload the page when the session has expired.
 
 ### SERVICE_LOC
 


### PR DESCRIPTION
On warning, prompt the user to make an ajax call, and restart the timer.
<img width="778" alt="screen shot 2018-10-30 at 1 17 10 pm" src="https://user-images.githubusercontent.com/937952/47752356-3a6e1a00-dc62-11e8-9bb4-b7a086d53a6b.png">

On timeout, prompt the user to reload the page.
<img width="601" alt="screen shot 2018-10-30 at 1 17 42 pm" src="https://user-images.githubusercontent.com/937952/47752361-3d690a80-dc62-11e8-999f-b85882027f69.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

