### PR TITLE
fix: make list-of-links display more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 ### Fixed
 
++ List of links widget has more consistent appearance across browsers and screen sizes (#875)
+
 ### Removed
 
 ### Deprecated

--- a/components/css/buckyless/directives/circle-button.less
+++ b/components/css/buckyless/directives/circle-button.less
@@ -31,7 +31,7 @@ circle-button {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
     min-height: 40px;
 
     > .fa {

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -193,35 +193,52 @@
       div[class^="list-of-links__"] {
         height: 194px;
         overflow: hidden;
+        display: -webkit-box;
         display: flex;
+        -webkit-flex-flow: row wrap;
         flex-flow: row wrap;
+        max-width: 290px;
+        margin: 0 auto;
 
         &.list-of-links__1 {
+          -webkit-box-pack: center;
           justify-content: center;
+          -webkit-box-align: center;
           align-items: center;
+          -webkit-align-content: center;
           align-content: center;
         }
 
         &.list-of-links__2 {
+          -webkit-box-pack: space-around;
           justify-content: space-around;
+          -webkit-box-align: baseline;
           align-items: baseline;
+          -webkit-align-content: center;
           align-content: center;
           padding: 40px 0;
         }
 
         &.list-of-links__3 {
+          -webkit-box-pack: space-around;
           justify-content: space-around;
+          -webkit-box-align: baseline;
           align-items: baseline;
+          -webkit-align-content: space-around;
           align-content: space-around;
         }
 
         &.list-of-links__4 {
+          -webkit-box-pack: space-around;
           justify-content: space-around;
+          -webkit-box-align: baseline;
           align-items: baseline;
+          -webkit-align-content: flex-start;
           align-content: flex-start;
         }
 
         &.list-of-links__long {
+          -webkit-box-pack: space-around;
           justify-content: space-around;
 
           .widget-list a:hover {
@@ -231,7 +248,8 @@
 
         circle-button {
           width: 120px;
-          height: 96px;
+          height: 90px;
+          max-height: 90px;
           text-align: center;
         }
       }


### PR DESCRIPTION
**In this PR:**
- Constrain width so appearance is consistent across screen sizes
- Prevent launch button from obscuring circle buttons 
- Add webkit fallbacks to support some IOS browser versions

### Screenshot
<img width="538" alt="screen shot 2018-12-19 at 1 10 21 pm" src="https://user-images.githubusercontent.com/5818702/50242934-50aa7380-0391-11e9-8a52-08ed0d42e564.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
