### PR TITLE
fix: gracefully degrade action-items to basic when sole indicator errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 ### Fixed
 
 + List of links widget has more consistent appearance across browsers and screen sizes (#875)
++ Action items widget degrades to basic widget when it is configured with just
+  one indicator and that one indicator is failing. ( [#876][] )
 
 ### Removed
 
@@ -981,3 +983,5 @@ break compatibility with some older components. If the app used any
 [uportal-home #750]: https://github.com/uPortal-Project/uportal-home/pull/750
 [uportal-home #795]: https://github.com/uPortal-Project/uportal-home/pull/795
 [sidenav-documentation]: http://uportal-project.github.io/uportal-app-framework/configurable-menu.html
+
+[#876]: https://github.com/uPortal-Project/uportal-app-framework/pull/876

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -18,7 +18,16 @@
     under the License.
 
 -->
-<div class="widget-body action-items">
+<!-- Single configured indicator failed: emulate a basic widget-->
+<basic-widget
+  ng-show="actionItems && actionItems.length == 0
+    && actionItemErrors && actionItemErrors.length == 1"
+  app="widget" config="widget.widgetConfig"></basic-widget>
+
+<div
+  ng-show="!actionItems || actionItems.length != 0
+    || !actionItemErrors || actionItemErrors.length != 1"
+  class="widget-body action-items">
   <!-- No action items to display -->
   <div layout="row" layout-align="center center">
     <!-- Loading case -->
@@ -59,7 +68,11 @@
 </div>
 
 <!-- LAUNCH BUTTON -->
-<launch-button data-href="{{ widget.url }}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
-               data-button-text="{{ launchText }}"
-               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>
+<!-- suppress when degraded to a basic widget, which rendered its own launch button-->
+<launch-button
+ng-show="!actionItems || actionItems.length != 0
+  || !actionItemErrors || actionItemErrors.length != 1"
+  data-href="{{ widget.url }}"
+  data-target="{{ widget.target ? widget.target : '_self' }}"
+  data-button-text="{{ launchText }}"
+  data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -392,14 +392,18 @@ four keys.
 
 #### Guidance about `action-items`
 
-If there are multiple action item types to display, the widget will display the
-first 3 in the list, or the first two if the widget needs to display an error
-message. If any of the action item types fail (independently), the widget shows
-an error message telling the user what it couldn't count.
-
-If there are more action item types configured than the widget has room to
-display, it will acknowledge it is not showing everything with
-"Showing {x} of {y}".
+* If `action-items` is configured with just one indicator and that one indicator
+  is failing, `action-items` silently degrades to be a `basic` widget. This is
+  to avoid distracting and taunting the user with broken functionality -- in the
+  case where the best it can do is offer a single hyperlink, the best it can do
+  is offer that single hyperlink as simply and clearly as possible.
+* If there are succeeding and failing indicators, `action-items` shows the first
+  up to 2 succeding indicators, and an error message telling the user what it
+  couldn't count.
+* If there are only succeeding indicators, `action-items` shows the first up to
+  3 indicators.
+* If there are more indicators configured than it can display, it will
+  acknowledge it is not showing everything with "Showing {x} of {y}".
 
 The **feedUrl** should return a simple JSON object containing a "quantity" key
 with an integer for a value. For example:


### PR DESCRIPTION
Adds a special error case to `action-items` widget type.

Back story: the HRS Approvals widget failed for a while in production. It shows a single action-items indicator telling the employee how many thingies they have awaiting their approval in HRS. During this extended failure period, it showed its fancy complicated error message. Which led to the UX insight/perspective/advice that really we're not doing employees any favors with that fancy error message in this case. When its sole indicator fails, it's a complicated single hyperlink. So in that case let it be a regular old simple single hyperlink.

In the special case where `action-items` is configured with one indicator and that one indicator fails, degrade to a `basic` widget.

Don't do this when there are multiple indicators, since even if they're all failing, they had individual hyperlinks that may add value beyond that of the overall widget launch hyperlink.

Before: complicated error message even in the case where the single configured indicator failed:

<img width="1429" alt="before-special-sole-error-handling" src="https://user-images.githubusercontent.com/952283/51653494-3bf56880-1f59-11e9-84fd-a33cbfb9a4e1.png">

After: degrades to basic in case where the single configured indicator failed.

<img width="1404" alt="after-sole-failing-indicator-degrades-to-basic" src="https://user-images.githubusercontent.com/952283/51653496-41eb4980-1f59-11e9-9567-4c92161adfd4.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

----

Tracked within MyUW as [MUMUP-3404](https://jira.doit.wisc.edu/jira/browse/MUMUP-3404)

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
