### PR TITLE
fix: rm watch, put css vars in :root for polyfill

### DIFF
--- a/components/css/themes/common-variables.less
+++ b/components/css/themes/common-variables.less
@@ -71,6 +71,7 @@
 :root {
   --z-index: 54;
 }
+
 myuw-app-bar {
   --z-index: 54;
 }

--- a/components/css/themes/common-variables.less
+++ b/components/css/themes/common-variables.less
@@ -68,6 +68,9 @@
 @widget-depth-2: 51;
 
 /* z-index css property for myuw-app-bar web component */
+:root {
+  --z-index: 54;
+}
 myuw-app-bar {
   --z-index: 54;
 }

--- a/components/css/themes/uPortal-variables.less
+++ b/components/css/themes/uPortal-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #0479a8;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #2196f3;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #2196f3;
 }

--- a/components/css/themes/uPortal-variables.less
+++ b/components/css/themes/uPortal-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #2196f3;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #2196f3;
 }

--- a/components/css/themes/uwColleges-variables.less
+++ b/components/css/themes/uwColleges-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #b42c2e;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #b42c2e;
 }

--- a/components/css/themes/uwColleges-variables.less
+++ b/components/css/themes/uwColleges-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #b42c2e;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #b42c2e;
 }

--- a/components/css/themes/uwEauClaire-variables.less
+++ b/components/css/themes/uwEauClaire-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #2b3e85;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #2b3e85;
 }

--- a/components/css/themes/uwEauClaire-variables.less
+++ b/components/css/themes/uwEauClaire-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #2b3e85;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #2b3e85;
 }

--- a/components/css/themes/uwExtension-variables.less
+++ b/components/css/themes/uwExtension-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #0d4c92;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #0d4c92;
 }

--- a/components/css/themes/uwExtension-variables.less
+++ b/components/css/themes/uwExtension-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #0d4c92;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #0d4c92;
 }

--- a/components/css/themes/uwGreenBay-variables.less
+++ b/components/css/themes/uwGreenBay-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #0f5640;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #0f5640;
 }

--- a/components/css/themes/uwGreenBay-variables.less
+++ b/components/css/themes/uwGreenBay-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #000;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #0f5640;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #0f5640;
 }

--- a/components/css/themes/uwLaCrosse-variables.less
+++ b/components/css/themes/uwLaCrosse-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #730019;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #730019;
 }

--- a/components/css/themes/uwLaCrosse-variables.less
+++ b/components/css/themes/uwLaCrosse-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #730019;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #730019;
 }

--- a/components/css/themes/uwMadison-variables.less
+++ b/components/css/themes/uwMadison-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #c5050c;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #c5050c;
 }

--- a/components/css/themes/uwMadison-variables.less
+++ b/components/css/themes/uwMadison-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #c5050c;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #c5050c;
 }

--- a/components/css/themes/uwMilwaukee-variables.less
+++ b/components/css/themes/uwMilwaukee-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #000;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwMilwaukee-variables.less
+++ b/components/css/themes/uwMilwaukee-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #000;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwOshkosh-variables.less
+++ b/components/css/themes/uwOshkosh-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #000;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwOshkosh-variables.less
+++ b/components/css/themes/uwOshkosh-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #000;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwParkside-variables.less
+++ b/components/css/themes/uwParkside-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #000;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #026937;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #026937;
 }

--- a/components/css/themes/uwParkside-variables.less
+++ b/components/css/themes/uwParkside-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #026937;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #026937;
 }

--- a/components/css/themes/uwPlatteville-variables.less
+++ b/components/css/themes/uwPlatteville-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #076bb3;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #076bb3;
 }

--- a/components/css/themes/uwPlatteville-variables.less
+++ b/components/css/themes/uwPlatteville-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #076bb3;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #076bb3;
 }

--- a/components/css/themes/uwRiverFalls-variables.less
+++ b/components/css/themes/uwRiverFalls-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #be0f34;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #be0f34;
 }

--- a/components/css/themes/uwRiverFalls-variables.less
+++ b/components/css/themes/uwRiverFalls-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #be0f34;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #be0f34;
 }

--- a/components/css/themes/uwStevensPoint-variables.less
+++ b/components/css/themes/uwStevensPoint-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #623f99;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #623f99;
 }

--- a/components/css/themes/uwStevensPoint-variables.less
+++ b/components/css/themes/uwStevensPoint-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #623f99;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #623f99;
 }

--- a/components/css/themes/uwStout-variables.less
+++ b/components/css/themes/uwStout-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #004990;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #004990;
 }

--- a/components/css/themes/uwStout-variables.less
+++ b/components/css/themes/uwStout-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #004990;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #004990;
 }

--- a/components/css/themes/uwSuperior-variables.less
+++ b/components/css/themes/uwSuperior-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #000;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwSuperior-variables.less
+++ b/components/css/themes/uwSuperior-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #000;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #000;
 }

--- a/components/css/themes/uwSystem-variables.less
+++ b/components/css/themes/uwSystem-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #780026;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #780026;
 }

--- a/components/css/themes/uwSystem-variables.less
+++ b/components/css/themes/uwSystem-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #780026;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #780026;
 }

--- a/components/css/themes/uwWhitewater-variables.less
+++ b/components/css/themes/uwWhitewater-variables.less
@@ -40,6 +40,7 @@
 :root {
   --myuw-app-bar-bg: #422d5c;
 }
+
 myuw-app-bar {
   --myuw-app-bar-bg: #422d5c;
 }

--- a/components/css/themes/uwWhitewater-variables.less
+++ b/components/css/themes/uwWhitewater-variables.less
@@ -37,6 +37,9 @@
 @username-menu-color: #fff;
 @username-menu-bg: lighten(@color1, 30%);
 
+:root {
+  --myuw-app-bar-bg: #422d5c;
+}
 myuw-app-bar {
   --myuw-app-bar-bg: #422d5c;
 }

--- a/components/main.js
+++ b/components/main.js
@@ -25,6 +25,6 @@ require(['./config'], function(config) {
         angular.bootstrap(document, ['my-app']);
         // apply cssvars ponyfill for IE11
         // eslint-disable-next-line no-undef
-        cssVars({shadowDOM: true, watch: true});
+        cssVars({shadowDOM: true});
     });
 });

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -91,6 +91,8 @@ define(['angular', 'require'], function(angular, require) {
       $rootScope.$watch('portal.theme', function(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
           updateWindowTitle();
+          // eslint-disable-next-line no-undef
+          cssVars({shadowDOM: true});
         }
       });
 


### PR DESCRIPTION
Attempting to combat the huge slowdown the "watch" configuration causes in IE11. Adding var definitions to ":root" because apparently that's the only way the css-vars-ponyfill works... if that's true, then I don't understand why it worked with the watch config.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [ ] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
