### PR TITLE
fix: rm cssvars call on theme watch

### DIFF
--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -91,8 +91,6 @@ define(['angular', 'require'], function(angular, require) {
       $rootScope.$watch('portal.theme', function(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
           updateWindowTitle();
-          // eslint-disable-next-line no-undef
-          cssVars({shadowDOM: true});
         }
       });
 


### PR DESCRIPTION
Tested this out and found adding this on the portal.theme watch did not improve the experience. Removing this call in preference for main load call.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [ ] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
