### PR TITLE
feat: add cookie to limit ie alert frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 + Tell IE users about recommended browsers during application bootstrapping (#877)
++ Track IE alert with a cookie so users aren't badgered too often (#881)
 
 ### Changed
 

--- a/components/static.html
+++ b/components/static.html
@@ -48,15 +48,35 @@
       </div>
     </md-dialog-content>   
     <md-dialog-actions>
-      <md-button ng-click="portal.hideIEAlert = true" class="md-primary md-confirm-button" type="button" ng-click="dialog.hide()" style="text-transform: none; margin: 8px 0 8px 8px; min-height: 36px; min-width: 88px;">Close</md-sbutton>
+      <md-button ng-click="portal.hideIEAlert = true" class="md-primary md-confirm-button" type="button" onclick="createCookie('ieAlertCookie', 'true', 20)" style="text-transform: none; margin: 8px 0 8px 8px; min-height: 36px; min-width: 88px;">Close</md-sbutton>
     </md-dialog-actions>     
   </md-dialog>
 </div>
 <script>
-  // If it's IE, show the alert
+  // If it's IE and the ieAlertCookie is null, show the alert
   if(window.navigator.userAgent.match(/(MSIE|Trident)/)) {
-    document.getElementById('ieAlert').style.display = 'flex';
+    if (readCookie('ieAlertCookie') === null) {
+      document.getElementById('ieAlert').style.display = 'flex';
+    }
   }
+
+  function readCookie(name) {
+	  var nameEQ = name + "=";
+	  var ca = document.cookie.split(';');
+	  for(var i=0;i < ca.length;i++) {
+		  var c = ca[i];
+		  while (c.charAt(0)==' ') c = c.substring(1,c.length);
+		  if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+	  }
+	  return null;
+  };
+
+  function createCookie(name, value, days) {
+    var date = new Date();
+    date.setTime(date.getTime()+(days*24*60*60*1000));
+    var expires = "; expires="+date.toGMTString();
+    document.cookie = name+"="+value+expires+"; path=/";
+  };
 </script>
 
 <!-- Loading state -->


### PR DESCRIPTION
**In this PR:**
- When user closes IE alert, add a cookie with 20-day lifespan

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
