### PR TITLE
fix: use fname rather than nodeId to uniquely identify widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to
 
 ## [unreleased][]
 
-(No changes so far.)
+### Fixes in unreleased
+
++ Now uses `fname` rather than `nodeId` when generating HTML element IDs for
+  widgets. In practice `nodeId` was always `-1` and so wasn't leading to unique
+  HTML element IDs. (#885)
 
 ### Dependency upgrades in unreleased
 

--- a/components/portal/widgets/partials/compact-widget-card.html
+++ b/components/portal/widgets/partials/compact-widget-card.html
@@ -37,12 +37,12 @@
     </md-menu-content>
   </md-menu>
   <!-- Widget clickable area -->
-  <a aria-labelledby="appTitle_widget.title-{{::widget.nodeId}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
+  <a aria-labelledby="appTitle_widget.title-{{::widget.fname}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
     <div class="icon-container">
       <widget-icon></widget-icon>
     </div>
     <div class="list-item-container">
-      <h4 id="appTitle_widget.title-{{::widget.nodeId}}">{{ ::widget.title }}</h4>
+      <h4 id="appTitle_widget.title-{{::widget.fname}}">{{ ::widget.title }}</h4>
     </div>
   </a>
 </md-card>

--- a/components/portal/widgets/partials/compact-widget-card.html
+++ b/components/portal/widgets/partials/compact-widget-card.html
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<md-card class="list-content" id="widget-id-{{::widget.nodeId}}">
+<md-card class="list-content" id="widget-id-{{::widget.fname}}">
   <!-- Widget contextual menu -->
   <md-menu class="widget-action" md-position-mode="target-right bottom">
     <md-button class="md-icon-button" aria-label="open {{ widget.title }} menu" ng-click="$mdOpenMenu($event)">

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<md-card class="widget-frame" id="widget-id-{{ widget.nodeId }}" aria-label="{{ widget.title }} widget">
+<md-card class="widget-frame" id="widget-id-{{ widget.fname }}" aria-label="{{ widget.title }} widget">
 
   <!-- MAINTENANCE MODE OVERLAY -->
   <div class="overlay__widget-mode" ng-if="widget.lifecycleState === 'MAINTENANCE'">

--- a/components/staticFeeds/sample-widget__action-items.json
+++ b/components/staticFeeds/sample-widget__action-items.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Action Items",
       "description": "See how many items need your attention",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_empty-string.json
+++ b/components/staticFeeds/sample-widget__action-items_empty-string.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Handles empty string quantities",
       "description": "action-items detects and treats as an error when a JSON callback returns the empty string quantity",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_many.json
+++ b/components/staticFeeds/sample-widget__action-items_many.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Many quantities",
       "description": "truncates excess quantity items",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_one.json
+++ b/components/staticFeeds/sample-widget__action-items_one.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "One quantity",
       "description": "action-items can show a single quantity of action items",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_partially-broken.json
+++ b/components/staticFeeds/sample-widget__action-items_partially-broken.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Some broken quantities",
       "description": "items fail independently",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_three.json
+++ b/components/staticFeeds/sample-widget__action-items_three.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Three quantities",
       "description": "action-items can show up to three quantities",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__action-items_totally-broken.json
+++ b/components/staticFeeds/sample-widget__action-items_totally-broken.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "All broken quantities",
       "description": "action-items when all its items fail",
       "url": "http://www.google.com",

--- a/components/staticFeeds/sample-widget__basic.json
+++ b/components/staticFeeds/sample-widget__basic.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Faculty Center",
       "description": "View your teaching schedule, class roster, and advisee information, and manage grades and textbook information.",
       "url": "/portal/p/faculty-center/max/action.uP?pP_action=loginAction",

--- a/components/staticFeeds/sample-widget__benefits.json
+++ b/components/staticFeeds/sample-widget__benefits.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Benefit Information",
       "description": "Summary information about your current benefit enrollments and links to your WRS Statement of Benefits.",
       "url": "/portal/p/university-staff-benefits-statement/render.uP",

--- a/components/staticFeeds/sample-widget__custom.json
+++ b/components/staticFeeds/sample-widget__custom.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Custom widget",
       "description": "`custom` type widgets render an arbitrary template, optionally considering dynamic JSON",
       "url": "staticFeeds/sample-widget__custom.json",

--- a/components/staticFeeds/sample-widget__generic.json
+++ b/components/staticFeeds/sample-widget__generic.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "generic means custom",
       "description": "generic is a deprecated alias for the custom widget type.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#custom-widgets",

--- a/components/staticFeeds/sample-widget__list-of-4-links-first-redundant.json
+++ b/components/staticFeeds/sample-widget__list-of-4-links-first-redundant.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "only collapse when single link",
       "description": "When list-of-links is configured with multiple links, it does not collapse to a basic widget even when the first link is redundant.",
       "url": "http://www.exammple.edu/altMaxLink",

--- a/components/staticFeeds/sample-widget__list-of-8-links.json
+++ b/components/staticFeeds/sample-widget__list-of-8-links.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "List of (many) Links widget type",
       "description": "Demonstrates presentation when seven or more links",
       "url": "staticFeeds/list-of-8-links-via-url.json",

--- a/components/staticFeeds/sample-widget__list-of-links.json
+++ b/components/staticFeeds/sample-widget__list-of-links.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "List of Links widget type",
       "description": "Convenient access to up to seven hyperlinks, sourced from widget configuration or from URL",
       "url": "staticFeeds/list-of-links-via-url.json",

--- a/components/staticFeeds/sample-widget__list-of-no-links.json
+++ b/components/staticFeeds/sample-widget__list-of-no-links.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "List of Links widget type with no links",
       "description": "Demonstrates list-of-links edge case of zero links.",
       "url": "staticFeeds/list-of-no-links-via-url.json",

--- a/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
+++ b/components/staticFeeds/sample-widget__list-of-one-redundant-link.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "list-of-links collapses to basic",
       "description": "When list-of-links is configured with a single link to its alternativeMaximizedUrl, it collapses to a basic widget.",
       "url": "staticFeeds/sample-widget__list-of-one-redundant-link.json",

--- a/components/staticFeeds/sample-widget__maintenance-custom.json
+++ b/components/staticFeeds/sample-widget__maintenance-custom.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Another App Under Maintenance",
       "description": "An example of an app in maintenance mode with a custom maintenance messsge.",
       "url": "/portal/p/faculty-center/max/action.uP?pP_action=loginAction",

--- a/components/staticFeeds/sample-widget__maintenance-default.json
+++ b/components/staticFeeds/sample-widget__maintenance-default.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Some App Under Maintenance",
       "description": "An example of an app in maintenance mode.",
       "url": "/portal/p/faculty-center/max/action.uP?pP_action=loginAction",

--- a/components/staticFeeds/sample-widget__rss.json
+++ b/components/staticFeeds/sample-widget__rss.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": false,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "UWRF News",
       "description": "Local news important for UW-River Falls",
       "url": "https://www.uwrf.edu/News/",
@@ -58,7 +57,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "News About MyUW",
           "description": "News about MyUW.",
           "url": "/portal/p/myuw-news/render.uP",
@@ -113,7 +111,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "Responsive MyUW",
           "description": "Information about the new responsive view of MyUW",
           "url": "/portal/p/responsive-myuw-announcement/render.uP",
@@ -162,7 +159,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "HR, Payroll and Benefits News",
           "description": "News and announcements about University of Wisconsin HR, Payroll, and Benefit topics.",
           "url": "/portal/p/hr-payroll-benefits-news/render.uP",
@@ -220,7 +216,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "DoIT Help Desk Notices",
           "description": "Computing support news and notices from the Help Desk.",
           "url": "/portal/p/doit-help-desk-notices/render.uP",
@@ -271,7 +266,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "New! Mobile MyUW",
           "description": "Information about the new mobile view of MyUW",
           "url": "/portal/p/mobile-myuw-announcement/render.uP",

--- a/components/staticFeeds/sample-widget__search-with-links.json
+++ b/components/staticFeeds/sample-widget__search-with-links.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Research Project Resource Guide",
       "description": "Find on and off campus resources available for each phase and step of your research project.",
       "url": "https://rprg.wisc.edu/",
@@ -57,7 +56,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "Classes I Teach Map",
           "description": "View a map of the buildings in which the classes you teach meet.",
           "url": "/portal/p/taught-classes-map/render.uP",
@@ -113,7 +111,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "Faculty Center",
           "description": "View your teaching schedule, class roster, and advisee information, and manage grades and textbook information.",
           "url": "/portal/p/faculty-center/max/action.uP?pP_action=loginAction",
@@ -171,7 +168,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "Research Facilities and Tools - Administrator",
           "description": "Create, edit, and manage all descriptions for the Research Facilities and Tools module.",
           "url": "/portal/p/rcat_admin/render.uP",
@@ -220,7 +216,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "Research Tab Messages",
           "description": "This module provides information about the status of modules and services on the Reserach tab.",
           "url": "/portal/p/research-tab-messages/render.uP",
@@ -269,7 +264,6 @@
       {
         "canAdd": false,
         "layoutObject": {
-          "nodeId": "-1",
           "title": "PI Financials Tool",
           "description": "View financial information about sponsored projects and gifts.",
           "url": "https://pi.wisc.edu",

--- a/components/staticFeeds/sample-widget__switch.json
+++ b/components/staticFeeds/sample-widget__switch.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Switch matching first case",
       "description": "This widget switches runtime type depending upon a JSON feed.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",

--- a/components/staticFeeds/sample-widget__switch_2.json
+++ b/components/staticFeeds/sample-widget__switch_2.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Matches 2nd case",
       "description": "In this case the second case matches.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",

--- a/components/staticFeeds/sample-widget__switch_broken.json
+++ b/components/staticFeeds/sample-widget__switch_broken.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Bad configuration",
       "description": "No case matches and no default case is configured so falls back on being a basic widget.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",

--- a/components/staticFeeds/sample-widget__switch_otherwise.json
+++ b/components/staticFeeds/sample-widget__switch_otherwise.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Matches neither case",
       "description": "In this switch neither case matches so it falls back on a default case.",
       "url": "https://github.com/uPortal-Project/uportal-app-framework/blob/master/docs/make-a-widget.md#switch-widget-type",

--- a/components/staticFeeds/sample-widget__time-current.json
+++ b/components/staticFeeds/sample-widget__time-current.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "After the action start date",
       "description": "time-sensitive-content widgets count down during the action period.",
       "url": "https://rprg.wisc.edu/",

--- a/components/staticFeeds/sample-widget__time-expired.json
+++ b/components/staticFeeds/sample-widget__time-expired.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "After the template retires",
       "description": "time-sensitive-content widget templates can retire entirely, returning the widget to basic-widget-like state.",
       "url": "https://rprg.wisc.edu/",

--- a/components/staticFeeds/sample-widget__time-future.json
+++ b/components/staticFeeds/sample-widget__time-future.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Before the template starts",
       "description": "time-sensitive-content widgets sleep as basic widgets until a templateLiveDate arrives.",
       "url": "https://rprg.wisc.edu/",

--- a/components/staticFeeds/sample-widget__time-past.json
+++ b/components/staticFeeds/sample-widget__time-past.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "After the action end date",
       "description": "time-sensitive-content widgets can solicit feedback after the action period.",
       "url": "https://rprg.wisc.edu/",

--- a/components/staticFeeds/sample-widget__time-soon.json
+++ b/components/staticFeeds/sample-widget__time-soon.json
@@ -2,7 +2,6 @@
   "entry": {
     "canAdd": true,
     "layoutObject": {
-      "nodeId": "-1",
       "title": "Once the template goes live",
       "description": "time-sensitive-content widgets foreshadow the action period.",
       "url": "https://rprg.wisc.edu/",


### PR DESCRIPTION
Widget cards had been relying upon `widget.nodeId` to uniquely identify the widget for generating HTML element IDs on the page. In practice `widget.nodeId` is always `-1`. (I don't just mean that it's -1 in the example JSON data here, I mean it's -1 in production MyUW.)

This probably fixes an accessibility issue, in that the `aria-labelledby` references to not-unique HTML element IDs probably weren't effective.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
