### PR TITLE
docs: deprecate "priority" notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased][]
 
+### Deprecations in unreleased
+
++ "priority" notifications are deprecated. (#890)
+
 ### Enhancements in unreleased
 
 + Adds link to MyUW news in `about-page.json` (#887)

--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -56,7 +56,7 @@
         .md-list-item-text {
           padding: 16px 0;
 
-          /* Priority notifications are deprecated. */
+          /* Priority notifications are DEPRECATED. */
           .notification__priority-message {
             color: @grayscale8;
             font-size: 12px;

--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -55,7 +55,7 @@
 
         .md-list-item-text {
           padding: 16px 0;
-
+          /* Priority notifications are deprecated. */
           .notification__priority-message {
             color: @grayscale8;
             font-size: 12px;
@@ -198,7 +198,7 @@
   }
 }
 
-/* PRIORITY NOTIFICATIONS */
+/* PRIORITY NOTIFICATIONS (DEPRECATED) */
 .priority-gt-xs .priority-notifications {
   height: 46px;
   width: 100%;

--- a/components/css/buckyless/notifications.less
+++ b/components/css/buckyless/notifications.less
@@ -55,6 +55,7 @@
 
         .md-list-item-text {
           padding: 16px 0;
+
           /* Priority notifications are deprecated. */
           .notification__priority-message {
             color: @grayscale8;

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -35,6 +35,7 @@ define(['angular', 'require'], function(angular, require) {
 
     /**
       * Listen for unseen notifications
+      * PRIORITY NOTIFICATIONS ARE DEPRECATED
       */
     $scope.$on('HAS_PRIORITY_NOTIFICATIONS', function(event, data) {
       if (angular.isDefined(data.hasNotifications)) {
@@ -235,6 +236,7 @@ define(['angular', 'require'], function(angular, require) {
 
       /**
        * Listen for unseen notifications
+       * PRIORITY NOTIFICATIONS ARE DEPRECATED
        */
       $scope.$on('HAS_PRIORITY_NOTIFICATIONS', function(event, data) {
         if (angular.isDefined(data.hasNotifications)) {

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -39,7 +39,7 @@
         <span><md-icon>notifications</md-icon></span>
         <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Notifications</md-tooltip>
       </md-button>
-      <!-- High priority notifications button -->
+      <!-- High priority notifications button (DEPRECATED) -->
       <md-button ng-href="{{ vm.notificationsPageUrl }}"
                 ng-click="vm.pushGAEvent('Sidenav notifications bell', 'Click link', 'High priority state');vm.closeMainMenu();"
                 aria-label="you have important notifications"

--- a/components/staticFeeds/sample-messages.json
+++ b/components/staticFeeds/sample-messages.json
@@ -23,7 +23,7 @@
     },
     {
       "id": "sample-uportal-app-framework-madison-priority-notification",
-      "title": "This is a high priority notification. It should only appear if group filtering is disabled in /settings",
+      "title": "PRIORITY NOTIFICATIONS ARE DEPRECATED. This is a high priority notification. It should only appear if group filtering is disabled in /settings",
       "goLiveDate": "2017-08-03",
       "priority": "high",
       "dismissible": true,

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -17,7 +17,7 @@ Widget messaging is based on JSON input configured in a
     "messages": [
         {
             "id": "sample-unactivated-services-notification",
-            "title": "You need to modify your NetID account to activate essential UW Services.",
+            "title": "PRIORITY NOTIFICATIONS ARE DEPRECATED. You need to modify your NetID account to activate essential UW Services.",
             "goLiveDate": "2017-08-01T09:30",
             "expireDate": "2017-08-02",
             "priority": "high",
@@ -66,7 +66,7 @@ Widget messaging is based on JSON input configured in a
   message will display only after this moment.
 - **expireDate**: *(optional)* ISO date, including time (as pictured). The
   message will display only before this moment.
-- **priority**: "high" triggers higher visibility
+- **priority**: DEPRECATED "high" triggers higher visibility
 - **recurrence**: *(experimental, optional)* If true, even if a notification is
   dismissed, it will continue to reoccur in the user's home at the start of
   every session until the user is no longer a member of the targeted group. For
@@ -108,6 +108,9 @@ Widget messaging is based on JSON input configured in a
 
 A given message can have at most one each of the `actionButton` and
 `moreInfoButton`.
+
+"PRIORITY" NOTIFICATIONS ARE DEPRECATED. In a future release notifications with
+non-null "priority" will not be supported.
 
 Historically there was a **messageType** that distinguished between
 "notification" and "announcement". This *no longer has any effect.*
@@ -162,7 +165,7 @@ Follow these steps to create a notification.
 1. Add a JSON message to
 [components/staticFeeds/sample-messages.json](https://github.com/uPortal-Project/uportal-app-framework/blob/master/components/staticFeeds/sample-messages.json)
 2. [Start frame](quickstart.md)
-3. Try changing some of the options like making the priority "high".
+3. Try changing some of the options.
 
 You can use this example JSON:
 

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -32,12 +32,12 @@ notifications page that also displays the number of unseen notifications.
 
 [![mobile menu notifications link](./img/notifications/mobile-link.png)](img/notifications/mobile-link.png)
 
-### Priority notifications
+### Priority notifications (DEPRECATED)
 
-Critical notifications designated "high priority" will appear more prominently,
-fixed above the application top bar. When the user has more than one priority
-notification, the framework displays a generic message featuring the priority
-notifications count and a link to the notifications page.
+DEPRECATED. Critical notifications designated "high priority" will appear more
+prominently, fixed above the application top bar. When the user has more than
+one priority notification, the framework displays a generic message featuring
+the priority notifications count and a link to the notifications page.
 
 [![priority notification](./img/notifications/priority.png)](img/notifications/priority.png)
 
@@ -46,7 +46,7 @@ notifications count and a link to the notifications page.
 On the notifications page, users can view, follow calls to action on, and
 dismiss their notifications. They can also click the "Dismissed" tab to view
 notifications they've previously dismissed. High priority notifications
-float to the top of the lists.
+(DEPRECATED) float to the top of the lists.
 
 ## Widget messaging
 


### PR DESCRIPTION
Updates documentation to reflect that the "priority" notification feature is deprecated, getting slightly in front of intent to replace with a new banner message feature hewing a bit closer to (spirit of?) Material Design and reducing complexity of notifications as such.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
