### PR TITLE
fix: banner messages as bare array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to
 + Adds link to MyUW news in `about-page.json` (#887)
 + Adds myuw-banner component to consume feed from myuw-banner-messages-back-end.
   Optionally set new `SERVICE_LOC.bannersURL` to opt in to this feature; without
-  that setting nothing changes. (#891)
+  that setting nothing changes. (#891, #893)
 
 ### Fixes in unreleased
 

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -128,9 +128,9 @@ define(['angular'], function(angular) {
       function getBanners() {
         return $http.get(SERVICE_LOC.bannersURL)
           .then(function(response) {
-            if (response.data && response.data.messages
-              && angular.isArray(response.data.messages)) {
-              return response.data.messages;
+            if (response.data
+              && angular.isArray(response.data)) {
+              return response.data;
             } else {
               return GET_BANNERS_FAILED;
             }

--- a/components/staticFeeds/sample-banners.json
+++ b/components/staticFeeds/sample-banners.json
@@ -1,19 +1,18 @@
-{
-  "messages": [
-    {
-      "text": "Example banner message",
-      "icon": "inbox",
-      "button": {
-        "label": "Read documentation",
-        "url": "https://uportal-project.github.io/uportal-app-framework/messaging.html"
-      }
-    },
-    {
-      "text": "Secondary test banner",
-      "button": {
-        "label": "Do thing",
-        "url": "#"
-      }
+[
+  {
+    "text": "Example banner message",
+    "icon": "inbox",
+    "button": {
+      "label": "Read documentation",
+      "url": "https://uportal-project.github.io/uportal-app-framework/messaging.html"
     }
-  ]
-}
+  },
+  {
+    "text": "Secondary test banner",
+    "button": {
+      "label": "Do thing",
+      "url": "#"
+    }
+  }
+]
+

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -127,18 +127,17 @@ informs the user experience; any messages after the first in the array have no
 effect. (The back end is therefore expected to prioritize these messages.)
 
 ```json
-{
-  "messages": [
-    {
-      "text": "Brief message to user",
-      "icon": "optional-material-icon",
-      "button": {
-        "label: "Take action",
-        "url": "https://www.example.edu/somewhere"
-      }
+[
+  {
+    "text": "Brief message to user",
+    "icon": "optional-material-icon",
+    "button": {
+      "label": "Take action",
+      "url": "https://www.example.edu/somewhere"
     }
-  ]
-}
+  }
+]
+
 ```
 
 A zero item array of banner messages suppresses the banner message feature.


### PR DESCRIPTION
Banner messages service expected to send a bare array of messages, but framework had expected this to be in a `messages` key; removing messages key to align expectations of banner message feed producer and consumer.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
