### PR TITLE
Add myuw-help-link web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 + Adds myuw-banner component to consume feed from myuw-banner-messages-back-end.
   Optionally set new `SERVICE_LOC.bannersURL` to opt in to this feature; without
   that setting nothing changes. (#891, #893)
++ Adds myuw-help-link web component 1.0.0 as dependency available in page (#894)
 
 ### Fixes in unreleased
 

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -41,6 +41,9 @@
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.0.3/dist/myuw-banner.min.mjs"></script>
 <script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.0.3/dist/myuw-banner.min.js"></script>
 
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-help-link@1.0.0/dist/myuw-help-link.min.mjs"></script>
+<script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-help-link@1.0.0/dist/myuw-help-link.min.js"></script>
+
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min.css"/>

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -37,6 +37,7 @@
 <!-- myuw-web-components -->
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.5.4/dist/myuw-app-bar.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.5.4/dist/myuw-app-bar.min.js"></script>
+
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.0.3/dist/myuw-banner.min.mjs"></script>
 <script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.0.3/dist/myuw-banner.min.js"></script>
 


### PR DESCRIPTION
Import new `myuw-help-link` web component so that content in the portal can use it to link to help.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
