### PR TITLE
fix: prevent multiple session expired dialogs from displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 + Now uses `fname` rather than `nodeId` when generating HTML element IDs for
   widgets. In practice `nodeId` was always `-1` and so wasn't leading to unique
   HTML element IDs. (#885)
++ Prevent multiple session-exipred dialogs from displaying. (#897)
 
 ### Documentation in unreleased
 

--- a/components/portal/timeout/controllers.js
+++ b/components/portal/timeout/controllers.js
@@ -145,6 +145,7 @@ define(['angular'], function(angular) {
         clickOutsideToClose: false,
         openFrom: 'left',
         closeTo: 'right',
+        multiple: false,
         controller: function DialogController($scope, $mdDialog) {
           $scope.continueBtn = function() {
             if (isContinue) {


### PR DESCRIPTION
**In this PR**:
- Don't display additional "session expired" dialog if one is already being displayed.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
