### PR TITLE
feat: replace "Loading..." screen with animated content preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
   that setting nothing changes. (#891, #893)
 + Adds `myuw-help-link` web component 1.x as dependency available in page
   (#894, #896)
++ Upgrades "Loading" splash screen to show a content preview (#898)
 
 ### Fixes in unreleased
 

--- a/components/static.html
+++ b/components/static.html
@@ -31,6 +31,17 @@
     }
   }
 
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+  }
+
   .no-js {
     margin-bottom: 0;
     font-size: medium;
@@ -121,7 +132,6 @@
     width: 60%;
   }
 
-
   @media (max-width: 600px) {
     #skeleton__search {
       display: none;
@@ -170,6 +180,7 @@
 </script>
 
 <!-- Loading state -->
+<h1 class="sr-only">The application is getting ready...</h1>
 <div ng-hide="portal.loading.hidden" ng-class="{slowfade: portal.loading.startFade}" class="skeleton" id="loading-splash">
         <!--No javascript enabled-->
         <noscript>

--- a/components/static.html
+++ b/components/static.html
@@ -19,6 +19,18 @@
 
 -->
 <style type="text/css">
+  @keyframes pulse {
+    0% {
+      background-color: rgba(165, 165, 165, 0.1);
+    }
+    50% {
+      background-color: rgba(165, 165, 165, 0.3);
+    }
+    100% {
+      background-color: rgba(165, 165, 165, 0.1);
+    }
+  }
+
   .no-js {
     margin-bottom: 0;
     font-size: medium;
@@ -37,6 +49,77 @@
   #ieAlert {
     display: none;
   }
+
+  #loading-splash {
+    position: fixed;
+    top: 0;
+    z-index: 2000;
+    color: darkgrey;
+    background: #EAE8DF;
+    height: 100vh;
+    width: 100vw;
+    text-align: center;
+    font-size: xx-large;
+    margin: 0;
+    font-family: Roboto, Helvetica Neue, sans-serif;
+  }
+
+  #skeleton__header {
+    height:64px;
+    width: 100%;
+    position: fixed;
+    top: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-content: center;
+    align-items: center;
+    animation: pulse 1.5s infinite ease-in-out;
+  }
+
+  #skeleton__menu,
+  #skeleton__profile,
+  #skeleton__search {
+    width: 42px;
+    height: 42px;
+    margin: 0 16px;
+    border-radius: 4px;
+    background: #EAE8DF;
+  }
+
+  #skeleton__search {
+    width: 33%;
+    margin: 0 auto;
+  }
+
+  #skeleton__profile {
+    border-radius: 50%;
+  }
+
+  #skeleton__grid {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: center;
+    position: relative;
+    top: 64px;
+    width: 100%;
+    max-width: 1260px;
+    margin: 16px auto;
+  }
+
+  .skeleton__grid--widget {
+    width: 290px;
+    height: 290px;
+    margin: 10px;
+    animation: pulse 1.5s infinite ease-in-out;
+  }
+
+  @media (max-width: 600px) {
+    #skeleton__search {
+      display: none;
+    }
+  }
 </style>
 <!--Bad browser error message-->
 <div id="ieAlert" ng-hide="portal.hideIEAlert" class="md-dialog-container" style="top: 0px; height: 100%; width: 100%; background: rgba(0,0,0,0.3); z-index: 2001;">
@@ -46,10 +129,10 @@
       <div class="md-dialog-content-body">
         <a href="https://kb.wisc.edu/page.php?id=44398" target="_blank" style="color: #0479a8; text-decoration: none; font-size: 14px; line-height: 20px;">Get help updating your browser.</a>
       </div>
-    </md-dialog-content>   
+    </md-dialog-content>
     <md-dialog-actions>
       <md-button ng-click="portal.hideIEAlert = true" class="md-primary md-confirm-button" type="button" onclick="createCookie('ieAlertCookie', 'true', 20)" style="text-transform: none; margin: 8px 0 8px 8px; min-height: 36px; min-width: 88px;">Close</md-sbutton>
-    </md-dialog-actions>     
+    </md-dialog-actions>
   </md-dialog>
 </div>
 <script>
@@ -80,20 +163,7 @@
 </script>
 
 <!-- Loading state -->
-<div ng-hide="portal.loading.hidden" ng-class="{slowfade: portal.loading.startFade}" style="
-        position : fixed;
-        top: 0;
-        z-index: 2000;
-        color: darkgrey;
-        background: #EAE8DF;
-        height: 100vh;
-        width: 100vw;
-        text-align: center;
-        padding-top: 45vh;
-        font-size: xx-large;
-        margin: -8px;
-        font-family: Roboto, Helvetica Neue, sans-serif;"
-      id="loading-splash">
+<div ng-hide="portal.loading.hidden" ng-class="{slowfade: portal.loading.startFade}" class="skeleton" id="loading-splash">
         <!--No javascript enabled-->
         <noscript>
             <div class="no-js" role="alert">
@@ -105,6 +175,24 @@
             </div>
           </div>
         </noscript>
-        <!--loading for realz-->
-        Loading...</div>
-        
+        <!-- Skeleton screen for loading -- emphasize the coming content, not the loading experience -->
+        <header id="skeleton__header">
+          <div id="skeleton__menu"></div>
+          <div id="skeleton__search"></div>
+          <div id="skeleton__profile"></div>
+        </header>
+        <main id="skeleton__grid">
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+          <div class="skeleton__grid--widget"></div>
+        </main>
+</div>

--- a/components/static.html
+++ b/components/static.html
@@ -96,7 +96,7 @@
     border-radius: 50%;
   }
 
-  #skeleton__grid {
+  #skeleton__content {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
@@ -104,16 +104,23 @@
     position: relative;
     top: 64px;
     width: 100%;
-    max-width: 1260px;
+    height: 100%;
     margin: 16px auto;
   }
 
-  .skeleton__grid--widget {
-    width: 290px;
-    height: 290px;
-    margin: 10px;
+  .skeleton__content--block {
+    height: 100%;
+    margin: 16px;
+    border-radius: 4px;
+    width: 80%;
     animation: pulse 1.5s infinite ease-in-out;
   }
+
+  .skeleton__content--block:nth-child(2) {
+    height: 400px;
+    width: 60%;
+  }
+
 
   @media (max-width: 600px) {
     #skeleton__search {
@@ -181,18 +188,7 @@
           <div id="skeleton__search"></div>
           <div id="skeleton__profile"></div>
         </header>
-        <main id="skeleton__grid">
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
-          <div class="skeleton__grid--widget"></div>
+        <main id="skeleton__content">
+          <div class="skeleton__content--block"></div>
         </main>
 </div>


### PR DESCRIPTION
**In this PR:**
- Replace "Loading..." splash screen with a generic content preview screen
- Include screen-reader-only heading to indicate loading
- Preview content has a gradual pulse animation to give the impression that it's in progress

### Why?

Apple, Facebook, and other high-profile web presences have agreed that skeleton screens build anticipation for content, whereas loading spinners/screens put the focus on the wait time that the user has to endure. Also...this is just nicer to look at. :)

*Note: This doesn't solve the problem of un-styled content flashing during angularjs bootstrapping, but it's still an improvement in my view.*

### Demo
![_skeleton-preview](https://user-images.githubusercontent.com/5818702/56595264-f413cb00-65b3-11e9-9cfb-3920593b7231.gif)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
