### PR TITLE
docs(changelog): fix typo "exipred" --> "expired"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to
 + Now uses `fname` rather than `nodeId` when generating HTML element IDs for
   widgets. In practice `nodeId` was always `-1` and so wasn't leading to unique
   HTML element IDs. (#885)
-+ Prevent multiple session-exipred dialogs from displaying. (#897)
++ Prevent multiple session-expired dialogs from displaying. (#897)
 
 ### Documentation in unreleased
 


### PR DESCRIPTION
#897 's changelog update had a typo, this fixes it.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change. (Change *is* a CHANGELOG fix).
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
