### PR TITLE
docs: add example myuw-help-link usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to
 + Adds myuw-banner component to consume feed from myuw-banner-messages-back-end.
   Optionally set new `SERVICE_LOC.bannersURL` to opt in to this feature; without
   that setting nothing changes. (#891, #893)
-+ Adds `myuw-help-link` web component 1.x as dependency available in page
-  (#894, #896)
++ Adds `myuw-help-link` web component 1.x as dependency available in page and
+  demonstrates in example-page.html (#894, #896, #902)
 + Upgrades "Loading" splash screen to show a content preview (#898)
 + Upgrade banner component to latest version (#899)
 

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -267,4 +267,12 @@
           <compact-widget fname="sample-widget__generic"></compact-widget>
         </div>
       </div>
+
+
+
+  <h2 style="margin-left:26px">Miscellaneous Web Components</h2>
+  <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
+    <myuw-help-link app-context="uPortal App Framework" url="https://uportal-project.github.io/uportal-app-framework/">
+    </myuw-help-link>
+  </div>
 </frame-page>


### PR DESCRIPTION
Demonstrate the `myuw-help-link` web component in `example-page.html`

<img width="1116" alt="Screenshot of myuw-help-link web component at bottom of example-page" src="https://user-images.githubusercontent.com/952283/56920903-11e8a080-6a8a-11e9-820b-495d76e3c763.png">

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
