### PR TITLE
feat: widgetConfig.launchUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to
   (#894, #896)
 + Upgrades "Loading" splash screen to show a content preview (#898)
 + Upgrade banner component to latest version (#899)
++ Adds optional `launchUrl` and `launchUrlTarget` fields to `widgetConfig`,
+  parallel to existing `launchText`. These customize the launch bar URL and
+  target, only in the expanded mode of non-custom non-option-link widgets.
 
 ### Fixes in unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 + Adds optional `launchUrl` and `launchUrlTarget` fields to `widgetConfig`,
   parallel to existing `launchText`. These customize the launch bar URL and
   target, only in the expanded mode of non-custom non-option-link widgets.
+  ( [#904][] )
 
 ### Fixes in unreleased
 
@@ -1046,3 +1047,4 @@ break compatibility with some older components. If the app used any
 [sidenav-documentation]: http://uportal-project.github.io/uportal-app-framework/configurable-menu.html
 
 [#876]: https://github.com/uPortal-Project/uportal-app-framework/pull/876
+[#904]: https://github.com/uPortal-Project/uportal-app-framework/pull/904

--- a/components/portal/widgets/partials/type__action-items.html
+++ b/components/portal/widgets/partials/type__action-items.html
@@ -72,7 +72,7 @@
 <launch-button
 ng-show="!actionItems || actionItems.length != 0
   || !actionItemErrors || actionItemErrors.length != 1"
-  data-href="{{ widget.url }}"
-  data-target="{{ widget.target ? widget.target : '_self' }}"
+  data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+  data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
   data-button-text="{{ launchText }}"
   data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__basic.html
+++ b/components/portal/widgets/partials/type__basic.html
@@ -30,8 +30,8 @@
   </a>
 </div>
 <launch-button data-aria-label="{{ 'Launch ' + widget.title }}"
-  data-href="{{ renderUrl() }}"
-  data-target="{{ widget.target ? widget.target : '_self' }}"
+  data-href="{{ config.launchUrl? config.launchUrl : renderUrl() }}"
+  data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
   data-rel="noopener noreferrer"
   data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'Launch full app' }}">
 </launch-button>

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -83,7 +83,7 @@
   suppress in cases where collapsed to basic-widget, which rendered its own launch button -->
 <launch-button
   ng-show="config.links.length > 1 || (config.links.length !=1 || config.links[0].href != widget.url)"
-               data-href="{{widget.url}}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+               data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
                data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__rss.html
+++ b/components/portal/widgets/partials/type__rss.html
@@ -44,8 +44,8 @@
     <li ng-if="isEmpty" class="no-highlight">No information at this time.</li>
   </ul>
 </div>
-<launch-button data-href="{{ widget.url }}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+<launch-button data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="{{ widget.widgetConfig.launchText ? widget.widgetConfig.launchText : 'See all' }}"
                data-aria-label="{{ 'Launch ' + widget.title }}">
 </launch-button>

--- a/components/portal/widgets/partials/type__search-with-links.html
+++ b/components/portal/widgets/partials/type__search-with-links.html
@@ -51,7 +51,7 @@
     </div>
   </div>
 </div>
-<launch-button data-href="{{widget.url}}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+<launch-button data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
                data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__time-sensitive.html
+++ b/components/portal/widgets/partials/type__time-sensitive.html
@@ -62,7 +62,7 @@
 </a>
 
 <!-- LAUNCH BUTTON -->
-<launch-button data-href="{{widget.url}}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+<launch-button data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
                data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/portal/widgets/partials/type__weather.html
+++ b/components/portal/widgets/partials/type__weather.html
@@ -87,6 +87,6 @@
 
 <!-- Launch app button -->
 <launch-button data-href="{{ ::widget.url }}"
-               data-target="{{ widget.target ? widget.target : '_self' }}"
+               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="Launch full app"
                data-aria-label="Launch weather app"></launch-button>

--- a/components/staticFeeds/sample-widget__list-of-8-links.json
+++ b/components/staticFeeds/sample-widget__list-of-8-links.json
@@ -3,7 +3,7 @@
     "canAdd": true,
     "layoutObject": {
       "title": "List of (many) Links widget type",
-      "description": "Demonstrates presentation when seven or more links",
+      "description": "Demonstrates presentation when seven or more links and custom launchUrl, launchUrlTarget in widgetConfig",
       "url": "staticFeeds/list-of-8-links-via-url.json",
       "iconUrl": null,
       "faIcon": "fa-briefcase",
@@ -15,7 +15,9 @@
       "widgetTemplate": null,
       "widgetConfig": {
         "getLinksURL": "true",
-        "launchText": "View widget JSON"
+        "launchText": "Custom launchText",
+        "launchUrl" : "https://www.example.edu/custom/launchUrl/shouldOpenInNewTab",
+        "launchUrlTarget" : "_blank"
       },
       "widgetExternalMessageUrl": "/staticFeeds/sample-widget_message.json",
       "widgetExtneralMessageTextObjectLocation": ["result", 0, "message"],

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -698,6 +698,7 @@ reads its `widgetTemplate` as per normal. This means that a `switch` widget can 
 ## Other configuration common across widget types
 
 ### Launch button text
+
 If you provide a `widgetConfig` with any defined widget type (i.e. not a custom widget) with a value for `launchText`, it will replace the text of the
 launch button with the provided value, even for non-widgets. Use sentence case in launch button text.
 

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -704,6 +704,30 @@ launch button with the provided value, even for non-widgets. Use sentence case i
 
 Read more about the [launch button best practices](widget-launch-button.md).
 
+### Launch button URL
+
+Likewise, `launchUrl` in `widgetConfig` will customize the URL that the launch
+bar links to, but *only in the context of the expanded mode widget*. This
+overrides the widget `alternativeMaximizedLink`, only in the context of
+rendering the expanded-mode widget.
+
+Therefore specifying both `alternativeMaximizedLink` and
+`widgetConfig.launchUrl` is a way to configure the app directory entry to launch
+to either of two URLs, the `launchUrl` in the context of the expanded mode widget
+and the `alternativeMaximizedLink` in all other contexts. The
+`alternativeMaximizedLink` could even link to the expanded mode widget.
+
+Like `launchText`, this doesn't automatically work for `custom`-type widgets. A
+custom widget template could implement this feature but is not guaranteed to
+have done so.
+
+`config.launchUrlTarget` overrides widget `target` like how `config.launchUrl`
+overrides widget `alternativeMaximizedLink`.
+
+Neither `launchUrl` nor `launchUrlTarget` have effect in option-link type widgets,
+because such widgets dynamically set the launch URL depending upon the option
+the user selects.
+
 ### Maintenance mode
 If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
 add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display


### PR DESCRIPTION
Adds support for new `widgetConfig` fields `launchUrl` and `launchUrlTarget`, parallel to `launchText`, that further customize the expanded mode widget launch bar.

Allows specifying that the expanded mode widget launch bar should link elsewhere than the `alternativeMaximizedLink` of the overall `portlet-definition`. So that, say, the alt max link can link to the expanded mode of the widget, and then the expanded mode widget can link to somewhere that is not the expanded mode widget, for those cases where the expanded mode widget is the next thing to launch when it's not what you're currently looking at.

<img width="685" alt="Screen Shot 2019-05-08 at 2 55 17 PM" src="https://user-images.githubusercontent.com/952283/57404527-c331b980-71a1-11e9-8657-e8fe74cce62c.png">


----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
