### PR TITLE
fix: rm myuw-help-link web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ and this project adheres to
 + Adds myuw-banner component to consume feed from myuw-banner-messages-back-end.
   Optionally set new `SERVICE_LOC.bannersURL` to opt in to this feature; without
   that setting nothing changes. (#891, #893)
-+ Adds `myuw-help-link` web component 1.x as dependency available in page
-  (#894, #896)
 + Upgrades "Loading" splash screen to show a content preview (#898)
 + Upgrade banner component to latest version (#899)
 + Adds optional `launchUrl` and `launchUrlTarget` fields to `widgetConfig`,

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -41,10 +41,6 @@
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.1.1/dist/myuw-banner.min.mjs"></script>
 <script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.1.1/dist/myuw-banner.min.js"></script>
 
-<script type="module" src="/static/web-components/myuw/myuw-help-link/1-x/myuw-help-link.min.mjs"></script>
-<script nomodule src="/static/web-components/myuw/myuw-help-link/1-x/myuw-help-link.min.js"></script>
-
-
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css"/>
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.1/angular-material.min.css"/>


### PR DESCRIPTION
It turns out `myuw-help-link` is no longer used anywhere, and so doesn't need to be included in the page by the framework.

(It didn't reliably render in hrs-portlets, workaround was to implement the UI component as a custom JSP tag instead.)

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
