### PR TITLE
fix: move the sr-only h1 loading message into div conditioned on loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
   [myuw-banner-message-backend][]. Optionally set new `SERVICE_LOC.bannersURL`
   to opt in to this feature; without that setting nothing changes.
   (#891, #893, #899)
-+ Upgrades "Loading" splash screen to show a content preview (#898)
++ Upgrades "Loading" splash screen to show a content preview (#898, #907)
 + Adds optional `launchUrl` and `launchUrlTarget` fields to `widgetConfig`,
   parallel to existing `launchText`. These customize the launch bar URL and
   target, only in the expanded mode of non-custom non-option-link widgets.

--- a/components/static.html
+++ b/components/static.html
@@ -180,8 +180,8 @@
 </script>
 
 <!-- Loading state -->
-<h1 class="sr-only">The application is getting ready...</h1>
 <div ng-hide="portal.loading.hidden" ng-class="{slowfade: portal.loading.startFade}" class="skeleton" id="loading-splash">
+  <h1 class="sr-only">The application is getting ready...</h1>
         <!--No javascript enabled-->
         <noscript>
             <div class="no-js" role="alert">


### PR DESCRIPTION
#898 changed the loading indicator. It introduced a for-typical-browsers visual experience that disappears when loading completes. It also introduced a screen-reader-only h1 indicating that the page is loading, bugged such that the h1 persists after the application has fully loaded.

This change moves that screen-reader-only `<h1` into the `<div` predicated on loading, so that screen readers and typical browsers have a more equivalent experience of the loading indicator.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked internally to MyUW as [MUMUP-3469](https://jira.doit.wisc.edu/jira/browse/MUMUP-3469).