### PR TITLE
docs: add reminder to examine changes for security impact to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 ----
 
+Review for security considerations
+
+<!-- Place an x in the checkbox for YES. -->
+
+- [ ] The change has been examined for security impact.
+
 PR considerations checklist:
 
 <!-- Place an x in the checkbox for YES. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to
   from 1.1.11, thereby picking up a bunch of little bug fixes
 + fix: update FontAwesome version to [5.0.13](https://github.com/uPortal-Project/uportal-app-framework/pull/925)
 
+### Development process change
+
++ Added checkbox to Pull Request template reminding to consider security
+  implications of change. Need for checks to ensure considering security
+  implications of change was flagged in UW Cybersecurity Risk Management
+  Framework review of MyUW; this is one tiny process change to partially
+  address that finding. (#908)
+
 ## [12.2.0][] - 2019-06-07
 
 + feature: new `remote-content` widget type


### PR DESCRIPTION
Review of MyUW against the (UW Office of Cybersecurity) [Risk Management Framework](https://it.wisc.edu/about/division-of-information-technology/strategic-operations-departments-people/cybersecurity/risk-management-framework) flagged a need to add process to ensure changes are reviewed for security impact.

This PR would add a checkbox to the Pull Request template to remind to examine changes for security impact.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

---- 

Tracked internally to MyUW as [MUMMNG-4658](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4658).