### PR TITLE
feat: invent `list-of-links` `widgetConfig.suppressLaunchButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [unreleased][]
 
++ feature: in `list-of-links` widget type, new `widgetConfig` option
+  `suppressLaunchButton` which will make the widget omit the launch button
+  across the bottom of the widget.
++ documentation: stop documenting that omitting `launchText` in `list-of-links`
+  widgets would supress the widget launch button. This didn't work and instead
+  such list-of-links widgets would use default launch button text.
+
 ## [12.1.0][] - 2019-05-10
 
 ### Deprecations in 12.1.10

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -82,7 +82,7 @@
 <!-- LAUNCH BUTTON
   suppress in cases where collapsed to basic-widget, which rendered its own launch button -->
 <launch-button
-  ng-show="config.links.length > 1 || (config.links.length !=1 || config.links[0].href != widget.url)"
+  ng-show="config.links.length !=1 || config.links[0].href != widget.url"
                data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
                data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
                data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -82,7 +82,8 @@
 <!-- LAUNCH BUTTON
   suppress in cases where collapsed to basic-widget, which rendered its own launch button -->
 <launch-button
-  ng-show="config.links.length !=1 || config.links[0].href != widget.url"
+  ng-show="!config.suppressLaunchButton &&
+    (config.links.length !=1 || config.links[0].href != widget.url)"
   data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
   data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
   data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"

--- a/components/portal/widgets/partials/type__list-of-links.html
+++ b/components/portal/widgets/partials/type__list-of-links.html
@@ -83,7 +83,7 @@
   suppress in cases where collapsed to basic-widget, which rendered its own launch button -->
 <launch-button
   ng-show="config.links.length !=1 || config.links[0].href != widget.url"
-               data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
-               data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
-               data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
-               data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>
+  data-href="{{config.launchUrl ? config.launchUrl : widget.url}}"
+  data-target="{{ config.launchUrlTarget ? config.launchUrlTarget : widget.target ? widget.target : '_self' }}"
+  data-button-text="{{ config.launchText ? config.launchText : 'Launch full app' }}"
+  data-aria-label="{{ 'Launch ' + widget.title }}"></launch-button>

--- a/components/staticFeeds/sample-widget__list-of-links.json
+++ b/components/staticFeeds/sample-widget__list-of-links.json
@@ -15,7 +15,7 @@
       "widgetTemplate": null,
       "widgetConfig": {
         "getLinksURL": "true",
-        "launchText": "View widget JSON"
+        "suppressLaunchButton": true
       },
       "widgetExternalMessageUrl": "/staticFeeds/sample-widget_message.json",
       "widgetExtneralMessageTextObjectLocation": ["result", 0, "message"],

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -210,10 +210,11 @@ Example of how the `widgetURL` should respond (note the `content.links` path):
 
 #### Guidance about `list-of-links`
 
-* Omitting `launchText` suppresses the launch button
-  at the bottom of the list-of-links widget. This is appropriate when there's
-  nothing more to launch, that is, when the list-of-links widget presents
-  all the intended links and that's all there is to it.
+* Setting `suppressLaunchButton` in widgetConfig to a truthy value suppresses
+  the launch button at the bottom of the list-of-links widget. This is
+  appropriate when there's nothing more to launch, that is, when the
+  list-of-links widget presents all the intended links and that's all there is
+  to it.
 * Avoid using a `list-of-links` widget to display one link.
   Instead, use the name and `alternativeMaximizedLink` of
   [the app directory entry](http://uportal-project.github.io/uportal-home/app-directory)


### PR DESCRIPTION
There's long been a documented feature of `list-of-links` that would suppress the expanded mode widget launch button (bar) in the case where `widgetConfig.launchText` is not set.

That feature didn't actually work. But the Thumper Principle is a pretty good one. When the launch bar adds no value beyond the foregoing list-of-links, we should not show it. So this pull request (re-)adds the feature, this time triggering it more explicitly so that omitting `launchText` can continue to yield the default show-launch-button-with-default-text behavior.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
