### PR TITLE
add remote-content widget type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [unreleased][]
 
++ feature: new `remote-content` widget type
 + feature: in `list-of-links` widget type, new `widgetConfig` option
   `suppressLaunchButton` which will make the widget omit the launch button
   across the bottom of the widget.

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -167,6 +167,16 @@
         </div>
       </div>
 
+      <h3 style="margin-left:26px">
+        Example remote-content widget in expanded mode</h3>
+        <div style="margin-left:26px">remote-content widgets render arbitrary markup sourced from a URL.</div>
+        <div layout="row" layout-align="center start"
+          style="flex-wrap:wrap;padding:18px;">
+          <div flex-xs="100" class="widget-container">
+            <widget fname="sample-widget__remote"></widget>
+          </div>
+        </div>
+
     <h2 style="margin-left:26px">Example compact mode widgets</h2>
     <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
         <div flex-xs="100" class="widget-container">

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -101,7 +101,7 @@
 
     <h3 style="margin-left:26px">
       Example `time-sensitive-content` widgets in expanded mode</h3>
-      <div style="margin-left:26px">`time-sensitive-content` widgets render 
+      <div style="margin-left:26px">`time-sensitive-content` widgets render
         different content depending upon the date.</div>
       <div layout="row" layout-align="center start"
         style="flex-wrap:wrap;padding:18px;">
@@ -124,7 +124,7 @@
 
       <h3 style="margin-left:26px">
         Example `action-items` widgets in expanded mode</h3>
-      <div style="margin-left:26px">`action-items` widgets render indicators of quantities. Individual quantity 
+      <div style="margin-left:26px">`action-items` widgets render indicators of quantities. Individual quantity
       indicators fail independently. When there are more items than can be displayed, `action-items` prioritizes items that are not failing.</div>
       <div layout="row" layout-align="center start"
         style="flex-wrap:wrap;padding:18px;">
@@ -138,15 +138,15 @@
           <widget fname="sample-widget__action-items_many"></widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <widget 
+          <widget
             fname="sample-widget__action-items_partially-broken"></widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <widget 
+          <widget
             fname="sample-widget__action-items_totally-broken"></widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <widget 
+          <widget
             fname="sample-widget__action-items_empty-string"></widget>
         </div>
       </div>
@@ -154,8 +154,8 @@
 
     <h3 style="margin-left:26px">
       Example custom widgets in expanded mode</h3>
-      <div style="margin-left:26px">custom widgets render arbitrary AngularJS 
-        templates optionally applied to dynamic JSON. `generic` is a deprecated 
+      <div style="margin-left:26px">custom widgets render arbitrary AngularJS
+        templates optionally applied to dynamic JSON. `generic` is a deprecated
         alias for the `custom` widget type.</div>
       <div layout="row" layout-align="center start"
         style="flex-wrap:wrap;padding:18px;">
@@ -235,28 +235,28 @@
         </div>
 
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_one"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_three"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_many"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_partially-broken">
           </compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_totally-broken"></compact-widget>
         </div>
         <div flex-xs="100" class="widget-container">
-          <compact-widget 
+          <compact-widget
             fname="sample-widget__action-items_empty-string"></compact-widget>
         </div>
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -1042,5 +1042,32 @@ define(['angular', 'moment'], function(angular, moment) {
     } else {
       $log.warn('WeatherWidgetController did not receive a widgetURL');
     }
-  }]);
+  }])
+
+  .controller('RemoteContentWidgetController', [
+    '$scope', '$http', '$log',
+    function($scope, $http, $log) {
+      var initRemoteContentWidget = function() {
+        $scope.loading = true;
+        $log.debug('entered initRemoteContentWidget()');
+
+
+        $http.get($scope.widget.widgetURL).then(function(result) {
+          $scope.remoteContent = result.data;
+          $scope.loading = false;
+          $log.debug(
+            'Got [' + result.data + '] from [' +
+            $scope.widget.widgetURL + ']' );
+          return result;
+        }).catch(function(error) {
+          $scope.remoteContentErrors = error;
+          $log.error(error);
+          return error;
+        }
+        );
+      };
+
+      initRemoteContentWidget();
+    }]
+  );
 });

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -213,6 +213,18 @@ define(['angular', 'require'], function(angular, require) {
     };
   })
 
+  .directive('remoteContentWidget', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        widget: '=app',
+        config: '=config',
+      },
+      templateUrl: require.toUrl('./partials/type__remote-content.html'),
+      controller: 'RemoteContentWidgetController',
+    };
+  })
+
   .directive('basicWidget', function() {
     return {
       restrict: 'E',

--- a/components/portal/widgets/partials/type__remote-content.html
+++ b/components/portal/widgets/partials/type__remote-content.html
@@ -1,0 +1,33 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<div
+  ng-show="!remoteContentErrors && loading"
+  class="widget-body">
+  <div  layout="row" layout-align="center center">
+    <loading-gif data-object="remoteContent"></loading-gif>
+  </div>
+</div>
+
+<div ng-show="!remoteContentErrors && !loading" ng-bind-html="::remoteContent"></div>
+
+<basic-widget
+  ng-show="remoteContentErrors"
+  app="widget" config="widget.widgetConfig"></basic-widget>

--- a/components/portal/widgets/partials/widget-content.html
+++ b/components/portal/widgets/partials/widget-content.html
@@ -25,6 +25,7 @@
   <list-of-links ng-switch-when="list-of-links" app="widget" config="widget.widgetConfig"></list-of-links>
   <search-with-links ng-switch-when="search-with-links" app="widget" config="widget.widgetConfig"></search-with-links>
   <weather-widget ng-switch-when="weather" app="widget" config="widget.widgetConfig"></weather-widget>
+  <remote-content-widget ng-switch-when="remote-content" app="widget" config="widget.widgetConfig"></remote-content-widget>
 
   <!-- switch widget calls the same file as a template or shows loading -->
   <loading-gif ng-if="switching" ng-switch-when="switch"></loading-gif>

--- a/components/portal/widgets/partials/widget-content.html
+++ b/components/portal/widgets/partials/widget-content.html
@@ -25,12 +25,12 @@
   <list-of-links ng-switch-when="list-of-links" app="widget" config="widget.widgetConfig"></list-of-links>
   <search-with-links ng-switch-when="search-with-links" app="widget" config="widget.widgetConfig"></search-with-links>
   <weather-widget ng-switch-when="weather" app="widget" config="widget.widgetConfig"></weather-widget>
-  
+
   <!-- switch widget calls the same file as a template or shows loading -->
   <loading-gif ng-if="switching" ng-switch-when="switch"></loading-gif>
-  <switch-widget ng-if="!switching" ng-switch-when="switch" 
+  <switch-widget ng-if="!switching" ng-switch-when="switch"
     app="widget" config="widget.widgetConfig"></switch-widget>
-  
+
 
   <!-- `generic` is a deprecated alias for `custom` widget type -->
   <div ng-switch-when="generic" class="custom-widget" ng-controller="CustomWidgetController as customWidgetCtrl">

--- a/components/staticFeeds/remoteWidgetExample.html
+++ b/components/staticFeeds/remoteWidgetExample.html
@@ -1,0 +1,2 @@
+<div class='widget-body'>Arbitrary markup sourced from a URL</div>
+<a class='launch-app-button' target='_blank' href='staticFeeds/sample-widget__remote.json'>View widget JSON</a>

--- a/components/staticFeeds/remoteWidgetExample.html
+++ b/components/staticFeeds/remoteWidgetExample.html
@@ -1,2 +1,22 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <div class='widget-body'>Arbitrary markup sourced from a URL</div>
 <a class='launch-app-button' target='_blank' href='staticFeeds/sample-widget__remote.json'>View widget JSON</a>

--- a/components/staticFeeds/sample-widget__remote.json
+++ b/components/staticFeeds/sample-widget__remote.json
@@ -1,0 +1,56 @@
+{
+  "entry": {
+    "canAdd": false,
+    "layoutObject": {
+      "title": "remote-content widget",
+      "description": "`remote-content` type widgets render abritrary markup sourced from a URL",
+      "url": "/staticFeeds/sample-widget__remote.json",
+      "iconUrl": null,
+      "faIcon": "fa-credit-card-alt",
+      "fname": "sample-widget__remote",
+      "lifecycleState": "PUBLISHED",
+      "target": "_blank",
+      "widgetURL": "/staticFeeds/remoteWidgetExample.html",
+      "widgetType": "remote-content",
+      "widgetConfig": {
+      },
+      "altMaxUrl": true,
+      "renderOnWeb": false
+    },
+    "categories": [
+      "Applications"
+    ],
+    "portletName": "cms",
+    "title": "remote-content widget",
+    "keywords": [
+      "money",
+      "wisccard",
+      "wiscard",
+      "balance",
+      "deposit"
+    ],
+    "fname": "sample-widget__remote",
+    "rating": 0.0,
+    "lifecycleState": "PUBLISHED",
+    "portletReleaseNotes": {
+      "releaseDate": null,
+      "initialReleaseDate": null,
+      "releaseNotes": null
+    },
+    "renderUrl": "https://online.wiscard.wisc.edu/login.php?cid=120",
+    "portletWebAppName": "/SimpleContentPortlet",
+    "maxUrl": "https://online.wiscard.wisc.edu/login.php?cid=120",
+    "shortUrl": null,
+    "marketplaceScreenshots": [
+
+    ],
+    "userRated": 0,
+    "mdIcon": "build",
+    "relatedPortlets": [],
+    "description": "`remote-content` type widgets render abritrary markup sourced from a URL",
+    "name": "Remote widget",
+    "id": "6796",
+    "type": "Portlet",
+    "target": "_blank"
+  }
+}

--- a/docs/make-a-widget.md
+++ b/docs/make-a-widget.md
@@ -862,6 +862,35 @@ By doing just this we were able to generate:
 
 ![custom widget](./img/custom-widget.png)
 
+## remote-content widgets
+
+The `remote-content` widget type sources a URL for the widget content, allowing
+generating the widget content server-side.
+
+```xml
+<portlet-preference>
+    <name>widgetType</name>
+    <value>remote-content</value>
+</portlet-preference>
+```
+
+```xml
+<portlet-preference>
+  <name>widgetURL</name>
+  <value>/hrs-integration/widgets/benefit-information.html</value>
+</portlet-preference>
+```
+
+While waiting for the asynchronous request to the `widgetURL`, the
+remote-content widget type shows a loading indicator.
+
+The remote content should include the widget launch button if appropriate. The
+`remote-content` widget template will not provide a launch button except in the
+error case. The widget will use literally the markup responded from the
+`widgetURL` as the widget markup.
+
+If the asynchronous request receives an error response, `remote-content` falls
+back on rendering as if it were at `basic` widget.
 
 [rssToJson]: https://github.com/UW-Madison-DoIT/rssToJson
 [documentation about the app directory]: http://uportal-project.github.io/uportal-home/app-directory.html


### PR DESCRIPTION
Adds new widget type `remote-content` that shows a loading indicator until it can swap in markup sourced from a URL.

With this technology, widgets can be implemented in JSP, PHP, ...

It's a hammer. Not every problem is a nail. Some are. 🔨  💅 

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
