### PR TITLE
Change prompt text within search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 + feature: new optional `fail-silently` attribute on `widget` directive
   enables invoking a `widget` in contexts where it's not certain that the
   viewing user has permission on the widget or that it even exists
+
++ tweak: Changes search bar prompt text to "Search for apps by keyword..." from
+  "Search MyUW" (#922)
+
 + fix: upgrade `AngularJS` dependency to
   [1.7.8](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#178-enthusiastic-oblation-2019-03-11)
   from 1.7.2, thereby picking up a bunch of little bug fixes

--- a/components/portal/search/partials/search.html
+++ b/components/portal/search/partials/search.html
@@ -59,7 +59,7 @@
     </md-button>
     <input type="search"
            name="initialFilter"
-           placeholder="Search {{portal.theme.title}}"
+           placeholder="Search for apps by keyword..."
            ng-model="vm.initialFilter"
            aria-label="Search bar enter the app you are looking for"
            autocomplete="off">


### PR DESCRIPTION
Clarifies what sort of searching users might do. Intended to make the search bar more usable by giving users more of a hint of what they might usefully type in that box.

"Search for apps by keyword..."

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

[MUMUP-3489](https://jira.doit.wisc.edu/jira/browse/MUMUP-3489) as tracked internally to the MyUW project.
