### PR TITLE
fix: upgrade to angularjs 1.7.8 from 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [unreleased][], putatively 12.3.0
 
++ fix: upgrade `AngularJS` dependency to
+  [1.7.8](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#178-enthusiastic-oblation-2019-03-11)
+  from 1.7.2, thereby picking up a bunch of little bug fixes
 + fix: upgrade `angular-material` dependency to
   [1.1.19](https://github.com/angular/material/blob/master/CHANGELOG.md#1119-2019-05-31)
   from 1.1.11, thereby picking up a bunch of little bug fixes

--- a/components/config.js
+++ b/components/config.js
@@ -32,9 +32,9 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
   }
 
   var framePaths = {
-      'angular': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular.min',
-      'angular-animate': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular-animate.min',
-      'angular-mocks': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular-mocks',
+      'angular': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular.min',
+      'angular-animate': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-animate.min',
+      'angular-mocks': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-mocks',
       'angulartics': 'https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.1.0/angulartics.min',
       'angulartics-google-analytics': [
           'https://cdnjs.cloudflare.com/ajax/libs/angulartics-google-analytics/0.2.1/angulartics-ga.min',
@@ -42,10 +42,10 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       ],
       'jquery': 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min',
       'jquery-ui': 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min',
-      'ngAria': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular-aria.min',
+      'ngAria': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-aria.min',
       'ngMaterial': 'https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.19/angular-material.min',
-      'ngRoute': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular-route.min',
-      'ngSanitize': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.2/angular-sanitize.min',
+      'ngRoute': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-route.min',
+      'ngSanitize': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-sanitize.min',
       'ngStorage': 'https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.10/ngStorage.min',
       'ui-bootstrap': 'https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.2.0/ui-bootstrap-tpls.min',
       'ui-gravatar': 'https://cdnjs.cloudflare.com/ajax/libs/angular-gravatar/0.4.2/angular-gravatar.min',


### PR DESCRIPTION
Upgrades to [AngularJS 1.7.8](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#178-enthusiastic-oblation-2019-03-11) from 1.7.2, picking up some bug fixes.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
