### PR TITLE
Add optional `fail-silently` attribute on `widget` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [unreleased][], putatively 12.3.0
 
++ feature: new optional `fail-silently` attribute on `widget` directive
+  enables invoking a `widget` in contexts where it's not certain that the
+  viewing user has permission on the widget or that it even exists
 + fix: upgrade `AngularJS` dependency to
   [1.7.8](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#178-enthusiastic-oblation-2019-03-11)
   from 1.7.2, thereby picking up a bunch of little bug fixes

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -177,6 +177,22 @@
           </div>
         </div>
 
+
+    <h3 style="margin-left:26px">
+      Example failing silently when so configured</h3>
+      <div style="margin-left:26px">Demonstrates fail-silently attribute
+        on widget directive. There are two widgets here with bogus fnames,
+        but the second has fail-silently true, so it silently disappears.</div>
+      <div layout="row" layout-align="center start"
+        style="flex-wrap:wrap;padding:18px;">
+        <div flex-xs="100" class="widget-container">
+          <widget fname="no-exist-1"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="no-exist-2" fail-silently="true"></widget>
+        </div>
+      </div>
+
     <h2 style="margin-left:26px">Example compact mode widgets</h2>
     <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
         <div flex-xs="100" class="widget-container">

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -90,8 +90,11 @@ define(['angular', 'moment'], function(angular, moment) {
      * from the provided fname attribute, makes transcluded content
      * focusable
      * @param {string} fname
+     * @param {string} failSilently
      */
-    $scope.initializeWidget = function(fname) {
+    $scope.initializeWidget = function(fname, failSilently) {
+
+      $log.error("For name " + fname + " failSilently is " + failSilently);
       // Initialize scope variables
       $scope.widget = {};
       $scope.widgetType = '';
@@ -105,6 +108,7 @@ define(['angular', 'moment'], function(angular, moment) {
           if (data) {
             $scope.widget = data;
             $scope.widgetType = widgetType(data);
+            $scope.failSilently = failSilently;
           }
           // If there's a remove button, make it focusable by keyboard
           if ($transclude.isSlotFilled('removeButton')) {
@@ -122,7 +126,7 @@ define(['angular', 'moment'], function(angular, moment) {
     };
 
     // Initialize the widget
-      $scope.initializeWidget($scope.fname);
+      $scope.initializeWidget($scope.fname, $scope.failSilently);
   }])
 
   /**

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -32,6 +32,7 @@ define(['angular', 'require'], function(angular, require) {
       },
       scope: {
         fname: '@',
+        failSilently: '@?',
       },
       templateUrl: require.toUrl('./partials/widget-card.html'),
       controller: 'WidgetCardController',

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -18,7 +18,9 @@
     under the License.
 
 -->
-<md-card class="widget-frame" id="widget-id-{{ widget.fname }}" aria-label="{{ widget.title }} widget">
+<md-card id="widget-id-{{ widget.fname }}" aria-label="{{ widget.title }} widget"
+  ng-hide="failSilently && widget.widgetConfig && widget.widgetConfig.error"
+  class="widget-frame" >
 
   <!-- MAINTENANCE MODE OVERLAY -->
   <div class="overlay__widget-mode" ng-if="widget.lifecycleState === 'MAINTENANCE'">

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -66,6 +66,7 @@ define(['angular'], function(angular) {
         mdIcon: 'help',
         widgetType: 'generic',
         widgetConfig: {
+          error: true,
           additionalText: 'Please contact your help desk if you ' +
             'feel you should be able to access this content',
         },


### PR DESCRIPTION
This allows invoking `<widget>` in contexts where it's not clear the viewing user will be able to see that widget or even that the widget exists at all. Imagine pages with suggested widgets that gracefully degrade to what's working and permitted to the viewing user.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
