### PR TITLE
fix(messages): remove broken experimental `recurrence` property of msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Web Components rather than in AngularJS-specific Directives. However,
   **some icon choices may need to be changed**. In particular, some icon  name
   aliases and modifier suffixes are not supported.
 
+BREAKING CHANGE: `recurrence` flag on messages that had been "experimental" in
+prior releases is removed in this release. It had not been working reliably.
+
 Also in this release:
 
 + feature: new optional `fail-silently` attribute on `widget` directive

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -260,14 +260,6 @@ define(['angular'], function(angular) {
               allNotifications,
               result.seenMessageIds
             );
-            angular.forEach(separatedNotifications.seen, function(message) {
-              if (message.recurrence) {
-                var index = separatedNotifications.seen
-                  .indexOf(message);
-                separatedNotifications.unseen.push(message);
-                separatedNotifications.seen.splice(index, 1);
-              }
-            });
 
             // Set scope notifications and dismissed notifications
             vm.notifications = separatedNotifications.unseen;

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -60,7 +60,6 @@ define(['angular'], function(angular) {
          * @property {string} goLiveDate
          * @property {string} expireDate
          * @property {string} priority
-         * @property {Boolean} recurrence
          * @property {Boolean} dismissible
          * @property {Object} actionButton
          * @property {Object} moreInfoButton

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -20,7 +20,6 @@ point uportal-app-framework to your desired feed.
             "goLiveDate": "2017-08-01T09:30",
             "expireDate": "2017-08-02",
             "priority": "high",
-            "recurrence": true,
             "dismissible": false,
             "audienceFilter": {
                 "groups": ["Users - Service Activation Required"],
@@ -66,12 +65,6 @@ point uportal-app-framework to your desired feed.
 - **expireDate**: *(optional)* ISO date, including time (as pictured). The
   message will display only before this moment.
 - **priority**: DEPRECATED "high" triggers higher visibility
-- **recurrence**: *(experimental, optional)* If true, even if a notification is
-  dismissed, it will continue to reoccur in the user's home at the start of
-  every session until the user is no longer a member of the targeted group. For
-  example, if a user is a member of students-with-outstanding-parking-tickets,
-  that user will be confronted with the notification at every login until they
-  pay the fine.
 - **dismissible**: *(experimental, optional)* `false` prevents dismissing the
   notification. If `true` or not set at all, the notification will be
   dismissible.


### PR DESCRIPTION
Not reliably working: rather than dismissing for session, dismissing a recurrence=true message would result in the message immediately being un-dismissed.

----

Low security risk: this change is about whether and how a message displays has handled client-side in the UI, not about whether the message is available to the client in the first place.

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

----

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked internally to MyUW as [MUMUP-3491](https://jira.doit.wisc.edu/jira/browse/MUMUP-3491).