### PR TITLE
Revert "feat: use new myuw-compact-card web component (#932)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,6 @@ and this project adheres to
 
 ## [unreleased][], putatively 13.0.0
 
-WARNING: Depends upon `myuw-compact-card` 1.x which is unstable. Switch to
-depending upon a specific version (or move to a stable version series) before
-releasing app-framework.
-
-BREAKING CHANGE: uses `myuw-compact-card` to implement compact mode widget
-display. This is a step towards implementing MyUW in something other than
-AngularJS, by implementing the UI pieces in not-AngularJS-specific
-Web Components rather than in AngularJS-specific Directives. However,
-
-+ Deleting cards from the layout in compact card mode is temporarily
-  unsupported. Attempting to do so shows an alert apologizing.
-+ Font Awesome icon support in `myuw-compact-card` does not precisely match that
-  in the prior implementation of the compact card directive, so upon migrating
-  to this version of the app framework
-  **some icon choices may need to be changed**. In particular, some icon  name
-  aliases and modifier suffixes are not supported.
-
 BREAKING CHANGE: `recurrence` flag on messages that had been "experimental" in
 prior releases is removed in this release. It had not been working reliably.
 

--- a/components/portal/widgets/partials/compact-widget-card.html
+++ b/components/portal/widgets/partials/compact-widget-card.html
@@ -18,29 +18,31 @@
     under the License.
 
 -->
-<myuw-compact-card ng-if="widget && widget.mdIcon"
-id="{{::widget.fname}}-myuw-compact-card"
-title="{{::widget.title}}"
-uid="{{::widget.fname}}"
-url="{{::widget.url}}"
-md-icon="{{::widget.mdIcon}}"></myuw-compact-card>
-
-<myuw-compact-card ng-if="widget && !widget.mdIcon && widget.faIcon"
-id="{{::widget.fname}}-myuw-compact-card"
-title="{{::widget.title}}"
-uid="{{::widget.fname}}"
-url="{{::widget.url}}"
-fa-icon="{{::widget.faIcon | limitTo : 100 : 3}}"></myuw-compact-card>
-
-<myuw-compact-card ng-if="widget && !widget.mdIcon && !widget.faIcon && widget.iconUrl"
-id="{{::widget.fname}}-myuw-compact-card"
-title="{{::widget.title}}"
-uid="{{::widget.fname}}"
-url="{{::widget.url}}"
-svg-icon="{{::widget.iconUrl}}"></myuw-compact-card>
-
-<myuw-compact-card ng-if="widget && !widget.mdIcon && !widget.faIcon && !widget.iconUrl"
-id="{{::widget.fname}}-myuw-compact-card"
-title="{{::widget.title}}"
-uid="{{::widget.fname}}"
-url="{{::widget.url}}"></myuw-compact-card>
+<md-card class="list-content" id="widget-id-{{::widget.fname}}">
+  <!-- Widget contextual menu -->
+  <md-menu class="widget-action" md-position-mode="target-right bottom">
+    <md-button class="md-icon-button" aria-label="open {{ widget.title }} menu" ng-click="$mdOpenMenu($event)">
+      <md-tooltip class="widget-action-tooltip" md-direction="top" role="tooltip">
+        Open {{ widget.title }} menu
+      </md-tooltip>
+      <md-icon>more_vert</md-icon>
+    </md-button>
+    <md-menu-content class="widget-menu" width="4">
+      <md-menu-item class="widget-description" md-autofocus tabindex="1" layout="row" layout-align="start center">
+        <md-icon>info</md-icon>
+        <span><strong>{{ widget.title }}:</strong> {{ widget.description }}</span>
+      </md-menu-item>
+      <!-- Remove widget button -->
+      <div role="button" tabindex="{{ tabindex }}" ng-transclude="removeButton" ng-keyup="triggerRemoveButton($event)"></div>
+    </md-menu-content>
+  </md-menu>
+  <!-- Widget clickable area -->
+  <a aria-labelledby="appTitle_widget.title-{{::widget.fname}}" tabindex="0" ng-href="{{widget.url}}" target="{{::widget.target}}" rel="noopener noreferrer">
+    <div class="icon-container">
+      <widget-icon></widget-icon>
+    </div>
+    <div class="list-item-container">
+      <h4 id="appTitle_widget.title-{{::widget.fname}}">{{ ::widget.title }}</h4>
+    </div>
+  </a>
+</md-card>

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -30,11 +30,6 @@ define(['angular'], function(angular) {
      * @property {string} learnMoreUrl
     */
 
-   // eslint-disable-next-line angular/document-service
-   document.addEventListener('deleteCardNotify', function() {
-    // eslint-disable-next-line angular/document-service
-    document.defaultView.alert('Sorry! Removing a tile from your layout in compact display mode is temporarily unsupported. Switch to expanded widget mode to enable removing content from your layout. Learn more about widget display modes at https://kb.wisc.edu/myuw/51574 .');
-  });
     /**
      * Get the a single app's full entity file as JSON
      * @param {string} fname - The app's fname value (<fname> in entity files)


### PR DESCRIPTION
This reverts commit 9643edefefb904c34b5e02e908680bdf949a5ba4.

This backs out using the `myuw-compact-card` web component to implement compact cards, thereby avoiding the regressions and incomplete icon support in compact mode introduced by that attempt at implementing that feature as a web component.

Attempting to get stable with a more modest framework changeset to ship a release.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
