### PR TITLE
fix: source myuw-help via https rather than http

### DIFF
--- a/components/head-static.html
+++ b/components/head-static.html
@@ -42,8 +42,8 @@
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.1.1/dist/myuw-banner.min.mjs"></script>
 <script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.1.1/dist/myuw-banner.min.js"></script>
 
-<script type="module" src="http://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.1/myuw-help.min.mjs"></script>
-<script nomodule src="http://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.1/myuw-help.min.js"></script>
+<script type="module" src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.1/myuw-help.min.mjs"></script>
+<script nomodule src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.1/myuw-help.min.js"></script>
 
 <script src="https://unpkg.com/@myuw-web-components/myuw-compact-card@^1"></script>
 


### PR DESCRIPTION
Fixes import of the new `myuw-help` web component to do so over https: to avoid Chrome zealously blocking the import.

![block-insecure-sourcing-myuw-help-from-cdn](https://user-images.githubusercontent.com/952283/72469208-8e501a80-37a4-11ea-8af7-a73c89873cd7.png)


----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
