### PR TITLE
docs(releasing): remove Docker release section

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,16 +78,6 @@ git push origin uportal-app-framework-maven-<version>
 + Deploy npm package to the world; `npm publish`. (if you don't have [publish rights][uportal-app-framework access on npm] contact authors)
 + Push git changes to the github via `git push origin master` and `git push origin <tag>`
 
-### Docker release
-
-Deploy a new version to `docker.doit.wisc.edu` (note the version below x.y.z should be the release version)
-
-```
-git checkout vx.y.z
-docker build -t docker.doit.wisc.edu/myuw/uportal-app-framework-superstatic:x.y.z .
-docker push docker.doit.wisc.edu/myuw/uportal-app-framework-superstatic:x.y.z
-```
-
 ### Release notes
 
 * There should now be a couple tags above the `Latest release` on [the GitHub releases page][uportal-app-framework releases]


### PR DESCRIPTION
We no longer deploy to docker.doit.wisc.edu and haven't for a long time.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
