### PR TITLE
Update overflow-y of portal-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to
 
 ## [unreleased][]
 
-No changes yet.
++ Change CSS style `portal-header` -> `overflow-y: initial`
+  rather than `overflow-y: hidden`.
 
 ## [13.1.1][] - 2020-03-06
 

--- a/components/css/buckyless/header.less
+++ b/components/css/buckyless/header.less
@@ -21,7 +21,7 @@ portal-header {
   position: sticky;
   z-index: @top-bar-1;
   top: 0;
-  overflow-y: hidden;
+  overflow-y: initial;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
 
   myuw-app-bar.has-priority-notifications {


### PR DESCRIPTION
`overflow-y: hidden` was preventing Help Dialog from proper display, on top of the app's body. This change prevents the dialog from "showing" behind the content, and being unreachable.