### PR TITLE
Resolve linting errors in travis-ci build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to
 ### Breaking Change in 14.0.0
 
 + Replace existing search form with `myuw-search` v1.5.0 from myuw-web-components library ( [#951][] )
-+ Two files related to old search form have been reemoved: components/portal/search/directives.js and components/portal/search/partials/search.html 
++ Two files related to old search form have been reemoved: components/portal/search/directives.js and components/portal/search/partials/search.html
 
 ## 13.1.2 - 2020-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,39 +6,39 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased][]
+## unreleased
 
 + No changes yet
 
-## [14.0.1][] - 2020-03-20
+## 14.0.1 - 2020-03-20
 
 + Add $scope.apply inside myuw-search event listener to notify AngularJS of the change ( [#952][] )
 
-## [14.0.0][] - 2020-03-13
+## 14.0.0 - 2020-03-13
 
 ### Breaking Change in 14.0.0
 
 + Replace existing search form with `myuw-search` v1.5.0 from myuw-web-components library ( [#951][] )
 + Two files related to old search form have been reemoved: components/portal/search/directives.js and components/portal/search/partials/search.html 
 
-## [13.1.2][] - 2020-03-09
+## 13.1.2 - 2020-03-09
 
 + Change CSS style `portal-header` -> `overflow-y: initial`
   rather than `overflow-y: hidden`. This had broken the new help dialog in
   e.g. Safari.
 
-## [13.1.1][] - 2020-03-06
+## 13.1.1 - 2020-03-06
 
 + Remove import and example usage of not-actually-used `myuw-compact-card`
   Web Component. (Apparently this was breaking support for
   recent-but-not-latest MS Edge browser.)
 + Upgrade myuw-help Web Component to version 1.5.2
 
-## [13.1.0][] - 2020-02-07
+## 13.1.0 - 2020-02-07
 
 + Add myuw-help web component to myuw-app-bar at top of page. ( [#941][] )
 
-## [13.0.0][] - 2020-01-06
+## 13.0.0 - 2020-01-06
 
 BREAKING CHANGE: `recurrence` flag on messages that had been "experimental" in
 prior releases is removed in this release. It had not been working reliably.
@@ -70,7 +70,7 @@ Also in this release:
   Framework review of MyUW; this is one tiny process change to partially
   address that finding. (#908)
 
-## [12.2.0][] - 2019-06-07
+## 12.2.0 - 2019-06-07
 
 + feature: new `remote-content` widget type
 + feature: in `list-of-links` widget type, new `widgetConfig` option
@@ -80,7 +80,7 @@ Also in this release:
   widgets would supress the widget launch button. This didn't work and instead
   such list-of-links widgets would use default launch button text.
 
-## [12.1.0][] - 2019-05-10
+## 12.1.0 - 2019-05-10
 
 ### Deprecations in 12.1.10
 
@@ -117,7 +117,7 @@ Also in this release:
 
 + Upgraded `remark-validate-links` to `^8.0.0` (#873)
 
-## [12.0.0][] - 2019-02-26
+## 12.0.0 - 2019-02-26
 
 ### Breaking change in 12.0.0
 
@@ -159,7 +159,7 @@ announcements using that feature do not automatically port forward cleanly.
 
 ### Documentation
 
-## [11.0.0][] - 2018-11-19
+## 11.0.0 - 2018-11-19
 
 ### Breaking Change in 11.0.0
 
@@ -205,7 +205,7 @@ announcements using that feature do not automatically port forward cleanly.
 + Clarified `takeActionEndDate` in `time-sensitive-content` widget documentation
   (#861)
 
-## [10.3.0][] - 2018-09-19
+## 10.3.0 - 2018-09-19
 
 ### Added in 10.3.0
 
@@ -222,7 +222,7 @@ announcements using that feature do not automatically port forward cleanly.
 + Added localhost examples of `action-items` widget type (#835)
 + Added localhost examples of `time-sensitive-content` widget type (#831)
 
-## [10.2.0][] - 2018-09-12
+## 10.2.0 - 2018-09-12
 
 ### Added in 10.2.0
 
@@ -256,7 +256,7 @@ announcements using that feature do not automatically port forward cleanly.
 
 + Removes unused photo opt-out on settings page (#811)
 
-## [10.1.1][] - 2018-08-01
+## 10.1.1 - 2018-08-01
 
 ### Changed in 10.1.1
 
@@ -271,7 +271,7 @@ announcements using that feature do not automatically port forward cleanly.
 + Action items widget type now fails gracefully when service returns non-number
   data (#807)
 
-## [10.1.0][] - 2018-07-26
+## 10.1.0 - 2018-07-26
 
 ### Added in 10.1.0
 
@@ -294,7 +294,7 @@ announcements using that feature do not automatically port forward cleanly.
 + Enable keyboard activation of widget removal button, when present (#800) &
   (#805)
 
-## [10.0.0][] - 2018-07-13
+## 10.0.0 - 2018-07-13
 
 ### Removed in 10.0.0
 
@@ -323,7 +323,7 @@ announcements using that feature do not automatically port forward cleanly.
 
 + Note in changelog message handling changes needing upgrade coordination (#733)
 
-## [9.2.1][] - 2018-06-08
+## 9.2.1 - 2018-06-08
 
 ### Changed in 9.2.1
 
@@ -341,7 +341,7 @@ announcements using that feature do not automatically port forward cleanly.
 + Added basic `<body>` styles (override Bootstrap values) to ensure Roboto is
   always preferred (#771)
 
-## [9.2.0][] - 2018-05-22
+## 9.2.0 - 2018-05-22
 
 ### Added in 9.2.0
 
@@ -374,7 +374,7 @@ announcements using that feature do not automatically port forward cleanly.
 
 + No longer used LoginOnLoad option removed (#753)
 
-## [9.1.0][] - 2018-04-17
+## 9.1.0 - 2018-04-17
 
 ### Added in 9.1.0
 
@@ -411,7 +411,7 @@ still works in this release, the new `showAllMessages` beta setting is intended
 to replace it. `disableGroupFilteringForMessages` will have no effect in some
 future release. (#742)
 
-## [9.0.2][] - 2018-03-30
+## 9.0.2 - 2018-03-30
 
 This release is to mop up some weirdness which happened with 9.0.1 and get a
 clean artifact.
@@ -422,7 +422,7 @@ clean artifact.
   (#731)
 + Fix positioning of frame-page title when using on-page side navigation (#738)
 
-## [9.0.1][] - 2018-03-29
+## 9.0.1 - 2018-03-29
 
 BREAKING CHANGE:
 
@@ -460,7 +460,7 @@ audiences for whom they may not have been intended.
 + Modest improvements to `list-of-links` widget type documentation (#727)
 + Adds glossary (#725)
 
-## [9.0.0][] - 2018-03-21
+## 9.0.0 - 2018-03-21
 
 ### Breaking changes
 
@@ -529,7 +529,7 @@ version or later to avoid showing users a broken mascot announcement experience.
 
 + About dynamically sourcing `list-of-links` widget content (#717)
 
-## [8.0.0][] - 2018-01-08
+## 8.0.0 - 2018-01-08
 
 ### Breaking Changes
 
@@ -588,7 +588,7 @@ or expired messages.
 + require npm 5.6.0 or higher (#644)
 + resolved appveyor require.js flakiness (#645)
 
-## [7.0.0][] - 2017-11-30
+## 7.0.0 - 2017-11-30
 
 ### BREAKING CHANGES
 
@@ -668,7 +668,7 @@ app framework relies upon might still use Java, of course.)
 
 + Fix a bunch of JSDoc warnings (#598)
 
-## [6.1.0][] - 2017-10-18
+## 6.1.0 - 2017-10-18
 
 ### Added in 6.1.0
 
@@ -697,11 +697,11 @@ app framework relies upon might still use Java, of course.)
   notifications/announcements (#613)
 + Clarify that side navigation subheader is not a link (#617)
 
-## [6.0.3][] - 2017-09-29
+## 6.0.3 - 2017-09-29
 
 + fix(messages): return nothing on filter fail (#554)
 
-## [6.0.2][] - 2017-09-29
+## 6.0.2 - 2017-09-29
 
 BREAKING CHANGE: This release fixes priority notifications (#553). Before
 relying upon fixed notifications in a shared messages source, all participating
@@ -714,20 +714,20 @@ URLs in priority notifications as presented in not-yet-upgraded apps.
 + renaming angularjs-portal to uportal-home (#549)
 + correct references uportal app framework (#548)
 
-## [6.0.1][] - 2017-09-25
+## 6.0.1 - 2017-09-25
 
 + Cleaning up project name relics (#538, #539, #540, #541, #542)
 + Fix typo in time-sensitive widget (#537)
 
-## [6.0.0][] - 2017-09-22
+## 6.0.0 - 2017-09-22
 
 + Renaming project to uportal-app-framework
 
-## [5.2.1][] - 2017-09-21
+## 5.2.1 - 2017-09-21
 
 + Add time-sensitive-content widget type (#524)
 
-## [5.2.0][] - 2017-09-20
+## 5.2.0 - 2017-09-20
 
 ### Messages Enhancements in 5.2.0
 
@@ -748,7 +748,7 @@ URLs in priority notifications as presented in not-yet-upgraded apps.
 + Add a changelog (#513)
 + Release using Conventional Commits (#516)
 
-## [5.1.0][] - 2017-09-01
+## 5.1.0 - 2017-09-01
 
 BREAKING CHANGES: This release adds a feature to mascot announcements for adding
 a widget to home directly from the announcement. Before relying upon this
@@ -770,7 +770,7 @@ announcements in not-yet-upgraded applications.
 + Adopts Conventional Commits (#487)
 + Adds additional project status badges (#510)
 
-## [5.0.0][] - 2017-08-24
+## 5.0.0 - 2017-08-24
 
 Version 5.0.0 of uPortal-App-Framework consists of 67 pull requests over more
 than three months of work.
@@ -890,7 +890,7 @@ return to a faster paced release cycle in the future.
 + [style(less): Add Stylelint](https://github.com/uPortal-Project/uportal-app-framework/pull/485)
 + [style(md): Add Remarklint](https://github.com/uPortal-Project/uportal-app-framework/pull/486)
 
-## [4.1.0][] - 2017-05-04
+## 4.1.0 - 2017-05-04
 
 ### Code Cleanup in 4.1.0
 
@@ -929,15 +929,15 @@ return to a faster paced release cycle in the future.
 [Fixes display bug where drop down user menu covered user's avatar](https://github.com/uPortal-Project/uportal-app-framework/pull/422)
 [Fixes display bug in user drop down menu](https://github.com/uPortal-Project/uportal-app-framework/pull/425)
 
-## [4.0.3][] - 2017-04-13
+## 4.0.3 - 2017-04-13
 
 [Fixes a bug where rss widgets would always show an error](https://github.com/uPortal-Project/uportal-app-framework/pull/397)
 
-## [4.0.2][] - 2017-04-13
+## 4.0.2 - 2017-04-13
 
 Bug fixes for a specific widget (leave balances) #395 #394
 
-## [4.0.1][] - 2017-04-13
+## 4.0.1 - 2017-04-13
 
 This release has some code cleanup and some bug fixes. Upgrade from [v4.0.0](https://github.com/uPortal-Project/uportal-app-framework/releases/tag/uw-frame-maven-4.0.0) by only updating the dependency version.
 
@@ -946,7 +946,7 @@ This release has some code cleanup and some bug fixes. Upgrade from [v4.0.0](htt
 [Ensures consistent link launch behavior in widgets](https://github.com/uPortal-Project/uportal-app-framework/pull/391)
 [Fixes bug where icons weren't showing when using the widget directive](https://github.com/uPortal-Project/uportal-app-framework/pull/393)
 
-## [4.0.0][] - 2017-04-05
+## 4.0.0 - 2017-04-05
 
 This release adds a widget directive to the app-framework, adds personalized
 notifications, progresses [Apereo](https://www.apereo.org/)
@@ -969,11 +969,11 @@ notifications, progresses [Apereo](https://www.apereo.org/)
   services being added. [See the code for more details](https://github.com/uPortal-Project/uportal-app-framework/pull/385/files).
   This will not be a concern for most applications.
 
-## [3.1.4][] - 2017-03-20
+## 3.1.4 - 2017-03-20
 
 Fixes a bug where text in a static portlet was hard to read (#380)
 
-## [3.1.3][] - 2017-03-09
+## 3.1.3 - 2017-03-09
 
 Adds back in UW-Lacrosse theming
 
@@ -981,13 +981,13 @@ Adds back in UW-Lacrosse theming
 
 Unreleased due to issues pushing to Maven Central.
 
-## [3.1.1][] - 2017-03-02
+## 3.1.1 - 2017-03-02
 
 Increases Notification documentation #375
 Adds more documentation about best practices for notifications #376
 Adjusts link colors for themes #377
 
-## [3.1.0][] - 2017-02-21
+## 3.1.0 - 2017-02-21
 
 ### Uses GitHub Pages
 
@@ -1015,7 +1015,7 @@ Adjusts link colors for themes #377
 [Adds codeclimate badges](https://github.com/uPortal-Project/uportal-app-framework/pull/359)
 [Adds dependenci badges](https://github.com/uPortal-Project/uportal-app-framework/pull/358)
 
-## [3.0.3][] - 2016-12-20
+## 3.0.3 - 2016-12-20
 
 Patch release. Simply bump the app's dependency declaration from `uw-frame`
 `3.0.2` to `3.0.3` to adopt this release.
@@ -1030,7 +1030,7 @@ See also
 + [the 3.0.3 milestone](https://github.com/uPortal-Project/uportal-app-framework/milestone/9?closed=1).
 + [release announcement](https://groups.google.com/forum/#!topic/myuw-developers/evV8Ie3AhfQ).
 
-## [3.0.2][] - 2016-12-14
+## 3.0.2 - 2016-12-14
 
 Patch release. Trivial upgrade from `v3.0.1` (or even `v3.0.0`).
 
@@ -1047,7 +1047,7 @@ Supporting links:
 
 Unreleased due to issues pushing to Maven Central.
 
-## [3.0.0][] - 2016-11-28
+## 3.0.0 - 2016-11-28
 
 ### Major Version Upgrade
 
@@ -1075,49 +1075,6 @@ break compatibility with some older components. If the app used any
 + Added ability to have a name for the default theme (#336)
 + Fixed format for announcement end date (#332)
 
-[unreleased]: https://github.com/uPortal-Project/uportal-app-framework/compare/v13.1.2...HEAD
-[13.1.2]:  https://github.com/uPortal-Project/uportal-app-framework/compare/v13.1.1...v13.1.2
-[13.1.1]:  https://github.com/uPortal-Project/uportal-app-framework/compare/v13.1.0...v13.1.1
-[13.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v13.0.0...v13.1.0
-[13.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v12.2.0...v13.0.0
-[12.2.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v12.1.0...v12.2.0
-[12.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v12.0.0...v12.1.0
-[12.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v11.0.0...v12.0.0
-[11.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.3.0...v11.0.0
-[10.3.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.2.0...v10.3.0
-[10.2.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.1.1...v10.2.0
-[10.1.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.1.0...v10.1.1
-[10.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v10.0.0...v10.1.0
-[10.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.2.1...v10.0.0
-[9.2.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.2.0...v9.2.1
-[9.2.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.1.0...v9.2.0
-[9.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.0.2...v9.1.0
-[9.0.2]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.0.1...v9.0.2
-[9.0.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v9.0.0...v9.0.1
-[9.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v8.0.0...v9.0.0
-[8.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v7.0.0...v8.0.0
-[7.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v6.1.0...v7.0.0
-[6.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v6.0.3...v6.1.0
-[6.0.3]: https://github.com/uPortal-Project/uportal-app-framework/compare/v6.0.2...v6.0.3
-[6.0.2]: https://github.com/uPortal-Project/uportal-app-framework/compare/v6.0.1...v6.0.2
-[6.0.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v6.0.0...v6.0.1
-[6.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v5.2.1...v6.0.0
-[5.2.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v5.2.0...v5.2.1
-[5.2.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v5.1.0...v5.2.0
-[5.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v5.0.0...v5.1.0
-[5.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v4.1.0...v5.0.0
-[4.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v4.0.3...v4.1.0
-[4.0.3]: https://github.com/uPortal-Project/uportal-app-framework/compare/v4.0.2...v4.0.3
-[4.0.2]: https://github.com/uPortal-Project/uportal-app-framework/compare/v4.0.1...v4.0.2
-[4.0.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v4.0.0...v4.0.1
-[4.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.1.4...v4.0.0
-[3.1.4]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.1.3...v3.1.4
-[3.1.3]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.1.1...v3.1.3
-[3.1.1]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.1.0...v3.1.1
-[3.1.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.0.3...v3.1.0
-[3.0.3]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.0.2...v3.0.3
-[3.0.2]: https://github.com/uPortal-Project/uportal-app-framework/compare/v3.0.0...v3.0.2
-[3.0.0]: https://github.com/uPortal-Project/uportal-app-framework/compare/v2.9.0...v3.0.0
 [uportal-home #739]: https://github.com/uPortal-Project/uportal-home/pull/739
 [uportal-home #742]: https://github.com/uPortal-Project/uportal-home/pull/742
 [uportal-home #747]: https://github.com/uPortal-Project/uportal-home/pull/747

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1090,5 +1090,7 @@ break compatibility with some older components. If the app used any
 [#929]: https://github.com/uPortal-Project/uportal-app-framework/pull/929
 [#933]: https://github.com/uPortal-Project/uportal-app-framework/pull/933
 [#941]: https://github.com/uPortal-Project/uportal-app-framework/pull/941
+[#951]: https://github.com/uPortal-Project/uportal-app-framework/pull/951
+[#952]: https://github.com/uPortal-Project/uportal-app-framework/pull/952
 
 [myuw-banner-message-backend]: https://git.doit.wisc.edu/myuw/myuw-banner-message-backend

--- a/components/css/buckyless/base.less
+++ b/components/css/buckyless/base.less
@@ -23,7 +23,7 @@
 */
 
 html {
-    font-size: 16px;
+  font-size: 16px;
 }
 
 body {


### PR DESCRIPTION
[Travis-CI build on master has been failing](https://travis-ci.org/github/uPortal-Project/uportal-app-framework/builds/667419906?) because of some linting failures.

This pull request

+ resolves a LESS linting failure by normalizing an indent
+ resolves a couple missing PR reference links in the CHANGELOG by adding the missing definitions
+ resolves undefined version reference links in the CHANGELOG by removing the links from version number to diff. In practice those links are tedious to maintain and have proven a repeated area of errors and linting failures over time. Reduce commitments to low value manual work.


----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
