### PR TITLE
Clear more linter warnings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 + Be kind. (Uphold the [code of conduct][]).
 + Be an ICLA signatory. (Comply with [Apereo licensing policy][Apereo website on licensing]).
 + Try to compose commit messages implementing [Conventional Commits][].
++ Consider running `npm run lint-all` to catch earliest the issues that the
+  continuous integration build is going to flag.
 
 ## Code of conduct
 
@@ -38,6 +40,15 @@ by continuous integration (e.g. Travis-CI) on pull requests.
 You can locally lint (check for style compliance) your most recent commit message by `npm run lint-commit`.
 
 You can locally lint your commit messages via a pre-commit hook by running `npm run add-hooks`.
+
+## Linting
+
+The Travis-CI continual integration build continually lints the codebase.
+
+You can run linting locally to discover earlier what Travis-CI might be
+concerned about in your changes.
+
+`npm run lint-all`
 
 [uportal-home website on incubating]: http://uportal-project.github.io/uportal-home/apereo-incubation.html
 [Apereo inbound intellectual property licensing practices]: https://www.apereo.org/licensing/practices

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -113,12 +113,8 @@ create the next patch version.
 [uportal-app-framework access on npm]: https://www.npmjs.com/package/@uportal/app-framework/access
 [Release Maven artifacts]: https://central.sonatype.org/pages/releasing-the-deployment.html
 [central Maven staging repository]: https://oss.sonatype.org/#stagingRepositories
-[uportal-app-framework releases]: https://github.com/uPortal-Project/uportal-app-framework/releases
-[MyUW Developer Group]: https://groups.google.com/forum/#!forum/myuw-developers
 [adopted Apache rules]: https://github.com/uPortal-Project/uportal-app-framework/blob/master/committers.md#rules
 [Apache Release Policy re Release Approval]: http://www.apache.org/legal/release-policy.html#release-approval
 [the uPortal-app-framework Committers]: https://github.com/uPortal-Project/uportal-app-framework/blob/master/committers.md#who-are-the-committers
 [uportal-dev@]: https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev
-[my-app-seed]: https://github.com/UW-Madison-DoIT/my-app-seed
-[my-app-seed pom]: https://github.com/UW-Madison-DoIT/my-app-seed/blob/master/pom.xml
 [`MUMUP` JIRA project]: https://jira.doit.wisc.edu/jira/projects/MUMUP?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased


### PR DESCRIPTION
Another changeset had re-introduced Markdown linter failures by removing usages of reference links without removing the definition of those links.

This fixes that issue and also updates the CONTRIBUTING documentation to remind that linting is a thing and can be run locally.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- N/A Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
