### PR TITLE
Downgrade angular-resource to 1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 16.0.0 - 2020-07-03
+
+Breaking change: downgrade angular-resource to 1.5.8 from 1.7.8
+
 ## 15.0.0 - 2020-07-03
 
 ### Breaking Change in 15.0.0

--- a/components/config.js
+++ b/components/config.js
@@ -44,7 +44,7 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       'jquery-ui': 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min',
       'ngAria': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-aria.min',
       'ngMaterial': 'https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.19/angular-material.min',
-      'ngResource': 'https://cdnjs.cloudflare.com/ajax/libs/angular-resource/1.7.8/angular-resource.min',
+      'ngResource': 'https://cdnjs.cloudflare.com/ajax/libs/angular-resource/1.5.8/angular-resource.min',
       'ngRoute': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-route.min',
       'ngSanitize': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-sanitize.min',
       'ngStorage': 'https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.10/ngStorage.min',


### PR DESCRIPTION
Downgrading angular-resource in the hope of better supporting upgrading apps using that version of angular-resource.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
