### PR TITLE
condition widget context menu on optional attribute include-context-menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next release
+
+* Add optional attribute `include-context-menu` on `widget` directive.
+  attribute effectively defaults to `true`;
+  when set to `false` suppresses the upper-right context menu on widgets.
+
 ## 17.0.1
 
 + Update component `myuw-notifications` to v1.3.0

--- a/components/portal/main/partials/example-page.html
+++ b/components/portal/main/partials/example-page.html
@@ -193,6 +193,26 @@
         </div>
       </div>
 
+      <h3 style="margin-left:26px">
+        Example suppressing context menu when so configured</h3>
+      <div style="margin-left:26px">
+        Demonstrates include-context-menu attribute on widget directive.
+        These widgets have attribute include-context-menu present
+        with value false and true respectively.
+        The attribute effectively defaults to true when omitted.
+        It is omitted for all other widgets on this example page.</div>
+      <div layout="row" layout-align="center start"
+        style="flex-wrap:wrap;padding:18px;">
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__benefits"
+            include-context-menu="false"></widget>
+        </div>
+        <div flex-xs="100" class="widget-container">
+          <widget fname="sample-widget__benefits"
+            include-context-menu="true"></widget>
+        </div>
+      </div>
+
     <h2 style="margin-left:26px">Example compact mode widgets</h2>
     <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
         <div flex-xs="100" class="widget-container">

--- a/components/portal/widgets/directives.js
+++ b/components/portal/widgets/directives.js
@@ -33,6 +33,7 @@ define(['angular', 'require'], function(angular, require) {
       scope: {
         fname: '@',
         failSilently: '@?',
+        includeContextMenu: '@?',
       },
       templateUrl: require.toUrl('./partials/widget-card.html'),
       controller: 'WidgetCardController',

--- a/components/portal/widgets/partials/widget-card.html
+++ b/components/portal/widgets/partials/widget-card.html
@@ -53,7 +53,9 @@
     </md-card-header-text>
 
     <!-- Widget contextual menu -->
-    <md-menu class="widget-action" md-position-mode="target-right bottom">
+    <md-menu
+      ng-if="!includeContextMenu || includeContextMenu != 'false'"
+      class="widget-action" md-position-mode="target-right bottom">
       <md-button class="md-icon-button" aria-label="open {{ widget.title }} menu" ng-click="$mdOpenMenu($event)">
         <md-tooltip class="widget-action-tooltip" md-direction="top" role="tooltip">
           Open {{ widget.title }} menu

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,25 +1,31 @@
-# Widgets in uportal-app-framework
+# Using MyUW widgets in applications
 
-It's possible for uportal-app-framework apps to pull in the markup and configuration for widgets in the MyUW directory of apps.
+uportal-app-framework apps can invoke widgets from MyUW's directory of widgets.
 
-You can experiment with widgets in the [Widget Creator][] (currently available in test tier only).
-
-[Widget Creator]: https://test.my.wisc.edu/widget-creator
-
-## Fetching MyUW app widget
-
-If you're a uportal-app-framework developer and you want to include, for example, the Wiscard Balance widget in your app, you can do so by
-using the `widget` directive, like so:
-
+For example, to include the Wiscard Balance widget in an app,
+use the `widget` directive, like so:
 
 ```html
 <widget fname="wiscard-balance"></widget>
 ```
 
-You **must** know the app's "`fname`" attribute to use this feature.
+`fname` is required. This is the identifier for the content.
+It's in the URL when viewing an app directory entry's page on MyUW and it's
+in the entity XML file defining the content.
 
-If you want to create a new widget to include in your frame app, follow the steps described in the [widget documentation](make-a-widget.md)
-and then:
+The `widget` directive has two optional attributes.
 
-- [Contact your portal development team](mailto:uw-infra@office365.wisc.edu), OR
-- See the [entities contribution guide](https://git.doit.wisc.edu/myuw-overlay/entities/blob/master/CONTRIBUTING.md) (UW-Madison only)
+`fail-silently` (optional, defaults to `false`): set this to `true` to tell
+the directive to render no markup rather than rendering a widget in an error
+state, if the referenced widget would be in an error state, e.g. because the
+requesting user does not have access to the content. This is a handy way to
+define a relatively static page of widgets and let the directives gracefully
+degrade down to the ones that are working and available to the viewing user.
+The
+[MyUW search results](https://my.wisc.edu/web/apps/search/results?q=results)
+"other" tab uses this feature
+( [source](https://github.com/uPortal-Project/uportal-home/blob/master/web/src/main/webapp/my-app/search/partials/search-results.html#L163) ).
+
+`include-context-menu` (optional, defaults to `true`): include the upper right
+vertical dots context menu on the widget, which typically links to the widget's
+page in the MyUW app directory. Set this attribute to `false` to omit this menu.


### PR DESCRIPTION
Adds optional `include-context-menu` attribute on `widget` directive. Defaults to `true`. When set to `false`, suppresses the upper right context menu on widgets.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
