### PR TITLE
bugfix: empty notifications page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 
 ## 17.0.1
 
-+ Upgrade component `myuw-notifications` to v1.3.2
++ Upgrade component `myuw-notifications` to v1.3.3
 + Fix the bug when using `myuw-nofitications`, showing the bell even messages are disabled
 + Fix `myuw-notifications` "See all" page and styles
 

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -205,5 +205,5 @@ md-tooltip {
 }
 
 notifications-list-item {
-  width: 100%
+  width: 100%;
 }

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -203,3 +203,7 @@ md-tooltip {
 .md-panel-outer-wrapper.md-panel-is-showing {
   z-index: 54 !important;
 }
+
+notifications-list-item {
+  width: 100%
+}

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -51,8 +51,8 @@
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-profile@1.6.3/dist/myuw-profile.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-profile@1.6.3/dist/myuw-profile.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.3.2/dist/myuw-notifications.min.mjs"></script>
-<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.3.2/dist/myuw-notifications.min.js"></script>
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.3.3/dist/myuw-notifications.min.mjs"></script>
+<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.3.3/dist/myuw-notifications.min.js"></script>
 
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />

--- a/components/portal/messages/controllers.js
+++ b/components/portal/messages/controllers.js
@@ -168,7 +168,7 @@ define(['angular'], function(angular) {
     ])
 
     .controller('NotificationsController', ['$q', '$log', '$document',
-    '$scope', '$window', '$localStorage', '$filter', 'MESSAGES',
+    '$scope', '$window', '$rootScope', '$filter', 'MESSAGES',
     'SERVICE_LOC', 'miscService', 'messagesService', 'orderByFilter',
     function($q, $log, $document, $scope, $window, $rootScope,
              $filter, MESSAGES, SERVICE_LOC, miscService, messagesService,

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -1,0 +1,44 @@
+<!--
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<!-- NOTIFICATION CONTENT -->
+<div class="md-list-item-text" layout="row" layout-align="start center" layout-xs="column"
+    layout-align-xs="center start">
+    <!-- Notification text -->
+    <div layout="column" layout-align="center start" flex-gt-xs="70">
+        <div class="notification__priority-message" ng-if="notification.priority === 'high'">
+            <md-icon class="md-warn">priority_high</md-icon>
+            <span>High priority</span>
+        </div>
+        <div>{{ notification.title }}</div>
+    </div>
+    <!-- Notification buttons -->
+    <div ng-if="notification.moreInfoButton || notification.actionButton" class="notification-buttons" flex-gt-xs="30"
+        layout="row" layout-align="end center">
+        <md-button class="md-raised md-accent" ng-href="{{ notification.actionButton.url }}"
+            ng-if="notification.actionButton && notification.actionButton.url"
+            ng-click="pushGAEvent('notifications page', 'take action', notification.actionButton.url)" target="_blank"
+            rel="noopener noreferrer">
+            {{ notification.actionButton.label }}
+        </md-button>
+        <md-button class="md-raised md-default" ng-href="{{ notification.moreInfoButton.url }}"
+            ng-if="notification.moreInfoButton && notification.moreInfoButton.url"
+            ng-click="pushGAEvent('notifications page', 'more info', notification.moreInfoButton.url)" target="_blank"
+            rel="noopener noreferrer">
+            {{ notification.moreInfoButton.label }}
+        </md-button>
+    </div>
+</div>

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -1,4 +1,5 @@
 <!--
+
     Licensed to Apereo under one or more contributor license
     agreements. See the NOTICE file distributed with this work
     for additional information regarding copyright ownership.
@@ -6,13 +7,16 @@
     Version 2.0 (the "License"); you may not use this file
     except in compliance with the License.  You may obtain a
     copy of the License at the following location:
+
       http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <!-- NOTIFICATION CONTENT -->
 <div class="md-list-item-text" layout="row" layout-align="start center" layout-xs="column"

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -46,7 +46,7 @@
                 <notifications-list-item></notifications-list-item>
 
                 <!-- DISMISS BUTTON -->
-                <div class="notifications-list__action md-secondary">
+                <div class="notifications-list__action">
                   <md-button class="md-icon-button"
                              ng-hide="notification.dismissible === false"
                              ng-click="vm.dismissNotification(notification.id, true);pushGAEvent('Notifications page', 'Dismiss notification', notification.id)"
@@ -76,7 +76,7 @@
                 <notifications-list-item></notifications-list-item>
 
                 <!-- RESTORE BUTTON -->
-                <div class="notification-list__action md-secondary">
+                <div class="notification-list__action">
                   <md-button class="md-icon-button"
                              ng-click="vm.restoreNotification(notification);pushGAEvent('Notifications page', 'Restore notification', notification.id)"
                              aria-label="restore this notification">

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -46,7 +46,7 @@
                 <notifications-list-item></notifications-list-item>
 
                 <!-- DISMISS BUTTON -->
-                <div class="notifications-list__action">
+                <div class="notifications-list__action md-secondary">
                   <md-button class="md-icon-button"
                              ng-hide="notification.dismissible === false"
                              ng-click="vm.dismissNotification(notification.id, true);pushGAEvent('Notifications page', 'Dismiss notification', notification.id)"
@@ -76,7 +76,7 @@
                 <notifications-list-item></notifications-list-item>
 
                 <!-- RESTORE BUTTON -->
-                <div class="notification-list__action">
+                <div class="notification-list__action md-secondary">
                   <md-button class="md-icon-button"
                              ng-click="vm.restoreNotification(notification);pushGAEvent('Notifications page', 'Restore notification', notification.id)"
                              aria-label="restore this notification">


### PR DESCRIPTION
- Update `myuw-notifications` to v1.3.3
- Fix page-breaking injection error
- As`md-list-item` appends empty `md-secondary` element to DOM, change style of `notifications-list-item`: `width: 100%`