### PR TITLE
Fix 'See all' notifications page styles

### DIFF
--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -207,3 +207,8 @@ md-tooltip {
 notifications-list-item {
   width: 100%;
 }
+
+md-list-item.notification-item {
+  padding: 16px 0 !important;
+  border-bottom: 1px solid @grayscale3;
+}

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -209,6 +209,6 @@ notifications-list-item {
 }
 
 md-list-item.notification-item {
-  padding: 16px 0 !important;
+  padding: 16px !important;
   border-bottom: 1px solid @grayscale3;
 }

--- a/components/portal/messages/partials/notifications-list-item.html
+++ b/components/portal/messages/partials/notifications-list-item.html
@@ -25,7 +25,7 @@
     <div layout="column" layout-align="center start" flex-gt-xs="70">
         <div class="notification__priority-message" ng-if="notification.priority === 'high'">
             <md-icon class="md-warn">priority_high</md-icon>
-            <span>High priority</span>
+            <span><b>High priority</b></span>
         </div>
         <div>{{ notification.title }}</div>
     </div>

--- a/components/portal/messages/partials/view__notifications.html
+++ b/components/portal/messages/partials/view__notifications.html
@@ -48,7 +48,7 @@
                 <!-- DISMISS BUTTON -->
                 <div class="notifications-list__action">
                   <md-button class="md-icon-button"
-                             ng-hide="notification.dismissible === false"
+                             ng-style="{'visibility' : notification.dismissible === false  ? 'hidden' : 'visible'}"
                              ng-click="vm.dismissNotification(notification.id, true);pushGAEvent('Notifications page', 'Dismiss notification', notification.id)"
                              aria-label="dismiss this notification">
                     <md-icon>clear</md-icon>


### PR DESCRIPTION
Fix 'See all' notifications page styles
- add a bottom border for each notification item
- add vertical padding for each notification item
- realign action buttons
- set high priority text bold
