### PR TITLE
Improve visibility of Notifications button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ It is those war files that are being versioned.
 ## 17.0.2 - 2020-09-08
 
 + Update `myuw-notifications` to v1.3.4
++ Remove notifications bell from sidenav and keep in visible in the header at all times for better accessibility
 
 ## 17.0.1 - 2020-09-01
 

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -57,7 +57,6 @@
   </myuw-help>
 
   <myuw-notifications
-    hide-xs
     slot="myuw-notifications"
     limit=""
     see-all-url="/web/notifications"

--- a/components/portal/main/partials/main-menu.html
+++ b/components/portal/main/partials/main-menu.html
@@ -30,11 +30,6 @@
       <md-icon>arrow_back</md-icon>
       <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Close menu</md-tooltip>
     </md-button>
-    <myuw-notifications
-    slot="myuw-notifications"
-    limit=""
-    see-all-url="/web/notifications"
-    ></myuw-notifications>
   </div>
   <md-menu-content>
     <!-- App-specific content/navigation -->


### PR DESCRIPTION
I would like to propose displaying the Notifications bell icon in the header (since there's an estate for it) at all times rather than hiding it in the Sidenav.

<img width="320" alt="Screen Shot 2020-09-09 at 8 11 04 AM" src="https://user-images.githubusercontent.com/10341961/92603316-c5fc5d00-f274-11ea-90d7-68d6ff35755f.png">


----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
