### PR TITLE
Gracefully handle the case where a user has zero email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
+## Future release
+
++ Handle zero-options case in option-link widget type
+
 ## 17.0.4 - 2020-10-12
 
 + Update `myuw-banner` to v1.2.2

--- a/components/portal/widgets/partials/type__option-link.html
+++ b/components/portal/widgets/partials/type__option-link.html
@@ -35,7 +35,7 @@
     </div>
 
     <!-- IF ZERO ELEMENTS -->
-    <div ng-if="widget.widgetData && config.singleElement && !widget.widgetData[config.value]">
+    <div ng-if="widget.widgetData && config.singleElement && !widget.widgetData[config.display]">
       <p><a ng-href="widget.uri">{{widget.uri_message}}</a></p>
     </div>
 

--- a/components/portal/widgets/partials/type__option-link.html
+++ b/components/portal/widgets/partials/type__option-link.html
@@ -33,6 +33,12 @@
     <div ng-if="widget.widgetData.length == 0" layout="row" layout-align="center center">
       <loading-gif data-object='widget.widgetData'></loading-gif>
     </div>
+
+    <!-- IF ZERO ELEMENTS -->
+    <div ng-if="widget.widgetData && config.singleElement && !widget.widgetData[config.value]">
+      <p><a ng-href="widget.uri">{{widget.uri_message}}</a></p>
+    </div>
+
     <!-- IF ONE ELEMENT -->
     <div ng-if="widget.widgetData && config.singleElement && (!widget.widgetData[config.arrayName] || widget.widgetData[config.arrayName].length == 0)"
          layout="row" layout-align="center center">

--- a/components/portal/widgets/partials/type__option-link.html
+++ b/components/portal/widgets/partials/type__option-link.html
@@ -34,7 +34,7 @@
       <loading-gif data-object='widget.widgetData'></loading-gif>
     </div>
     <!-- IF ONE ELEMENT -->
-    <div ng-if="config.singleElement && (!widget.widgetData[config.arrayName] || widget.widgetData[config.arrayName].length == 0)"
+    <div ng-if="widget.widgetData && config.singleElement && (!widget.widgetData[config.arrayName] || widget.widgetData[config.arrayName].length == 0)"
          layout="row" layout-align="center center">
       <span title='{{ widget.widgetData[config.display].length > 26 ? widget.widgetData[config.display] : "" }}'>
         {{ widget.widgetData[config.display] | trimMiddle:26 }}


### PR DESCRIPTION
Okay, this kind of fun.

In practice, the only usage of option-link in MyUW is for the O365 email integration.

Most users have one email address. Some have several. Hence the use case for option-links, so they can select which to launch. Some have zero, as in the case where they're eligible to activate but have not yet activated.

In practice, the only [option-link usage is in singleElement mode](https://git.doit.wisc.edu/myuw-overlay/entities/-/blob/prod/src/main/resources/portlet-definition/wisc-mail.portlet-definition.xml#L98).

In practice, when the user has no email address, `!widget.widgetData[config.display]` will evaluate true. [("display" is set to "email" in the widgetConfig](https://git.doit.wisc.edu/myuw-overlay/entities/-/blob/prod/src/main/resources/portlet-definition/wisc-mail.portlet-definition.xml#L98), and ["email" is null in the data when the user has no email address](https://docs.google.com/document/d/19xi6zx_FtCa6jpZt7Q2hpYDNVkoyzUrgv4gnSlhtfy0/edit).

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
