### PR TITLE
Rely on Google Tag Manager to init Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ It is those war files that are being versioned.
 
 + Handle zero-options case in option-link widget type
 + Implement Snippets for the MyUW Tag Manager Account
-+ Remove Google Analytics JavaScript import obviated by Google Tag Manager
 
 ## 17.0.4 - 2020-10-12
 

--- a/components/js/ga.js
+++ b/components/js/ga.js
@@ -1,0 +1,51 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+var config = config || {};
+var _gaq = _gaq || [];
+
+if(config.gaID !== undefined && config.gaID !== null) {
+  ga('create', config.gaID, 'auto');
+} else {
+  console.log("ga disabled for this app");
+}
+
+function _gaLt(event){
+    var el = event.srcElement || event.target;
+
+    /* Loop up the tree through parent elements if clicked element is not a link (eg: an image in a link) */
+    while(el && (typeof el.tagName == 'undefined' || el.tagName.toLowerCase() != 'a' || !el.href))
+        el = el.parentNode;
+
+    if(el && el.href){
+    if(el.href.indexOf(location.host) == -1 && el.href != 'javascript:;'){ /* external link */
+            var eventOptions = {eventCategory: 'Outbound Link', eventAction: el.href, eventLabel : el.text };
+            window.ga('send', 'event', eventOptions);
+            console.log('ga event logged c: Outbound Link a: '+el.href+' l:'+ el.text);
+            // Click will open in a new window if it is the middle button or the
+            // meta or control keys are held
+            var target = (el.target && !el.target.match(/^_(self|parent|top)$/i)) ? el.target : false;
+            var newWindow = event.button == 1 || event.metaKey || event.ctrlKey || target;
+            /* HitCallback function to either open link in either same or new window */
+            var hitBack = function(link, target){
+                target ? window.open(link, target) : window.location.href = link;
+            };
+            
+            if(newWindow){
+                setTimeout(function(){
+                    window.open(el.href, target);
+                }.bind(el),500);
+                /* Prevent standard click */
+                event.preventDefault ? event.preventDefault() : event.returnValue = !1;
+            }
+        }
+
+    }
+}
+
+/* Attach the event to all clicks in the document after page has loaded */
+var w = window;
+w.addEventListener ? w.addEventListener("load",function(){document.body.addEventListener("click",_gaLt,!1)},!1)
+ : w.attachEvent && w.attachEvent("onload",function(){document.body.attachEvent("onclick",_gaLt)});

--- a/components/js/ga.js
+++ b/components/js/ga.js
@@ -1,16 +1,5 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
 var config = config || {};
 var _gaq = _gaq || [];
-
-if(config.gaID !== undefined && config.gaID !== null) {
-  ga('create', config.gaID, 'auto');
-} else {
-  console.log("ga disabled for this app");
-}
 
 function _gaLt(event){
     var el = event.srcElement || event.target;

--- a/docs/Google-analytics.md
+++ b/docs/Google-analytics.md
@@ -2,22 +2,10 @@
 
 ## Introduction
 
-[www.google.com/analytics](https://www.google.com/analytics) (GA for short) is
-a great (and free) way to analyze traffic to a web application. By default
-uportal-app-framework disables GA.
-
-## Basic configuration
-
-Add in a `/js/config.js` file that will overwrite the `components/js/config.js`.
-
-<!-- eslint-disable no-unused-vars -->
-```javascript
-var config = {
-  gaID: 'UA-########-##',
-};
-```
+Uses Google Tag Manager, with the MyUW and WPS organizations hard-coded.
 
 ## Site search
+
 GA has a great feature called site search. It collects information about what
 people are searching for within a site. To configure it in
 uportal-app-framework is a couple steps.

--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -33,6 +33,8 @@
   <uw-body></uw-body>
 
   <!--javascript-->
+  <script type="text/javascript" src="js/config.js"></script>
+  <script type="text/javascript" src="js/ga.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js" data-main="main"></script>
 
 </body>

--- a/src/main/webapp/frame.jsp
+++ b/src/main/webapp/frame.jsp
@@ -33,7 +33,6 @@
   <uw-body></uw-body>
 
   <!--javascript-->
-  <script type="text/javascript" src="js/config.js"></script>
   <script type="text/javascript" src="js/ga.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js" data-main="main"></script>
 

--- a/static/index.html
+++ b/static/index.html
@@ -38,7 +38,6 @@
   <uw-body></uw-body>
 
   <!--javascript-->
-  <script type="text/javascript" src="js/config.js"></script>
   <script type="text/javascript" src="js/ga.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js" data-main="main"></script>
 

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,8 @@
   <uw-body></uw-body>
 
   <!--javascript-->
+  <script type="text/javascript" src="js/config.js"></script>
+  <script type="text/javascript" src="js/ga.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.min.js" data-main="main"></script>
 
 </body>


### PR DESCRIPTION
A more surgical version of #998 .

Stops *initializing* Google Analytics while continuing to add our special sauce for eventing on outbound links.