### PR TITLE
Bigger circle-button click targets (for example, in list-of-links)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ It is those war files that are being versioned.
 + portalShibbolethService no longer invokes miscService.redirectUser on error
   of the Shibboleth SP JSON service it calls. That JSON service normally fails
   in public.my site contexts.
++ Make the text label of circle-button clickable,
+  increasing the size of the click target and thus the usability
 + Updates `myuw-search` to v.1.5.5
 
 ## 18.1.0

--- a/components/portal/misc/partials/circle-button.html
+++ b/components/portal/misc/partials/circle-button.html
@@ -31,6 +31,10 @@
     {{ title }}
   </md-tooltip>
 </md-button>
-<p ng-show="title">
+<a
+  ng-show="title"
+  aria-label="open {{ title }}" tabindex="-1"
+  ng-href="{{ cbDisabled ? '#' : href}}"
+  target="{{cbDisabled ? '' : target}}" rel='noopener noreferrer'>
   {{title | truncate:trunclen}}
-</p>
+</a>

--- a/components/portal/misc/partials/circle-button.html
+++ b/components/portal/misc/partials/circle-button.html
@@ -37,4 +37,8 @@
   ng-href="{{ cbDisabled ? '#' : href}}"
   target="{{cbDisabled ? '' : target}}" rel='noopener noreferrer'>
   {{title | truncate:trunclen}}
+  <md-tooltip ng-if="title.length > trunclen"
+    md-direction="bottom">
+    {{ title }}
+  </md-tooltip>
 </a>


### PR DESCRIPTION
Makes the text label of `circle-button` (used on widgets like `list-of-links` and `search-with-links`) clickable with the same effect as the icon circle part of the button. 

![circle-button-links-clickable](https://user-images.githubusercontent.com/952283/98151581-03a4ed00-1e96-11eb-8c9f-02bdd7dfd3b2.png)

This improves usability by offering a larger click target. Clicking the label clearly expresses user intent to launch the link, so it should launch the link, rather than requiring the user to hone in on the circle icon bit.

The implementation is a little weird in that there are two redundant links, with the new link kept out of keyboard tab navigation. This is because I didn't immediately find a way to get this down to one hyperlink in the DOM. That would be more semantic and it would be more usable if hovering over either the text or the icon actuated the hover UI treatment on both, reinforcing to the user that they are one big clickable thing. So, that would be a welcome further improvement.

That said, the working hypothesis here (heuristic analysis?) is that this change still represents an improvement in usability, in that it makes clicking or tapping the text do the right thing. Better is better.

