### PR TITLE
Fix documentation about "tablecloth" messages over widgets

### DIFF
--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -169,7 +169,7 @@ Example widget configuration
     <value>/example/path/to/some.json</value>
 </portlet-preference>
 <portlet-preference>
-    <name>widgetExtneralMessageTextObjectLocation</name>
+    <name>widgetExternalMessageTextObjectLocation</name>
     <value>["result", 0, "message"]</value>
 </portlet-preference>
 <portlet-preference>

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -166,7 +166,7 @@ Example widget configuration
 ```xml
 <portlet-preference>
     <name>widgetExternalMessageUrl</name>
-    <value>locationToFindJSONObject</value>
+    <value>/example/path/to/some.json</value>
 </portlet-preference>
 <portlet-preference>
     <name>widgetExtneralMessageTextObjectLocation</name>

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -170,14 +170,35 @@ Example widget configuration
 </portlet-preference>
 <portlet-preference>
     <name>widgetExternalMessageTextObjectLocation</name>
-    <value>["result", 0, "message"]</value>
+    <value>result</value>
+    <value>0</value>
+    <value>message</value>
 </portlet-preference>
 <portlet-preference>
     <name>widgetExternalMessageLearnMoreUrlLocation</name>
-    <value>["learnMoreUrl"]</value>
+    <value>learnMoreUrl</value>
 </portlet-preference>
 
 ```
+
+Note that the
+`widgetExternalMessageTextObjectLocation` and
+`widgetExternalMessageLearnMoreUrlLocation` preferences
+are a query language,
+indexing into the JSON.
+
+In these examples, `widgetExternalMessageTextObjectLocation` is telling the
+framework to read the message text from the value of `message` in the zeroth
+item of the array named `result` in the JSON.
+
+In these examples, `widgetExternalMessageLearnMoreUrlLocation` is telling the
+framework to read the URL for the Learn more button
+from the value of `learnMoreUrl` in the JSON.
+
+This means there's tremendous flexibility in JSON that can work to drive
+widget messaging. It will often be feasible
+to re-purpose JSON from other purposes
+to drive widget messaging, un-modified.
 
 ## Exercises
 

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -137,6 +137,8 @@ A zero item array of banner messages suppresses the banner message feature.
 
 ## Widget messages
 
+Colloquially known as "widget tablecloths" because they overlay on a widget.
+
 Widget messaging is based on JSON input configured in a
 [widget's configuration](make-a-widget.md).
 

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -173,7 +173,7 @@ Example widget configuration
     <value>["result", 0, "message"]</value>
 </portlet-preference>
 <portlet-preference>
-    <name>widgetExternalMessageLearnMoreUrl</name>
+    <name>widgetExternalMessageLearnMoreUrlLocation</name>
     <value>["learnMoreUrl"]</value>
 </portlet-preference>
 

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -140,12 +140,24 @@ A zero item array of banner messages suppresses the banner message feature.
 Widget messaging is based on JSON input configured in a
 [widget's configuration](make-a-widget.md).
 
-Configuration is done by two required items and one optional.  Required is a url
-where to find a JSON object and an array representing where in the object the
-message can be found.  Optional is an array representing where in the object the
-learn more url can be found.
-The url to find the JSON object can be both external and internal to the app's
-configuration.
+Three portlet-preferences configure on-widget dismissable messages.
+
+- `widgetExternalMessageUrl` (required): the URL from which to read the JSON.
+  Typically this is to a static file, or to a URL proxied through the REST proxy,
+  or to a resource URL within a Portlet.
+  If this portlet-preference is not set,
+  the widget message does not display at all.
+- `widgetExternalMessageTextObjectLocation` (required):
+  a multi-valued portlet-preference representing the query path into the JSON
+  to read the String representing the text to show on the widget.
+  If the path does not point to a value in the JSON,
+  the widget message does not display at all.
+- `widgetExternalMessageLearnMoreUrlLocation` (optional):
+  a multi-valued portlet-preference representing the query path into the JSON
+  to read the String
+  representing the URL to which a "Learn more" button should link.
+  If not present or if it does not point to a value in the JSON,
+  the "Learn more" button does not show.
 
 Example JSON object (at `/example/path/to/some.json`)
 

--- a/docs/messaging-implementation.md
+++ b/docs/messaging-implementation.md
@@ -147,7 +147,7 @@ learn more url can be found.
 The url to find the JSON object can be both external and internal to the app's
 configuration.
 
-Example JSON object
+Example JSON object (at `/example/path/to/some.json`)
 
 ```json
 {


### PR DESCRIPTION
The status quo documentation is incorrect in several respects. This fixes the documentation, validated by what works for the new tablecloth message being deployed over the STAR widget.

