### PR TITLE
Update myuw-banner to v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ It is those war files that are being versioned.
 + Update `myuw-notifications` to v.1.4.1
 + Update `myuw-profile` to v.1.6.5
 + Update `myuw-app-bar` to v.1.7.2
++ Update `myuw-banner` to v1.2.3
 + Add `myuw-feedback` v.1.0.2
 + Fix MyUW custom Outbound Link event firing
 

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -59,8 +59,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.7.2/dist/myuw-app-bar.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.7.2/dist/myuw-app-bar.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.2.2/dist/myuw-banner.min.mjs"></script>
-<script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.2.2/dist/myuw-banner.min.js"></script>
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@1.2.3/dist/myuw-banner.min.mjs"></script>
+<script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@1.2.3/dist/myuw-banner.min.js"></script>
 
 <script type="module" src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.3/myuw-help.min.mjs"></script>
 <script nomodule src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.3/myuw-help.min.js"></script>


### PR DESCRIPTION
Upgrades to [myuw-banner version 1.2.3](https://github.com/myuw-web-components/myuw-banner/blob/master/CHANGELOG.md#123), which styles more compactly at wide screen widths.

Allows retiring the [local overlay patching head-static](https://git.doit.wisc.edu/myuw-overlay/uportal-home-overlay/-/blob/prod/src/main/webapp/head-static.html) to use this version of myuw-banner.


- [x] Updates `CHANGELOG.md` to reflect this PR's change.