### PR TITLE
do not predicate miscService.redirectUser on status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,19 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next (18.1.2)
+## Next
 
-## 18.1.1
-
++ miscService.redirectUser no longer predicates redirecting on response code.
+  This has the effect of supporting the newly generated
+  401 Unauthorized responses from uPortal server.
+  The intention is that if the server gets confused about the user's session,
+  it responds 401 Unauthorized
+  (which is mis-named and really means "unauthenticated",
+  as distinct from authenticated and FORBIDDEN). uPortal-home detects the 401
+  error response and redirects the user to login to become fully authenticated
+  again, establishing a fresh uPortal session, and tada! the user gets a
+  consistent, logged-in experience rather than
+  an inconsistent only-sort-of-logged-in experience.
 + Updates `myuw-search` to v.1.5.5
 
 ## 18.1.0

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -165,23 +165,16 @@ define(['angular', 'jquery'], function(angular, $) {
   function($analytics, $http, $window, $location, $log, MISC_URLS) {
     /**
      * Used to redirect users to login screen
-     *    if result code is 0 (yay shib) or 302
      *    Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
      * @param {number} status
      * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
-      if (status === 0 || status === 302) {
-        $log.log('redirect happening due to ' + status);
-        if (MISC_URLS.loginURL) {
-          $window.location.replace(MISC_URLS.loginURL);
-        } else {
-          $log.warn('MISC_URLS.loginURL was not set, cannot redirect');
-        }
+      $log.log('redirect because status ' + status + ' from ' + caller);
+      if (MISC_URLS.loginURL) {
+        $window.location.replace(MISC_URLS.loginURL);
       } else {
-        $log.warn(
-          'Strange behavior from ' + caller +
-          '. Returned status code : ' + status);
+        $log.warn('MISC_URLS.loginURL was not set, cannot redirect');
       }
     };
 


### PR DESCRIPTION
Intended to support newly generated `401 Unauthorized` from uPortal server.

With this change, when uPortal responds `401 Unauthorized` when it loses the plot of the user session, app framework will redirect user to log in again.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.

