### PR TITLE
don't redirect for login on failure of Shibboleth JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ It is those war files that are being versioned.
   again, establishing a fresh uPortal session, and tada! the user gets a
   consistent, logged-in experience rather than
   an inconsistent only-sort-of-logged-in experience.
++ portalShibbolethService no longer invokes miscService.redirectUser on error
+  of the Shibboleth SP JSON service it calls. That JSON service normally fails
+  in public.my site contexts.
 + Updates `myuw-search` to v.1.5.5
 
 ## 18.1.0

--- a/components/portal/timeout/services.js
+++ b/components/portal/timeout/services.js
@@ -32,7 +32,9 @@ define(['angular', 'jquery'], function(angular, $) {
       'miscService', 'SERVICE_LOC',
         function($http, $log, miscService, SERVICE_LOC) {
           var onError = function(response) {
-            miscService.redirectUser(response.status, 'Shibboleth Service');
+            // do not redirect on failure of the Shibboleth session request,
+            // as this normally fails on public.my sites
+            // miscService.redirectUser(response.status, 'Shibboleth Service');
             return response.data;
           };
 


### PR DESCRIPTION
Shibboleth JSON 404s expectedly on public.my sites, so stop those expected failures from causing an infinite login redirect loop.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.

