### PR TITLE
Redirect in miscService.redirectUser on 401, 302, and 0 specifically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ It is those war files that are being versioned.
 
 ## Next
 
++ miscService.redirectUser will now redirect on status 401, not just on 0 and 302
 + portalShibbolethService no longer invokes miscService.redirectUser on error
   of the Shibboleth SP JSON service it calls. That JSON service normally fails
   in public.my site contexts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,8 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next
+## Next (18.1.2)
 
-+ miscService.redirectUser no longer predicates redirecting on response code.
-  This has the effect of supporting the newly generated
-  401 Unauthorized responses from uPortal server.
-  The intention is that if the server gets confused about the user's session,
-  it responds 401 Unauthorized
-  (which is mis-named and really means "unauthenticated",
-  as distinct from authenticated and FORBIDDEN). uPortal-home detects the 401
-  error response and redirects the user to login to become fully authenticated
-  again, establishing a fresh uPortal session, and tada! the user gets a
-  consistent, logged-in experience rather than
-  an inconsistent only-sort-of-logged-in experience.
 + portalShibbolethService no longer invokes miscService.redirectUser on error
   of the Shibboleth SP JSON service it calls. That JSON service normally fails
   in public.my site contexts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next (18.1.2)
+## Next
 
 + portalShibbolethService no longer invokes miscService.redirectUser on error
   of the Shibboleth SP JSON service it calls. That JSON service normally fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ It is those war files that are being versioned.
 + Updates `myuw-search` to v.1.5.5
 
 ## 18.1.0
+
 + Adds myuw-feedback web component with conditional flag feature
 
 ## 18.0.1 - 2021-01-14

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -165,13 +165,16 @@ define(['angular', 'jquery'], function(angular, $) {
   function($analytics, $http, $window, $location, $log, MISC_URLS) {
     /**
      * Used to redirect users to login screen
-     *    if result code is 0 (yay shib) or 302
+     *    if result code is
+     *    0 (Shibboleth weirdness?) or
+     *   302 (a shib redirect?) or
+     *   401 (Unauthorized, due to lack of authentication?)
      *    Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
      * @param {number} status
      * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
-      if (status === 0 || status === 302) {
+      if (status === 0 || status === 302 || status === 401) {
         $log.log('redirect happening due to ' + status);
         if (MISC_URLS.loginURL) {
           $window.location.replace(MISC_URLS.loginURL);

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -165,16 +165,23 @@ define(['angular', 'jquery'], function(angular, $) {
   function($analytics, $http, $window, $location, $log, MISC_URLS) {
     /**
      * Used to redirect users to login screen
+     *    if result code is 0 (yay shib) or 302
      *    Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
      * @param {number} status
      * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
-      $log.log('redirect because status ' + status + ' from ' + caller);
-      if (MISC_URLS.loginURL) {
-        $window.location.replace(MISC_URLS.loginURL);
+      if (status === 0 || status === 302) {
+        $log.log('redirect happening due to ' + status);
+        if (MISC_URLS.loginURL) {
+          $window.location.replace(MISC_URLS.loginURL);
+        } else {
+          $log.warn('MISC_URLS.loginURL was not set, cannot redirect');
+        }
       } else {
-        $log.warn('MISC_URLS.loginURL was not set, cannot redirect');
+        $log.warn(
+          'Strange behavior from ' + caller +
+          '. Returned status code : ' + status);
       }
     };
 


### PR DESCRIPTION
On reflection, https://github.com/uPortal-Project/uportal-app-framework/pull/1014 went too far in making *any* status redirect the user in miscService.redirectUser(). In particular this made 404s redirect. 

Instead, add status 401 specifically to the statuses that cause redirects. This will keep the newfound support for detecting when APIs are failing because the user isn't logged in and for automatically handling this case, with fewer under-considered side effects.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
