### PR TITLE
Set uPortal refUrl on the redirect to login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ It is those war files that are being versioned.
 
 ## Next
 
-(No changes yet.)
++ miscUrl.redirectUser will set refUrl on the redirect to uPortal login
+  so that uPortal login will return the user to the page
+  that launched the log-in-again redirect.
 
 ## 18.1.1 - 2021-02-02
 

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -164,8 +164,8 @@ define(['angular', 'jquery'], function(angular, $) {
   .factory('miscService',
   function($analytics, $http, $window, $location, $log, MISC_URLS) {
     /**
-     * Used to redirect users to login screen
-     *    if result code is
+     * Redirects users to uPortal server login
+     *  if result code is
      *    0 (Shibboleth weirdness?) or
      *   302 (a shib redirect?) or
      *   401 (Unauthorized, due to lack of authentication?)

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -167,9 +167,11 @@ define(['angular', 'jquery'], function(angular, $) {
      * Redirects users to uPortal server login
      *  if result code is
      *    0 (Shibboleth weirdness?) or
-     *   302 (a shib redirect?) or
-     *   401 (Unauthorized, due to lack of authentication?)
-     *    Setup MISC_URLS.loginURL in js/app-config.js to have redirects happen
+     *    302 (a shib redirect?) or
+     *    401 (Unauthorized, due to lack of authentication?)
+     *  Requires MISC_URLS.loginURL in js/app-config.js
+     *  Sets refUrl to current URL, so that uPortal will attempt to return the
+     *  user to the current page after login.
      * @param {number} status
      * @param {string} caller
     **/
@@ -177,7 +179,10 @@ define(['angular', 'jquery'], function(angular, $) {
       if (status === 0 || status === 302 || status === 401) {
         $log.log('redirect happening due to ' + status);
         if (MISC_URLS.loginURL) {
-          $window.location.replace(MISC_URLS.loginURL);
+          var currentUrl = $window.href;
+          var currentUrlEncoded = encodeURIComponent(currentUrl);
+          var newUrl = MISC_URLS.loginURL + "?refUrl=" + currentUrlEncoded;
+          $window.location.replace(newUrl);
         } else {
           $log.warn('MISC_URLS.loginURL was not set, cannot redirect');
         }

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -181,7 +181,7 @@ define(['angular', 'jquery'], function(angular, $) {
         if (MISC_URLS.loginURL) {
           var currentUrl = $window.href;
           var currentUrlEncoded = encodeURIComponent(currentUrl);
-          var newUrl = MISC_URLS.loginURL + "?refUrl=" + currentUrlEncoded;
+          var newUrl = MISC_URLS.loginURL + '?refUrl=' + currentUrlEncoded;
           $window.location.replace(newUrl);
         } else {
           $log.warn('MISC_URLS.loginURL was not set, cannot redirect');


### PR DESCRIPTION
miscService.redirectUser exists to redirect the user back through uPortal login in the case where it seems that API calls are failing because no longer logged in.

One big downside of that is losing the user's place in the application. They end up back at the uPortal-home main page (`/web`).

This Pull Request improves upon that status quo by leveraging uPortal server's existing `refUrl` feature. This sets `refUrl` on the redirect to uPortal Login, so that once uPortal Login has re-established a logged in uPortal session, *uPortal Login redirects back to the refUrl rather than to the uPortal-home front page*, and thus the logging back in is less disruptive, returning the user to where they were.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.

