### PR TITLE
Pivot away from asynchronous "silent" login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,21 @@ It is those war files that are being versioned.
 
 ## Next
 
-+ miscUrl.redirectUser will set refUrl on the redirect to uPortal login
-  so that uPortal login will return the user to the page
-  that launched the log-in-again redirect.
+**Breaking change: pivot away from "silent" login.**
+
++ `miscService.redirectUser` will set `refUrl` on the redirect to uPortal login
+  so that uPortal login will return the user to
+  the page that launched the log-in-again redirect.
++ Undocumented configuration `loginSilentURL` is deprecated
+  and now defaults to regular, non-silent login.
+  (With improved `miscService.redirectUser` triggering and behavior,
+  **all login attempts should be changed to trigger miscService.redirectUser**
+  or to directly link to login; attempting to "silently" bootstrap login in an
+  asynchronous request was never reliable and is now emphatically deprecated
+  as it will function correctly in strictly a subset of the situations where
+  miscService.redirectUser will now function correctly.)
++ Fixed several calls to miscService.redirectUser
+  that did not correctly convey the status code.
 
 ## 18.1.1 - 2021-02-02
 

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -65,7 +65,7 @@ define(['angular'], function(angular) {
         .value('MISC_URLS', {
             'feedbackURL': 'https://my.wisc.edu/portal/p/feedback',
             'helpdeskURL': 'https://kb.wisc.edu/helpdesk/',
-            'loginURL': '/portal/Login?profile=bucky',
+            'loginURL': '/portal/Login',
             'logoutURL': '/portal/Logout',
             'myuwHome': 'https://my.wisc.edu',
             'resetLayoutURL': '/portal/p/reset-my-layout',

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -39,7 +39,7 @@ define(['angular'], function(angular) {
             'aboutPageURL': null,
             'groupURL': '/portal/api/groups',
             'kvURL': '/storage',
-            'loginSilentURL': '/portal/Login', // deprecated; use MISC_URLS.loginURL instead
+            'loginSilentURL': '/portal/Login', // deprecated
             'messagesURL': '', // staticFeeds/sample-messages.json
             'sessionInfo': 'staticFeeds/session.json',
             'shibbolethSessionURL': 'staticFeeds/Shibboleth.sso/Session.json',

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -39,7 +39,7 @@ define(['angular'], function(angular) {
             'aboutPageURL': null,
             'groupURL': '/portal/api/groups',
             'kvURL': '/storage',
-            'loginSilentURL': '/portal/Login?silent=true',
+            'loginSilentURL': '/portal/Login', // deprecated; use MISC_URLS.loginURL instead
             'messagesURL': '', // staticFeeds/sample-messages.json
             'sessionInfo': 'staticFeeds/session.json',
             'shibbolethSessionURL': 'staticFeeds/Shibboleth.sso/Session.json',

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -42,8 +42,8 @@ define(['angular'], function(angular) {
             var person = result.data.person;
             return person;
           })
-          .catch(function(data, status) { // failure function
-            miscService.redirectUser(status, 'Get User Info');
+          .catch(function(error) { // failure function
+            miscService.redirectUser(error.status, 'Get User Info');
           });
         return userPromise;
       };

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -38,7 +38,7 @@ define(['angular'], function(angular) {
         }
 
         userPromise = prom
-          .then(function(result, status) { // success function
+          .then(function(result) { // success function
             var person = result.data.person;
             return person;
           })

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -179,7 +179,7 @@ define(['angular', 'jquery'], function(angular, $) {
       if (status === 0 || status === 302 || status === 401) {
         $log.log('redirect happening due to ' + status);
         if (MISC_URLS.loginURL) {
-          var currentUrl = $window.href;
+          var currentUrl = $window.location.href;
           var currentUrlEncoded = encodeURIComponent(currentUrl);
           var newUrl = MISC_URLS.loginURL + '?refUrl=' + currentUrlEncoded;
           $window.location.replace(newUrl);

--- a/components/portal/timeout/services.js
+++ b/components/portal/timeout/services.js
@@ -98,7 +98,7 @@ define(['angular', 'jquery'], function(angular, $) {
               .catch(function(error) {
                 $log.warn('Failed to get Shibboleth session info');
                 $log.error(error);
-                miscService.redirectUser(status, 'Get User Info');
+                miscService.redirectUser(error.status, 'Get User Info');
               });
           }
 

--- a/components/portal/timeout/services.js
+++ b/components/portal/timeout/services.js
@@ -96,7 +96,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 }
               })
               .catch(function(error) {
-                $log.warn('Could\'t get Shibboleth session info');
+                $log.warn('Failed to get Shibboleth session info');
                 $log.error(error);
                 miscService.redirectUser(status, 'Get User Info');
               });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,8 +112,11 @@ the "See all" link should go).
 
 + **feedbackURL**: A link to a feedback form
 + **helpdeskURL**: Link to the relevant help desk
-+ **loginURL**: How a user would login. Used for guestMode, and for stale
-sessions when they hit a service.
++ **loginURL**: How a user would login.
+  In intentionally unauthenticated views, this is the href of the Login link.
+  When calls to back end services fail apparently for lack of being logged in,
+  this is the URL the framework will redirect through
+  to attempt to log the user in again server-side.
 + **logoutURL**: The sign out link
 + **myuwHome**: The home page for MyUW
 + **rootURL**: The root URL used for what happens when they click the crest.


### PR DESCRIPTION
Heads up, this one's important. 

(The specific line-by-line changes here aren't important. These lines look like bugfixes because they're bugfixes. It's the big picture, the pivot in approach to how login works, that's important.)

Big picture: with improvements to `miscService.redirectUser` it is now preferable to trigger *all* logins via `miscService.redirectUser` or via direct hyperlink to login (in the case of a login button on public.my, say.)

Therefore:

+ Deprecate the undocumented configuration of the "silent" login URL. "Silent" logins in the background on asynchronous requests will work in strictly a subset of the situations in which `miscService.redirectUser` will work.
+ Change default configuration of "silent" login to not be "silent", so that where it is still used it will fail less confusingly.
+ Fix the `miscService.redirectUser` feature to correctly set `refUrl` so that it successfully redirects back to the user's place in the app after login
+ Fix a couple invocations of `miscService.redirectUser` to correctly convey the status code

Expected result: with corresponding changes in uPortal-home ( https://github.com/uPortal-Project/uportal-home/pull/922 ), we get to fewer code paths that trigger login with better results.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
