### PR TITLE
Integrate Angulartics with Google Tag Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ It is those war files that are being versioned.
 
 + Consistently cache when using `$http.get`.
   Previously some usages did not cache.
-
++ Configure angulartics to integrate with Google Tag Manager.
 
 ## 19.0.0 - 2021-02-05
 

--- a/components/config.js
+++ b/components/config.js
@@ -36,7 +36,7 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       'angular': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular.min',
       'angular-animate': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-animate.min',
       'angular-mocks': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-mocks',
-      'angulartics': 'https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.1.0/angulartics.min',
+      'angulartics': 'https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.6.0/angulartics.min',
       'jquery': 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min',
       'jquery-ui': 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min',
       'ngAnimate': 'js/angular-animate.min',

--- a/components/config.js
+++ b/components/config.js
@@ -37,10 +37,6 @@ define(['./my-app/app-config.js'], function(myAppConfig) {
       'angular-animate': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-animate.min',
       'angular-mocks': 'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular-mocks',
       'angulartics': 'https://cdnjs.cloudflare.com/ajax/libs/angulartics/1.1.0/angulartics.min',
-      'angulartics-google-analytics': [
-          'https://cdnjs.cloudflare.com/ajax/libs/angulartics-google-analytics/0.2.1/angulartics-ga.min',
-          'js/noop',
-      ],
       'jquery': 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min',
       'jquery-ui': 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min',
       'ngAnimate': 'js/angular-animate.min',

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -143,7 +143,6 @@ define([
             'value': properties.value,
             'interaction-type': properties.noninteraction,
         });
-
     });
 
       $analyticsProvider.firstPageview(true);

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -59,13 +59,6 @@ define([
     'ui-gravatar',
     'angulartics-google-analytics',
 ], function(angular, require) {
-    // Define a stub in case this angular module is undefined, i.e. was blocked
-    try {
-        angular.module('angulartics.google.analytics');
-    } catch (e) {
-      angular.module('angulartics.google.analytics', []);
-    }
-
     return angular.module('portal', [
         'app-config',
         'override',
@@ -105,7 +98,6 @@ define([
         'ui.bootstrap',
         'ui.gravatar',
         'angulartics',
-        'angulartics.google.analytics',
     ])
 
     .config([

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -110,6 +110,7 @@ define([
       };
 
       $analyticsProvider.firstPageview(true);
+      $analyticsProvider.withAutoBase(true);
       $mdThemingProvider.alwaysWatchTheme(true);
       $mdThemingProvider.generateThemesOnDemand(true);
 

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -121,11 +121,14 @@ define([
     });
 
     /**
-   * Send interactions to the dataLayer, i.e. for event tracking in Google Analytics
+   * Send interactions to the dataLayer,
+   * i.e. for event tracking in Google Analytics
    * @name eventTrack
    *
    * @param {string} action Required 'action' (string) associated with the event
-   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   * @param {object} properties Comprised of the mandatory field
+   *   'category' (string) and optional  fields 'label' (string),
+   *   'value' (integer) and 'noninteraction' (boolean)
    */
 
     $analyticsProvider.registerEventTrack(function(action, properties) {

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -109,6 +109,40 @@ define([
         'default': 'https://yt3.ggpht.com/-xE0EQR3Ngt8/AAAAAAAAAAI/AAAAAAAAAAA/zTofDHA3-s4/s100-c-k-no/photo.jpg',
       };
 
+      // Google Tag Manager integration from
+      // https://web.archive.org/web/20160630102903/https://github.com/angulartics/angulartics/blob/master/src/angulartics-gtm.js
+      $analyticsProvider.registerPageTrack(function(path) {
+        // eslint-disable-next-line angular/window-service
+        var dataLayer = window.dataLayer = window.dataLayer || [];
+        dataLayer.push({
+            'event': 'content-view',
+            'content-name': path,
+        });
+    });
+
+    /**
+   * Send interactions to the dataLayer, i.e. for event tracking in Google Analytics
+   * @name eventTrack
+   *
+   * @param {string} action Required 'action' (string) associated with the event
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   */
+
+    $analyticsProvider.registerEventTrack(function(action, properties) {
+      // eslint-disable-next-line angular/window-service
+        var dataLayer = window.dataLayer = window.dataLayer || [];
+        properties = properties || {};
+        dataLayer.push({
+            'event': properties.event || 'interaction',
+            'target': properties.category,
+            'action': action,
+            'target-properties': properties.label,
+            'value': properties.value,
+            'interaction-type': properties.noninteraction,
+        });
+
+    });
+
       $analyticsProvider.firstPageview(true);
       $analyticsProvider.withAutoBase(true);
       $mdThemingProvider.alwaysWatchTheme(true);


### PR DESCRIPTION
Configure Angulartics to use Google Tag Manager rather than directly Google Analytics.

Removes the Google Analytics plugin for angulartics.
Adds the Google Tag Manager plugin, the essential bit of it inline rather than as a dependency.
Upgrades to angulartics 1.6.
