### PR TITLE
Use caching in $http.get consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
+## Next
+
++ Consistently cache when using `$http.get`.
+  Previously some usages did not cache.
+
+
 ## 19.0.0 - 2021-02-05
 
 **Breaking change: pivot away from "silent" login.**

--- a/components/js/angucomplete.js
+++ b/components/js/angucomplete.js
@@ -119,7 +119,7 @@
 
 
               } else {
-                $http.get($scope.url + str, {}).
+                $http.get($scope.url + str, {cache: true}).
                   success(function (responseData, status, headers, config) {
                     $scope.searching = false;
                     $scope.processResults(responseData);

--- a/components/portal/main/services.js
+++ b/components/portal/main/services.js
@@ -126,7 +126,7 @@ define(['angular'], function(angular) {
        * Get banner messages from bannersURL endpoint
        */
       function getBanners() {
-        return $http.get(SERVICE_LOC.bannersURL)
+        return $http.get(SERVICE_LOC.bannersURL, {cache: true})
           .then(function(response) {
             if (response.data
               && angular.isArray(response.data)) {

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -149,7 +149,7 @@ define(['angular'], function(angular) {
           angular.forEach(messages, function(message) {
             if (message.data && message.data.dataUrl) {
               // If the message has a dataUrl, add it to promises array
-              promises.push($http.get(message.data.dataUrl)
+              promises.push($http.get(message.data.dataUrl, {cache: true})
                 .then(function(result) {
                   var objectToFind = result.data;
 

--- a/components/portal/messages/services.js
+++ b/components/portal/messages/services.js
@@ -70,7 +70,7 @@ define(['angular'], function(angular) {
          * @return {Array} An array of message objects
          */
         var getAllMessages = function() {
-          return $http.get(SERVICE_LOC.messagesURL)
+          return $http.get(SERVICE_LOC.messagesURL, {cache: true})
             .then(function(response) {
               if (response.data && response.data.messages
                 && angular.isArray(response.data.messages)) {

--- a/components/portal/storage/services.js
+++ b/components/portal/storage/services.js
@@ -58,7 +58,7 @@ define(['angular', 'jquery'], function(angular, $) {
       };
 
       var getValue = function(key) {
-        return $http.get(SERVICE_LOC.kvURL + '/'+key)
+        return $http.get(SERVICE_LOC.kvURL + '/'+key, {cache: true})
                   .then(successFn, errorFn);
       };
 

--- a/components/portal/timeout/services.js
+++ b/components/portal/timeout/services.js
@@ -61,7 +61,7 @@ define(['angular', 'jquery'], function(angular, $) {
            * @return {*|Function|any|Promise}
            */
           function getSession() {
-            return $http.get(SERVICE_LOC.shibbolethSessionURL)
+            return $http.get(SERVICE_LOC.shibbolethSessionURL, {cache: true})
                         .then(onGetSessionSuccess, onError);
           }
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -1054,18 +1054,19 @@ define(['angular', 'moment'], function(angular, moment) {
         $log.debug('entered initRemoteContentWidget()');
 
 
-        $http.get($scope.widget.widgetURL, {cache: true}).then(function(result) {
-          $scope.remoteContent = result.data;
-          $scope.loading = false;
-          $log.debug(
-            'Got [' + result.data + '] from [' +
-            $scope.widget.widgetURL + ']' );
-          return result;
-        }).catch(function(error) {
-          $scope.remoteContentErrors = error;
-          $log.error(error);
-          return error;
-        }
+        $http.get($scope.widget.widgetURL, {cache: true}).then(
+          function(result) {
+            $scope.remoteContent = result.data;
+            $scope.loading = false;
+            $log.debug(
+              'Got [' + result.data + '] from [' +
+              $scope.widget.widgetURL + ']' );
+            return result;
+          }).catch(function(error) {
+            $scope.remoteContentErrors = error;
+            $log.error(error);
+            return error;
+          }
         );
       };
 

--- a/components/portal/widgets/controllers.js
+++ b/components/portal/widgets/controllers.js
@@ -1054,7 +1054,7 @@ define(['angular', 'moment'], function(angular, moment) {
         $log.debug('entered initRemoteContentWidget()');
 
 
-        $http.get($scope.widget.widgetURL).then(function(result) {
+        $http.get($scope.widget.widgetURL, {cache: true}).then(function(result) {
           $scope.remoteContent = result.data;
           $scope.loading = false;
           $log.debug(

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -183,7 +183,7 @@ define(['angular'], function(angular) {
      * @return {number} The number of items needing attention
      */
     var getActionItemQuantity = function(url) {
-      return $http.get(url)
+      return $http.get(url, {cache: true})
         .then(function(result) {
           return result.data;
         })

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -40,7 +40,7 @@ define(['angular'], function(angular) {
       var entrySuffix =
         angular.isUndefined(SERVICE_LOC.widgetApi.entrySuffix) ? '.json' :
           SERVICE_LOC.widgetApi.entrySuffix;
-      return $http.get(SERVICE_LOC.widgetApi.entry + fname + entrySuffix)
+      return $http.get(SERVICE_LOC.widgetApi.entry + fname + entrySuffix, {cache: true})
         .then(function(result) {
           if (angular.isDefined(result.data.entry.layoutObject)) {
             return result.data.entry.layoutObject;

--- a/components/portal/widgets/services.js
+++ b/components/portal/widgets/services.js
@@ -40,7 +40,8 @@ define(['angular'], function(angular) {
       var entrySuffix =
         angular.isUndefined(SERVICE_LOC.widgetApi.entrySuffix) ? '.json' :
           SERVICE_LOC.widgetApi.entrySuffix;
-      return $http.get(SERVICE_LOC.widgetApi.entry + fname + entrySuffix, {cache: true})
+      return $http.get(SERVICE_LOC.widgetApi.entry + fname + entrySuffix,
+        {cache: true})
         .then(function(result) {
           if (angular.isDefined(result.data.entry.layoutObject)) {
             return result.data.entry.layoutObject;


### PR DESCRIPTION
Configure `$http.get` to cache the success responses it gets from the server.
