### PR TITLE
redirect on status undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next
+## Next (21.0.0)
 
 BREAKING CHANGES
 
@@ -20,6 +20,12 @@ BREAKING CHANGES
   times out, the framework will attempt to re-bootstrap a session via portal
   login on next interaction.
 
+Other changes
+
++ In miscService.redirectUser, redirect through login when the status code
+  is undefined. This is intended to better handle observed weirdness where the
+  status code is coming through undefined on failed attempt to get session info.
+
 ## 20.0.0 - 2021-04-23
 
 + Update `myuw-banner` to v3.0.0 (non-goofy support for Learn more link).
@@ -27,7 +33,7 @@ BREAKING CHANGES
 ## 19.0.3 - 2021-04-12
 
 + Update `myuw-banner` to v2.0.0 (this is a goofy version that hard-codes a
-  Lear more link. It should be soon replaced with a non-goofy version.)
+  Learn more link. It should be soon replaced with a non-goofy version.)
 
 ## 19.0.2 - 2021-04-12
 

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -166,6 +166,7 @@ define(['angular', 'jquery'], function(angular, $) {
     /**
      * Redirects users to uPortal server login
      *  if result code is
+     *    undefined (Shibboleth weirdness?) or
      *    0 (Shibboleth weirdness?) or
      *    302 (a shib redirect?) or
      *    401 (Unauthorized, due to lack of authentication?)
@@ -176,12 +177,15 @@ define(['angular', 'jquery'], function(angular, $) {
      * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
-      if (status === 0 || status === 302 || status === 401) {
-        $log.log('redirect happening due to ' + status);
+      if (!status || status === 0 || status === 302 || status === 401) {
+
         if (MISC_URLS.loginURL) {
           var currentUrl = $window.location.href;
           var currentUrlEncoded = encodeURIComponent(currentUrl);
           var newUrl = MISC_URLS.loginURL + '?refUrl=' + currentUrlEncoded;
+          $log.log('redirecting to ' + newUrl +
+            ' on behalf of caller ' + caller +
+            'which signaled status ' + status);
           $window.location.replace(newUrl);
         } else {
           $log.warn('MISC_URLS.loginURL was not set, cannot redirect');


### PR DESCRIPTION
When something calls the redirect method in the misc service passing `undefined` as the status code, err on the side of performing the redirect.

----

- [x] The change has been examined for security impact.


