### PR TITLE
Document MISC_URLS.loginURL breaking change in 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Next
 
 **Breaking change: pivot away from "silent" login.**
 
+`MISC_URLS.loginURL` must *not* have a parameter on it. Prior to this version,
+`/portal/Login?profile=bucky` was a typical value.
+That value will not work in this version.
+The `profile` parameter is unnnecessary as MyUW uPortal
+now defaults to the correct profile anyway.
+So the equivalent, typical value is now `/portal/Login`. Note that the framework
+defaults to that value so adopting applications can decline to override this
+value and thereby inherit the typical value from the framework.
+
 + `miscService.redirectUser` will set `refUrl` on the redirect to uPortal login
   so that uPortal login will return the user to
   the page that launched the log-in-again redirect.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -2,6 +2,17 @@
 
 At a glance notes for upgrading apps between major versions.
 
+## 18 to 19
+
+19 drops the "silent login" feature in favor of detecting when calls to the
+server are failing for lack of authentication and redirecting through uPortal
+login setting the `refUrl` parameter to encourage a redirect from uPortal back
+to the current path when the session is (re-)established.
+
+`MISC_URLS.loginURL` *must not* have a request parameter on it in 19.
+So, `/portal/Login`, not `/portal/Login?profile=...`. Note that an application
+using the app framework may not need to override `MISC_URLS.loginURL` at all.
+
 ## 17 to 18
 
 18.0.0 drops direct instantiation of Google Analytics in favor of hard-coded


### PR DESCRIPTION
Document the breaking change to viable `MISC_URLS.loginURL` value that tripped up MUMAA on attempt to upgrade `preparing-for-soar`.
