### PR TITLE
Upgrade to myuw-banner 3 with its Learn more link support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-Next
+## Next
+
++ Update `myuw-banner` to v3.0.0 (non-goofy support for Learn more link).
 
 ## 19.0.3 - 2021-04-12
 

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -59,8 +59,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.7.2/dist/myuw-app-bar.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-app-bar@1.7.2/dist/myuw-app-bar.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@2.0.0/dist/myuw-banner.min.mjs"></script>
-<script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@2.0.0/dist/myuw-banner.min.js"></script>
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-banner@3.0.0/dist/myuw-banner.min.mjs"></script>
+<script nomodule scr="https://unpkg.com/@myuw-web-components/myuw-banner@3.0.0/dist/myuw-banner.min.js"></script>
 
 <script type="module" src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.3/myuw-help.min.mjs"></script>
 <script nomodule src="https://cdn.my.wisc.edu/@myuw-web-components/myuw-help@1.5.3/myuw-help.min.js"></script>

--- a/components/portal/main/controllers.js
+++ b/components/portal/main/controllers.js
@@ -52,10 +52,15 @@ define(['angular', 'require'], function(angular, require) {
           // Ensure messages exist
           if (angular.isArray(result) && result.length > 0) {
             $scope.banner.message = result[0].text;
-            if (result[0].button) {
-              $scope.banner.confirmingText = result[0].button.label;
-              $scope.banner.confirmingUrl = result[0].button.url;
+            if (result[0]['action-button']) {
+              $scope.banner.actionLabel = result[0]['action-button'].label;
+              $scope.banner.actionAriaLabel = result[0]['action-button']['aria-label'];
+              $scope.banner.actionUrl = result[0]['action-button'].url;
               $scope.banner.icon = result[0].icon;
+              if (result[0]['learn-more-button']) {
+                $scope.banner.learnMoreUrl = result[0]['learn-more-button'].url;
+                $scope.banner.learnMoreAriaLabel = result[0]['learn-more-button']['aria-label'];
+              }
             }
             $scope.bannerHasContent = true;
           }
@@ -114,9 +119,11 @@ define(['angular', 'require'], function(angular, require) {
       $scope.bannerHasContent = false;
       $scope.banner = {
         'message': '',
-        'confirming-text': '',
-        'confirming-url': '',
-        'dismissiveText': 'Skip for now',
+        'action-label': '',
+        'action-aria-label': '',
+        'action-url': '',
+        'learn-more-aria-label': '',
+        'learn-more-url': '',
       };
 
       // Update window title and set app name in top bar

--- a/components/portal/main/partials/body.html
+++ b/components/portal/main/partials/body.html
@@ -26,7 +26,15 @@
   </div>
   <div class="my-uw-body">
     <portal-header ng-controller="MessagesController"></portal-header>
-    <myuw-banner ng-if="banner && banner.message" message="{{ banner.message }}" icon="{{banner.icon}}" confirming-text="{{ banner.confirmingText }}" confirming-url="{{ banner.confirmingUrl }}" dismissive-text="{{ banner.dismissiveText }}"></myuw-banner>
+    <myuw-banner
+      ng-if="banner && banner.message"
+      message="{{ banner.message }}" icon="{{banner.icon}}"
+      action-label="{{ banner.actionLabel }}"
+      action-aria-label="{{ banner.actionAriaLabel }}"
+      action-url="{{banner.actionUrl}}"
+      learn-more-aria-label="{{banner.learnMoreAriaLabel}}"
+      learn-more-url="{{banner.learnMoreUrl}}"
+    ></myuw-banner>
 
     <div class="page-content" layout="column" tabindex="0" role="main">
       <div role="main" class="region-main" class="no-padding">

--- a/components/staticFeeds/sample-banners.json
+++ b/components/staticFeeds/sample-banners.json
@@ -1,17 +1,28 @@
 [
   {
-    "text": "Example banner message",
-    "icon": "inbox",
-    "button": {
-      "label": "Read documentation",
-      "url": "https://uportal-project.github.io/uportal-app-framework/messaging.html"
+    "text":"This is an example banner message",
+    "icon":"notifications_active",
+    "action-button":{
+      "label":"Action button label",
+      "aria-label":"This is the ARIA label for the action button",
+      "url":"https://www.example.edu/example-action-url"
+    },
+    "learn-more-button":{
+      "aria-label":"Learn more button ARIA label",
+      "url":"https://www.example.edu/example-learn-more-url"
     }
   },
   {
-    "text": "Secondary test banner",
-    "button": {
-      "label": "Do thing",
-      "url": "#"
+    "text":"A subsequent message that will be ignored.",
+    "icon":"campaign",
+    "action-button":{
+      "label":"Verb",
+      "aria-label":"Actions are a verb",
+      "url":"https://www.example.edu/another-example-action-url"
+    },
+    "learn-more-button":{
+      "aria-label":"Noun",
+      "url":"https://www.example.edu/another-example-learn-more-url"
     }
   }
 ]


### PR DESCRIPTION
Upgrades to `myuw-banner` v3.
Expects the API from the new myuw banner backend v2.
Connects these together to offer banner messages with learn more link.

<img width="1554" alt="Screenshot showing banner with learn more link" src="https://user-images.githubusercontent.com/952283/115889164-4db86580-a419-11eb-9822-caed6b9ff241.png">
