### PR TITLE
stop redirecting through login on status undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next
+## Next - may be versioned 21.0.2
 
-## 21.0.2 - 2021-11-08
 + Update import path to use latest unpkg version of MyUW Help Web Component
++ Backs out the 21.0.1 change to redirect through login when the status code
+  is undefined, because this was leading to infinite redirects when loading
+  the layout failed.
 
 ## 21.0.1 - 2021-09-08
 

--- a/components/portal/misc/services.js
+++ b/components/portal/misc/services.js
@@ -166,18 +166,19 @@ define(['angular', 'jquery'], function(angular, $) {
     /**
      * Redirects users to uPortal server login
      *  if result code is
-     *    undefined (Shibboleth weirdness?) or
      *    0 (Shibboleth weirdness?) or
      *    302 (a shib redirect?) or
      *    401 (Unauthorized, due to lack of authentication?)
      *  Requires MISC_URLS.loginURL in js/app-config.js
      *  Sets refUrl to current URL, so that uPortal will attempt to return the
      *  user to the current page after login.
+     * Does NOT redirect if result code is undefined, because in practice
+     * this has led to infinite redirects.
      * @param {number} status
      * @param {string} caller
     **/
     var redirectUser = function(status, caller) {
-      if (!status || status === 0 || status === 302 || status === 401) {
+      if (status === 0 || status === 302 || status === 401) {
 
         if (MISC_URLS.loginURL) {
           var currentUrl = $window.location.href;


### PR DESCRIPTION
Observed on predev.my infinite redirect on a particular failure of the layout backend.

The layout backend should not, of course, fail.

But if it does fail, the front end shouldn't enter an infinite redirect loop. 

This pull request backs out the change that made the framework more aggressive about redirecting through login on failures. Before this change, undefined responses yielded redirect. After this change, undefined responses don't yield a redirect.
