### PR TITLE
Fix reset-fail toast message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
+## Next
+
++ Show toast when layout reset fails.
+
 ## 21.0.2 - 2021-11-22
 
 + Switches Reset layout button in user settings to reset in the new

--- a/components/portal/settings/controllers.js
+++ b/components/portal/settings/controllers.js
@@ -65,8 +65,6 @@ define(['angular'], function(angular) {
       $scope.resetNewLayout = function() {
         newLayoutResetService.resetNewLayoutPOST().then(
         function() {
-          $scope.resetLayoutSuccess = true;
-          $scope.resetLayoutFail = false;
           $log.log('reset layout succeeded');
 
           var logInAgainRequiredAlert = $mdDialog.alert()
@@ -82,11 +80,24 @@ define(['angular'], function(angular) {
 
           return true;
         }).catch(function() {
-          $scope.resetLayoutSuccess= false;
-          $scope.resetLayoutFail = true;
-
-          // broken: this toast doesn't actually render
-          $mdToast.showSimple('Reset layout failed');
+          $mdToast.show({
+            position: 'bottom right',
+            hideDelay: 4000,
+            scope: $scope,
+            preserveScope: true,
+            parent: angular.element(document).find('.wrapper__frame-page')[0],
+            templateUrl:
+              require.toUrl('/web/portal/misc/partials/toast-reset-layout.html'),
+            controller: function ToastResetLayoutController(
+              $scope,
+              $mdToast,
+              newLayoutResetService
+            ) {
+              $scope.dismissToast = function() {
+                $mdToast.hide();
+              };
+            },
+          });
 
           $log.log('Reset layout failed');
         });

--- a/components/portal/settings/partials/toast-reset-layout.html
+++ b/components/portal/settings/partials/toast-reset-layout.html
@@ -20,8 +20,7 @@
 -->
 <md-toast class="toast__layout-reset">
   <div class="md-toast-content" layout="row">
-    <span class="md-toast-text" ng-if="resetLayoutSuccess"><md-icon>check</md-icon> Reset completed</span>
-    <span class="md-toast-text" ng-if="resetLayoutFail"><md-icon>error</md-icon> Reset failed</span>
+    <span class="md-toast-text"><md-icon>error</md-icon> Reset failed</span>
     <md-button ng-click="dismissToast()" aria-label="Dismiss toast">
       <md-icon>close</md-icon>
     </md-button>


### PR DESCRIPTION
This should display the toast message when the reset layout POST request fails.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
