### PR TITLE
Use timeout to delay fading loading placeholder content too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ It is those war files that are being versioned.
 
 ## Next
 
-+ Make tooltip text more accessible by adding contrasting background to it
++ Move startFade into a timeout to avoid skeleton content fading out before it hides.
++ Make tooltip text more accessible by adding contrasting background to it.
 + Show toast when layout reset fails.
 
 ## 21.0.2 - 2021-11-22

--- a/components/portal/main.js
+++ b/components/portal/main.js
@@ -234,8 +234,8 @@ define([
       var loadingCompleteSequence = function() {
         // loading sequence
         $rootScope.portal.loading = {};
-        $rootScope.portal.loading.startFade = true;
         $timeout(function() {
+          $rootScope.portal.loading.startFade = true;
           $rootScope.portal.loading.hidden = true;
         }, 1500);
 


### PR DESCRIPTION
Visual fading out style (slowfade class) was getting applied 1.5 sec sooner than hiding the skeleton (placeholder content used while waiting for the app to get loaded), resulting skeleton being invisible to the users providing confusing experience.

I'm moving `$rootScope.portal.loading.startFade = true;` inside the $timeout so that dading and hiding happens with the same delay.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
