### PR TITLE
Make tooltips more readable by applying contrasting background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ It is those war files that are being versioned.
 
 ## Next
 
++ Make tooltips more readable by applying contrasting background
 + Include lastName to be passed into myuw-login event listener
 + Updates `myuw-profile` to v.1.6.7
 + Updates `myuw-profile` to v.1.6.6
 + Remove additional startFade so that the skeleton content fades out on hiding.
-+ Make tooltip text more accessible by adding contrasting background to it.
 + Show toast when layout reset fails.
 
 ## 21.0.2 - 2021-11-22

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -174,26 +174,17 @@ md-menu-content.top-bar-menu-content {
 }
 
 md-tooltip {
-  &.widget-action-tooltip {
-    max-width: 250px;
-    background: #fff;
-    white-space: normal;
-    height: auto;
-    line-height: 18px;
-    font-size: 12px;
+  max-width: 250px;
+  background-color: rgb(97,97,97);
+  color: rgba(255,255,255,0.87);
+  font-size: 12px !important;
+  @media (max-width: @xs) {
     padding: 4px 8px;
-
-    @media (max-width: @xs) {
-      line-height: 20px;
-      padding: 4px 8px;
-    }
   }
+}
 
-  &.top-bar-tooltip {
-    .md-content {
-      background: #fff;
-    }
-  }
+md-tooltip.widget-action-tooltip {
+  margin-top: 0px !important;
 }
 
 // Adjust z-index of tooltips


### PR DESCRIPTION
Make tooltips more readable by applying contrasting background

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
