### PR TITLE
Apply focus & hover style to widget action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
-## Next
+## 21.0.3 - 2022-02-04
 
++ Apply focus style to widget action button
 + Make tooltips more readable by applying contrasting background
 + Include lastName to be passed into myuw-login event listener
 + Updates `myuw-profile` to v.1.6.7
-+ Updates `myuw-profile` to v.1.6.6
-+ Remove additional startFade so that the skeleton content fades out on hiding.
++ Remove additional startFade so that the skeleton content fades out on hiding
 + Show toast when layout reset fails.
 
 ## 21.0.2 - 2021-11-22

--- a/components/css/buckyless/general.less
+++ b/components/css/buckyless/general.less
@@ -50,11 +50,7 @@ ul {
   padding-left: 0;
 }
 
-div:focus,
-input:focus,
-select:focus,
-textarea:focus,
-button:focus {
+div:focus {
   outline: none !important;
 }
 

--- a/components/css/buckyless/widget.less
+++ b/components/css/buckyless/widget.less
@@ -532,11 +532,16 @@
       .material-icons {
         font-size: 18px;
         line-height: 24px;
+        &:hover {
+          color: rgb(0,0,0);
+        }
       }
-    }
-
-    &:focus {
-      opacity: 1;
+      &:hover {
+        background-color: rgba(0,0,0,0.1);
+      }
+      &:focus {
+        outline: 2px solid #5e9ed6;
+      }
     }
   }
 }
@@ -564,6 +569,9 @@
     &:hover {
       background-color: #f8f8f8;
       box-shadow: 0 3px 0 #ddd;
+    }
+    &:focus {
+      outline: 2px solid #5E9ED6;
     }
   }
 
@@ -610,18 +618,15 @@
 
 .add-favorites {
   background: transparent;
-  border: 1px dashed #ccc;
   display: flex;
   justify-content: center;
   align-items: center;
 
-  &:hover {
-    border: 1px solid #f8f8f8;
-  }
-
   a {
     transition: @background-transition;
     box-shadow: 0 0 0 transparent;
+    &:focus {
+      outline: 2px solid #5e9ed6;
   }
 }
 

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -138,7 +138,7 @@
       ng-hide="sessionCtrl.guestMode"
       aria-label="Open options menu"
       class="top-bar-tooltip"
-      style="margin-top: 24px !important;" 
+      style="margin-top: 24px !important;"
       md-direction="bottom" md-delay="400">
       Options</md-tooltip>
   </myuw-profile>


### PR DESCRIPTION
- Apply focus and hover style to widget action button
- Remove focusable elements from `outline: none` style rule
- 
![Screen Shot 2022-02-04 at 11 25 41 AM](https://user-images.githubusercontent.com/10341961/152576544-be9d8beb-0f79-4d8b-a5a4-955a91201be0.png)

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
