### PR TITLE
Adjust z-index and position of tooltips attached to header buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
+## 21.0.4 - 2022-03-04
+
++ Update `myuw-notifications` to v1.4.2
++ Adjust z-index and position of tooltips attached to header buttons
 
 ## 21.0.3 - 2022-02-22
 

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -185,7 +185,7 @@ md-tooltip.widget-action-tooltip {
 
 // Adjust z-index of tooltips
 .md-panel-outer-wrapper.md-panel-is-showing {
-  z-index: 70 !important;
+  z-index: 54 !important;
 }
 
 notifications-list-item {

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -74,8 +74,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-profile@1.6.7/dist/myuw-profile.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-profile@1.6.7/dist/myuw-profile.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.4.1/dist/myuw-notifications.min.mjs"></script>
-<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.4.1/dist/myuw-notifications.min.js"></script>
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.4.2/dist/myuw-notifications.min.mjs"></script>
+<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-notifications@1.4.2/dist/myuw-notifications.min.js"></script>
 
 <link href="my-app/my-app.css" rel="stylesheet" type="text/css" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -39,6 +39,7 @@
       md-direction="bottom"
       md-delay="400"
       md-autohide
+      style="margin-top: 18px"
       class="top-bar-tooltip">
       Menu</md-tooltip>
   </md-button>
@@ -80,6 +81,7 @@
       aria-label="Open help dialog"
       class="top-bar-tooltip"
       md-direction="bottom"
+      style="margin-top: 14px;"
       md-delay="400">Help
     </md-tooltip>
     <div slot="myuw-help-content">
@@ -115,6 +117,7 @@
       md-direction="bottom"
       md-delay="400"
       md-autohide
+      style="margin-top: 18px;"
       class="top-bar-tooltip">
       Notifications</md-tooltip>
   </myuw-notifications>
@@ -137,8 +140,8 @@
     <md-tooltip
       ng-hide="sessionCtrl.guestMode"
       aria-label="Open options menu"
+      style="margin-top: 26px"
       class="top-bar-tooltip"
-      style="margin-top: 24px !important;"
       md-direction="bottom" md-delay="400">
       Options</md-tooltip>
   </myuw-profile>


### PR DESCRIPTION
+ Update `myuw-notifications` to v1.4.2
+ Adjust z-index and position of tooltips attached to header buttons so they display with equal distance from the naviggation bar



https://user-images.githubusercontent.com/10341961/156805395-dccd8ce0-0d5e-46ca-9576-19f1551534c5.mov


Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
