### PR TITLE
Activate Feedback Web Component in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The versions in this change log should match those published
 to [the Sonatype Maven Central Repository][].
 It is those war files that are being versioned.
 
+## 21.0.5 - 2022-04-04
+
++ Update `myuw-feedback` to v1.0.5
++ Set showFeedbackComponent to true, to activate Feedback Web Component in header
+
 ## 21.0.4 - 2022-03-07
 
 + Update `myuw-notifications` to v1.4.2

--- a/components/css/buckyless/md-generated.less
+++ b/components/css/buckyless/md-generated.less
@@ -202,3 +202,9 @@ md-list-item.notification-item {
 .notifications__empty {
   margin-left: 1.6em;
 }
+
+#feedback-icon {
+  color: var(--myuw-primary-color, #fff);
+  fill: var(--myuw-primary-color, #fff);
+  margin-top: 6px;
+}

--- a/components/head-static.html
+++ b/components/head-static.html
@@ -65,8 +65,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-help@1.5.5/dist/myuw-help.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-help@1.5.5/dist/myuw-help.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-feedback@1.0.4/dist/myuw-feedback.min.mjs"></script>
-<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-feedback@1.0.4/dist/myuw-feedback.min.js"></script>
+<script type="module" src="https://unpkg.com/@myuw-web-components/myuw-feedback@1.0.5/dist/myuw-feedback.min.mjs"></script>
+<script nomodule src="https://unpkg.com/@myuw-web-components/myuw-feedback@1.0.5/dist/myuw-feedback.min.js"></script>
 
 <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-search@1.5.5/dist/myuw-search.min.mjs"></script>
 <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-search@1.5.5/dist/myuw-search.min.js"></script>

--- a/components/js/app-config.js
+++ b/components/js/app-config.js
@@ -24,7 +24,7 @@ define(['angular'], function(angular) {
             'isWeb': false,
             'defaultTheme': 0,
             'showUserSettingsPage': false,
-            'showFeedbackComponent': false,
+            'showFeedbackComponent': true,
             'debug': false,
             'campusIdAttribute': null,
             'useNewLayout': true,

--- a/components/portal/main/partials/header.html
+++ b/components/portal/main/partials/header.html
@@ -57,19 +57,17 @@
     hide-xs
     myuw-feedback-title="Feedback"
     slot="myuw-feedback"
-    show-button>
+    show-link>
     <md-tooltip
       aria-label="Open feedback dialog"
       class="top-bar-tooltip"
       md-direction="bottom"
       md-delay="400">Feedback
     </md-tooltip>
-    <div slot="myuw-feedback-content">
-      <p>Please tell us what you think about the new all-in-one, integrated home for MyUW widgets.</p>
-      <div id="feedback-dialog-actions">
-        <a class="feedback-dialog-action" target="_blank" rel="noopener noreferrer" href="https://my.wisc.edu/portal/p/feedback.ctf5/max/render.uP">
-          Give Feedback</a>
-      </div>
+    <div slot="myuw-feedback-link">
+      <a id="myuw-feedback-link" aria-label="Open link to provide feedback" href="https://docs.google.com/forms/d/1F14ux4DzfpEViMZG5rGoGw2wAruXJzfugurHl7cr5mk/edit" target="_blank">
+        <svg aria-hidden="true" id="feedback-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"/></svg>
+      </a>
     </div>
   </myuw-feedback>
 


### PR DESCRIPTION
## 21.0.5 - 2022-04-04

+ Update `myuw-feedback` to v1.0.5
+ Set showFeedbackComponent to true, to activate Feedback Web Component in header

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

PR considerations checklist:

<!-- Place an x in the checkbox for YES. -->

- [x] Updates `CHANGELOG.md` to reflect this PR's change.
- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
